### PR TITLE
fix: inference of `ResponseType<HttpRoute>`

### DIFF
--- a/packages/io-ts-http/src/httpResponse.ts
+++ b/packages/io-ts-http/src/httpResponse.ts
@@ -2,11 +2,13 @@ import * as t from 'io-ts';
 
 import { Status } from '@api-ts/response';
 
-export type HttpResponse = t.Props;
+export type HttpResponse = {
+  [K: string]: t.Mixed;
+};
 
-export type KnownResponses<Response extends HttpResponse> = {
-  [K in keyof Response]: K extends Status ? K : never;
-}[keyof Response];
+type KnownResponses<Response extends HttpResponse> = {
+  [K in Status]: K extends keyof Response ? K : never;
+}[Status];
 
 export const HttpResponseCodes: { [K in Status]: number } = {
   ok: 200,

--- a/packages/io-ts-http/src/httpResponse.ts
+++ b/packages/io-ts-http/src/httpResponse.ts
@@ -3,14 +3,18 @@ import * as t from 'io-ts';
 import { Status } from '@api-ts/response';
 
 export type HttpResponse = {
-  [K: string]: t.Mixed;
+  [K in Status]?: t.Mixed;
 };
 
-type KnownResponses<Response extends HttpResponse> = {
-  [K in Status]: K extends keyof Response ? K : never;
-}[Status];
+export type KnownResponses<Response extends HttpResponse> = {
+  [K in keyof Response]: K extends Status
+    ? undefined extends Response[K]
+      ? never
+      : K
+    : never;
+}[keyof Response];
 
-export const HttpResponseCodes: { [K in Status]: number } = {
+export const HttpResponseCodes = {
   ok: 200,
   invalidRequest: 400,
   unauthenticated: 401,
@@ -19,7 +23,23 @@ export const HttpResponseCodes: { [K in Status]: number } = {
   rateLimitExceeded: 429,
   internalError: 500,
   serviceUnavailable: 503,
-};
+} as const;
 
-export type KnownHttpStatusCodes<Response extends HttpResponse> =
-  typeof HttpResponseCodes[KnownResponses<Response>];
+export type HttpResponseCodes = typeof HttpResponseCodes;
+
+// Create a type-level assertion that the HttpResponseCodes map contains every key
+// in the Status union of string literals, and no unexpected keys. Violations of
+// this assertion will cause compile-time errors.
+//
+// Thanks to https://stackoverflow.com/a/67027737
+type ShapeOf<T> = Record<keyof T, any>;
+type AssertKeysEqual<X extends ShapeOf<Y>, Y extends ShapeOf<X>> = never;
+type _AssertHttpStatusCodeIsDefinedForAllResponses = AssertKeysEqual<
+  { [K in Status]: number },
+  HttpResponseCodes
+>;
+
+export type ResponseTypeForStatus<
+  Response extends HttpResponse,
+  S extends keyof Response,
+> = Response[S] extends t.Mixed ? t.TypeOf<Response[S]> : never;

--- a/packages/io-ts-http/src/httpRoute.ts
+++ b/packages/io-ts-http/src/httpRoute.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 
-import { HttpResponse } from './httpResponse';
-import { HttpRequestCodec } from './httpRequest';
+import { HttpResponse, KnownResponses } from './httpResponse';
+import { httpRequest, HttpRequestCodec } from './httpRequest';
 import { Status } from '@api-ts/response';
 
 export type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
@@ -13,15 +13,17 @@ export type HttpRoute = {
   readonly response: HttpResponse;
 };
 
+type ResponseItem<Status, Codec extends t.Mixed | undefined> = Codec extends t.Mixed
+  ? {
+      type: Status;
+      payload: t.TypeOf<Codec>;
+    }
+  : never;
+
 export type RequestType<T extends HttpRoute> = t.TypeOf<T['request']>;
 export type ResponseType<T extends HttpRoute> = {
-  [K in Status]: K extends keyof T['response']
-    ? {
-        type: K;
-        payload: t.TypeOf<T['response'][K]>;
-      }
-    : never;
-}[Status];
+  [K in KnownResponses<T['response']>]: ResponseItem<K, T['response'][K]>;
+}[KnownResponses<T['response']>];
 
 export type ApiSpec = {
   [Key: string]: {

--- a/packages/io-ts-http/src/httpRoute.ts
+++ b/packages/io-ts-http/src/httpRoute.ts
@@ -1,7 +1,8 @@
 import * as t from 'io-ts';
 
-import { HttpResponse, KnownResponses } from './httpResponse';
+import { HttpResponse } from './httpResponse';
 import { HttpRequestCodec } from './httpRequest';
+import { Status } from '@api-ts/response';
 
 export type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
@@ -14,11 +15,13 @@ export type HttpRoute = {
 
 export type RequestType<T extends HttpRoute> = t.TypeOf<T['request']>;
 export type ResponseType<T extends HttpRoute> = {
-  [K in KnownResponses<T['response']>]: {
-    type: K;
-    payload: t.TypeOf<T['response'][K]>;
-  };
-}[KnownResponses<T['response']>];
+  [K in Status]: K extends keyof T['response']
+    ? {
+        type: K;
+        payload: t.TypeOf<T['response'][K]>;
+      }
+    : never;
+}[Status];
 
 export type ApiSpec = {
   [Key: string]: {


### PR DESCRIPTION
Instead of `never` this should be something like the union of all
responses with `any` or `unknown` body.

Broken:
<img width="457" alt="image" src="https://user-images.githubusercontent.com/88669932/161837031-2d8e96e2-47e8-4fa0-aa47-4d0d5e276cb6.png">


Fixed:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/88669932/161836878-2c959206-6cbc-4c8e-b054-81c83531fe7a.png">
