### PR TITLE
feat: simplify intersections of simple types

### DIFF
--- a/packages/io-ts-openapi/corpus/test-intersection-flattening.ts
+++ b/packages/io-ts-openapi/corpus/test-intersection-flattening.ts
@@ -1,0 +1,65 @@
+//! should simplify intersections of plain types
+
+/// file: index.ts
+
+import * as t from 'io-ts';
+import * as h from '@bitgo/io-ts-http';
+
+const MyRoute = h.httpRoute({
+  path: '/test',
+  method: 'GET',
+  request: h.httpRequest({}),
+  response: {
+    ok: t.intersection([t.type({ foo: t.string }), t.type({ bar: t.string })]),
+  },
+});
+
+export const Routes = h.apiSpec({
+  'api.v1.test.myroute': {
+    get: MyRoute,
+  },
+});
+
+///
+
+`
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "test",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "summary": "MyRoute",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["foo", "bar"],
+                  "properties": {
+                    "foo": {
+                      "type": "string"
+                    },
+                    "bar": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  }
+}`;


### PR DESCRIPTION
This is mostly noticeable with `optionalize`d codecs as they internally
are represented as an `io-ts` intersection of two types, one containing
the required properties, and the other the optional ones. With this
change, the resulting OpenAPI spec won't needlessly generate an `allOf`
for these.

Ticket: BG-46081