### PR TITLE
chore: add test for decoding overlapping keys with flatten

### DIFF
--- a/packages/io-ts-http/test/combinators.test.ts
+++ b/packages/io-ts-http/test/combinators.test.ts
@@ -39,6 +39,15 @@ describe('flattened', () => {
 
   it('combines with optional params', () =>
     assertEncodes(codec, { foo: 42 }, { test: { foo: 42 }, anotherParam: {} }));
+
+  it('does not get confused by overlapping extra parameters', () => {
+    const input = {
+      test: { foo: 42, bar: 'bad' },
+      anotherParam: { foo: 123, bar: '123' },
+    };
+    const expected = { foo: 42, bar: '123' };
+    assertDecodes(codec, input, expected);
+  });
 });
 
 describe('optionalized', () => {


### PR DESCRIPTION
Although it is undefined behavior to define a `flatten` codec with
overlapping keys, the actual codec needs to handle arbitrary input which
might have them. This commit adds a test for this, and fortunately the
existing code passes.