### PR TITLE
ci: reduce runtime and upgrade GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm install --global 'npm@>7'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Compile TypeScript
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: npm
           node-verions: ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Configure Node.js
         uses: actions/setup-node@v2
         with:
+          cache: npm
           node-verions: ${{ matrix.node-version }}
 
       # Install npm greater-than-or-equal-to 7 so we can use npm workspaces.


### PR DESCRIPTION
- upgrade setup-node to v3
- cache npm dependencies between builds
- use npm ci over npm install