### PR TITLE
fix!: rename errors to error in 400 responses

### DIFF
--- a/packages/express-wrapper/src/index.ts
+++ b/packages/express-wrapper/src/index.ts
@@ -48,7 +48,7 @@ const decodeRequestAndEncodeResponse = <Route extends HttpRoute>(
         const validationErrors = PathReporter.failure(maybeRequest.left);
         const validationErrorMessage = validationErrors.join('\n');
         res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.write(JSON.stringify({ errors: validationErrorMessage }));
+        res.write(JSON.stringify({ error: validationErrorMessage }));
         res.end();
         return;
       }

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -44,7 +44,7 @@
         "test/": "dist/test/"
       }
     },
-    "timeout": "30s"
+    "timeout": "1m"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
For consistency, since the value of this key is a scalar (`string`)
and not a vector, and for congruence with our convention at BitGo of
handling errors.

Closes #39