### PR TITLE
feat: add turbo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 node_modules/
 coverage/
+.turbo/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@bitgo/api-ts",
       "version": "0.1.0",
-      "license": "UNLICENSED",
+      "license": "(Apache-2.0 or MIT)",
       "workspaces": [
         "packages/**"
       ],
@@ -15,6 +15,7 @@
         "lint-staged": "12.3.7",
         "pre-commit": "1.2.2",
         "prettier": "2.5.1",
+        "turbo": "1.1.10",
         "typescript": "4.5.5"
       }
     },
@@ -5867,6 +5868,186 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
+    "node_modules/turbo": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.1.10.tgz",
+      "integrity": "sha512-y8vx8uIyBRFI3aFjZ3PeGaOvYtNk6t7xNLzRsPY+xtnknTeqdBad56ElS8z+j0RyVwKCvI+wgvTHGkEle4VnJA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "turbo-darwin-64": "1.1.10",
+        "turbo-darwin-arm64": "1.1.10",
+        "turbo-freebsd-64": "1.1.10",
+        "turbo-freebsd-arm64": "1.1.10",
+        "turbo-linux-32": "1.1.10",
+        "turbo-linux-64": "1.1.10",
+        "turbo-linux-arm": "1.1.10",
+        "turbo-linux-arm64": "1.1.10",
+        "turbo-linux-mips64le": "1.1.10",
+        "turbo-linux-ppc64le": "1.1.10",
+        "turbo-windows-32": "1.1.10",
+        "turbo-windows-64": "1.1.10"
+      }
+    },
+    "node_modules/turbo-darwin-64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.1.10.tgz",
+      "integrity": "sha512-MY/1mHg+tS/GaZKG805e5JSGNS8A4j/M2GzLwCbNL+lwGMfneNASri1vAd80ss3T2MgMsfsFMVyIQJljqpDBvA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.1.10.tgz",
+      "integrity": "sha512-gMPLseYqGKwdy6UHVWKMLA433ZTfQRV5FlYz5n4XVtx30cF6ajOqq12ykeCUUX/lZkH4Uq5zT0tNEYpUhUw7mA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-freebsd-64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-freebsd-64/-/turbo-freebsd-64-1.1.10.tgz",
+      "integrity": "sha512-wra27mvakr5ZFceQnCCSR8gHQtKV8Q0EhtzO/wEdyhEssw0wVaNtMHUOOdvFN0HLmjQmmLZgmfZbURc83UDuZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/turbo-freebsd-arm64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-freebsd-arm64/-/turbo-freebsd-arm64-1.1.10.tgz",
+      "integrity": "sha512-J2I76pTwtrEVjHt1+zWY/s/Y0YIGdWHBIWOjhCXi1E8dav98oGw+WUaiFwzAkcksAblOhNpDL3qhnrnm7kHqrg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/turbo-linux-32": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-32/-/turbo-linux-32-1.1.10.tgz",
+      "integrity": "sha512-d1ILhEv2B/lOtpH4niFUKGb8YMU6G7gNCQCY6wG+SXARWJtDti+KiNWESechD5DycCIMgtE40XNy/c1US+LI5g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.1.10.tgz",
+      "integrity": "sha512-8VEOiNJFNfUMZOyrN32wOcdT1Ik1nlIuTwkO4UeonAJhuWjTvdDLPCQkz0SECTu60q90l6nXCnNYtoZA6LrZzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm/-/turbo-linux-arm-1.1.10.tgz",
+      "integrity": "sha512-qJ50K/s5MjpHjam+UdnK3GniEIv5XOBCZOGslgMMyz8V/q43vhB9BU9HQODclM89uQgsKxhs8Fue6ytOY4vIpg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.1.10.tgz",
+      "integrity": "sha512-ng3dEEL4SbBudF/UZzsOrfyJh8DLtTHawTepeS30FdtvYuVBXdCPc5BAhbawGoau/2AV4vrN3qzh9e3LCqD6Qg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-mips64le": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-mips64le/-/turbo-linux-mips64le-1.1.10.tgz",
+      "integrity": "sha512-Jd4yH7ZEXCo0xmdJWZ6YsyqcNLyL5vRU3j5ZT+1W97YJCT+g+1on3/nd3rBVPzVz52lb8JIqgGtrBrnOO0AWJg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-ppc64le": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-ppc64le/-/turbo-linux-ppc64le-1.1.10.tgz",
+      "integrity": "sha512-YF8+Oi53glqY29O1A7KJsHZxBzeVBobYFnPEXMt8vm+ouuo8kkbxXxShOP4h+33YGEkesTw/CTXtfDC1Xj1hDw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-32": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-windows-32/-/turbo-windows-32-1.1.10.tgz",
+      "integrity": "sha512-IO92tVTCtWVPPgcCjf8J7AmBEcwnjv1zPq7t9GFdqZ/6QA06atgPJNzQ/QvyzbzJgUsJUN2ByzwT04o4QUbrBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.1.10.tgz",
+      "integrity": "sha512-g/RIXaVDaOgliHEJuOsuB6Tefwue9fXBH1/iIH9dmT3Z7lL0banGh+C10RW6Jd6PBPMoPBWir9PLYuzxoPcCNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -6327,7 +6508,7 @@
     "packages/io-ts-express": {
       "name": "@bitgo/io-ts-express",
       "version": "0.1.0",
-      "license": "UNLICENSED",
+      "license": "(Apache-2.0 or MIT)",
       "dependencies": {
         "@bitgo/io-ts-http": "0.1.0",
         "express": "4.17.2",
@@ -6347,7 +6528,7 @@
     "packages/io-ts-http": {
       "name": "@bitgo/io-ts-http",
       "version": "0.1.0",
-      "license": "UNLICENSED",
+      "license": "(Apache-2.0 or MIT)",
       "dependencies": {
         "@bitgo/io-ts-response": "0.1.0",
         "fp-ts": "2.11.8",
@@ -6376,7 +6557,7 @@
     "packages/io-ts-openapi": {
       "name": "@bitgo/io-ts-openapi",
       "version": "0.1.0",
-      "license": "UNLICENSED",
+      "license": "(Apache-2.0 or MIT)",
       "dependencies": {
         "@bitgo/io-ts-http": "0.1.0",
         "cmd-ts": "0.10.0",
@@ -6401,7 +6582,7 @@
     "packages/io-ts-response": {
       "name": "@bitgo/io-ts-response",
       "version": "0.1.0",
-      "license": "UNLICENSED",
+      "license": "(Apache-2.0 or MIT)",
       "dependencies": {
         "fp-ts": "2.11.8",
         "io-ts": "2.2.16"
@@ -6414,7 +6595,7 @@
     "packages/superagent-codec-adapter": {
       "name": "@bitgo/superagent-codec-adapter",
       "version": "0.1.0",
-      "license": "UNLICENSED",
+      "license": "(Apache-2.0 or MIT)",
       "dependencies": {
         "@bitgo/io-ts-http": "0.1.0",
         "fp-ts": "2.11.8",
@@ -11390,6 +11571,110 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "turbo": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.1.10.tgz",
+      "integrity": "sha512-y8vx8uIyBRFI3aFjZ3PeGaOvYtNk6t7xNLzRsPY+xtnknTeqdBad56ElS8z+j0RyVwKCvI+wgvTHGkEle4VnJA==",
+      "dev": true,
+      "requires": {
+        "turbo-darwin-64": "1.1.10",
+        "turbo-darwin-arm64": "1.1.10",
+        "turbo-freebsd-64": "1.1.10",
+        "turbo-freebsd-arm64": "1.1.10",
+        "turbo-linux-32": "1.1.10",
+        "turbo-linux-64": "1.1.10",
+        "turbo-linux-arm": "1.1.10",
+        "turbo-linux-arm64": "1.1.10",
+        "turbo-linux-mips64le": "1.1.10",
+        "turbo-linux-ppc64le": "1.1.10",
+        "turbo-windows-32": "1.1.10",
+        "turbo-windows-64": "1.1.10"
+      }
+    },
+    "turbo-darwin-64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.1.10.tgz",
+      "integrity": "sha512-MY/1mHg+tS/GaZKG805e5JSGNS8A4j/M2GzLwCbNL+lwGMfneNASri1vAd80ss3T2MgMsfsFMVyIQJljqpDBvA==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-darwin-arm64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.1.10.tgz",
+      "integrity": "sha512-gMPLseYqGKwdy6UHVWKMLA433ZTfQRV5FlYz5n4XVtx30cF6ajOqq12ykeCUUX/lZkH4Uq5zT0tNEYpUhUw7mA==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-freebsd-64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-freebsd-64/-/turbo-freebsd-64-1.1.10.tgz",
+      "integrity": "sha512-wra27mvakr5ZFceQnCCSR8gHQtKV8Q0EhtzO/wEdyhEssw0wVaNtMHUOOdvFN0HLmjQmmLZgmfZbURc83UDuZQ==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-freebsd-arm64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-freebsd-arm64/-/turbo-freebsd-arm64-1.1.10.tgz",
+      "integrity": "sha512-J2I76pTwtrEVjHt1+zWY/s/Y0YIGdWHBIWOjhCXi1E8dav98oGw+WUaiFwzAkcksAblOhNpDL3qhnrnm7kHqrg==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-32": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-32/-/turbo-linux-32-1.1.10.tgz",
+      "integrity": "sha512-d1ILhEv2B/lOtpH4niFUKGb8YMU6G7gNCQCY6wG+SXARWJtDti+KiNWESechD5DycCIMgtE40XNy/c1US+LI5g==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.1.10.tgz",
+      "integrity": "sha512-8VEOiNJFNfUMZOyrN32wOcdT1Ik1nlIuTwkO4UeonAJhuWjTvdDLPCQkz0SECTu60q90l6nXCnNYtoZA6LrZzA==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-arm": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm/-/turbo-linux-arm-1.1.10.tgz",
+      "integrity": "sha512-qJ50K/s5MjpHjam+UdnK3GniEIv5XOBCZOGslgMMyz8V/q43vhB9BU9HQODclM89uQgsKxhs8Fue6ytOY4vIpg==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-arm64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.1.10.tgz",
+      "integrity": "sha512-ng3dEEL4SbBudF/UZzsOrfyJh8DLtTHawTepeS30FdtvYuVBXdCPc5BAhbawGoau/2AV4vrN3qzh9e3LCqD6Qg==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-mips64le": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-mips64le/-/turbo-linux-mips64le-1.1.10.tgz",
+      "integrity": "sha512-Jd4yH7ZEXCo0xmdJWZ6YsyqcNLyL5vRU3j5ZT+1W97YJCT+g+1on3/nd3rBVPzVz52lb8JIqgGtrBrnOO0AWJg==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-ppc64le": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-ppc64le/-/turbo-linux-ppc64le-1.1.10.tgz",
+      "integrity": "sha512-YF8+Oi53glqY29O1A7KJsHZxBzeVBobYFnPEXMt8vm+ouuo8kkbxXxShOP4h+33YGEkesTw/CTXtfDC1Xj1hDw==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-windows-32": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-windows-32/-/turbo-windows-32-1.1.10.tgz",
+      "integrity": "sha512-IO92tVTCtWVPPgcCjf8J7AmBEcwnjv1zPq7t9GFdqZ/6QA06atgPJNzQ/QvyzbzJgUsJUN2ByzwT04o4QUbrBQ==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-windows-64": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.1.10.tgz",
+      "integrity": "sha512-g/RIXaVDaOgliHEJuOsuB6Tefwue9fXBH1/iIH9dmT3Z7lL0banGh+C10RW6Jd6PBPMoPBWir9PLYuzxoPcCNQ==",
+      "dev": true,
+      "optional": true
     },
     "type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -17,20 +17,21 @@
   "workspaces": [
     "packages/**"
   ],
+  "packageManager": "npm@8.5.0",
   "scripts": {
-    "build": "tsc --build --incremental --verbose .",
-    "clean": "npm run --workspaces clean",
+    "build": "turbo run build",
+    "clean": "turbo run clean",
+    "predistclean": "turbo run clean",
     "distclean": "rm -rf node_modules packages/*/node_modules",
     "lint-staged": "lint-staged",
-    "test": "npm run --workspaces test"
+    "test": "turbo run test"
   },
   "pre-commit": "lint-staged",
   "devDependencies": {
     "lint-staged": "12.3.7",
     "pre-commit": "1.2.2",
     "prettier": "2.5.1",
+    "turbo": "1.1.10",
     "typescript": "4.5.5"
-  },
-  "dependencies": {
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "baseBranch": "origin/master",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["build"],
+      "outputs": [".nyc_output/**"]
+    },
+    "clean": {
+      "outputs": [],
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
Adds turborepo to the project. Even for a project of this size, it is convenient to be able to just run `turbo run test` and have it figure out what dependencies need to be rebuilt for testing. The caching is nice here but not as big of a deal as it would be in a bigger monorepo.