### PR TITLE
Fix local pkg versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15127,16 +15127,16 @@
     },
     "packages/express-wrapper": {
       "name": "@api-ts/express-wrapper",
-      "version": "*",
+      "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "dependencies": {
-        "@api-ts/io-ts-http": "*",
+        "@api-ts/io-ts-http": "0.0.0-semantically-released",
         "express": "4.17.2",
         "fp-ts": "2.11.8",
         "io-ts": "2.2.16"
       },
       "devDependencies": {
-        "@api-ts/superagent-wrapper": "*",
+        "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
         "@ava/typescript": "3.0.1",
         "@types/express": "4.17.13",
         "@types/node": "16.11.7",
@@ -15147,10 +15147,10 @@
     },
     "packages/io-ts-http": {
       "name": "@api-ts/io-ts-http",
-      "version": "*",
+      "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "dependencies": {
-        "@api-ts/response": "*",
+        "@api-ts/response": "0.0.0-semantically-released",
         "fp-ts": "2.11.8",
         "io-ts": "2.2.16",
         "io-ts-types": "0.5.16",
@@ -15176,10 +15176,10 @@
     },
     "packages/openapi-generator": {
       "name": "@api-ts/openapi-generator",
-      "version": "*",
+      "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "dependencies": {
-        "@api-ts/io-ts-http": "*",
+        "@api-ts/io-ts-http": "0.0.0-semantically-released",
         "cmd-ts": "0.10.0",
         "comment-parser": "1.3.1",
         "fp-ts": "2.11.8",
@@ -15201,7 +15201,7 @@
     },
     "packages/response": {
       "name": "@api-ts/response",
-      "version": "*",
+      "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "4.5.5"
@@ -15209,10 +15209,10 @@
     },
     "packages/superagent-wrapper": {
       "name": "@api-ts/superagent-wrapper",
-      "version": "*",
+      "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "dependencies": {
-        "@api-ts/io-ts-http": "*",
+        "@api-ts/io-ts-http": "0.0.0-semantically-released",
         "fp-ts": "2.11.8",
         "io-ts": "2.2.16",
         "superagent": "3.8.3",
@@ -15539,8 +15539,8 @@
     "@api-ts/express-wrapper": {
       "version": "file:packages/express-wrapper",
       "requires": {
-        "@api-ts/io-ts-http": "*",
-        "@api-ts/superagent-wrapper": "*",
+        "@api-ts/io-ts-http": "0.0.0-semantically-released",
+        "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
         "@ava/typescript": "3.0.1",
         "@types/express": "4.17.13",
         "@types/node": "16.11.7",
@@ -15555,7 +15555,7 @@
     "@api-ts/io-ts-http": {
       "version": "file:packages/io-ts-http",
       "requires": {
-        "@api-ts/response": "*",
+        "@api-ts/response": "0.0.0-semantically-released",
         "@types/chai": "4.2.12",
         "@types/mocha": "9.0.0",
         "@types/node": "14.18.9",
@@ -15582,7 +15582,7 @@
     "@api-ts/openapi-generator": {
       "version": "file:packages/openapi-generator",
       "requires": {
-        "@api-ts/io-ts-http": "*",
+        "@api-ts/io-ts-http": "0.0.0-semantically-released",
         "@ava/typescript": "3.0.1",
         "ava": "4.0.1",
         "cmd-ts": "0.10.0",
@@ -15606,7 +15606,7 @@
     "@api-ts/superagent-wrapper": {
       "version": "file:packages/superagent-wrapper",
       "requires": {
-        "@api-ts/io-ts-http": "*",
+        "@api-ts/io-ts-http": "0.0.0-semantically-released",
         "@types/chai": "4.2.12",
         "@types/express": "4.17.13",
         "@types/mocha": "9.0.0",

--- a/packages/express-wrapper/package.json
+++ b/packages/express-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-ts/express-wrapper",
-  "version": "*",
+  "version": "0.0.0-semantically-released",
   "description": "Implement an HTTP specification with Express",
   "author": "Eric Crosson <ericcrosson@bitgo.com>",
   "license": "Apache-2.0",
@@ -15,13 +15,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@api-ts/io-ts-http": "*",
+    "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "express": "4.17.2",
     "fp-ts": "2.11.8",
     "io-ts": "2.2.16"
   },
   "devDependencies": {
-    "@api-ts/superagent-wrapper": "*",
+    "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
     "@ava/typescript": "3.0.1",
     "@types/express": "4.17.13",
     "@types/node": "16.11.7",

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-ts/io-ts-http",
-  "version": "*",
+  "version": "0.0.0-semantically-released",
   "description": "Types for (de)serializing HTTP requests from both the client and server side",
   "author": "Patrick McLaughlin <patrickmclaughlin@bitgo.com>",
   "license": "Apache-2.0",
@@ -17,7 +17,7 @@
     "test": "nyc --reporter=lcov --reporter=text --reporter=json-summary mocha test/**/*.test.ts --require ts-node/register --exit"
   },
   "dependencies": {
-    "@api-ts/response": "*",
+    "@api-ts/response": "0.0.0-semantically-released",
     "fp-ts": "2.11.8",
     "io-ts": "2.2.16",
     "io-ts-types": "0.5.16",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-ts/openapi-generator",
-  "version": "*",
+  "version": "0.0.0-semantically-released",
   "description": "Generate an OpenAPI specification from an io-ts-http contract",
   "author": "Patrick McLaughlin <patrickmclaughlin@bitgo.com>",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
     "test": "ava test/test-corpus.ts"
   },
   "dependencies": {
-    "@api-ts/io-ts-http": "*",
+    "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "cmd-ts": "0.10.0",
     "comment-parser": "1.3.1",
     "fp-ts": "2.11.8",

--- a/packages/response/package.json
+++ b/packages/response/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-ts/response",
-  "version": "*",
+  "version": "0.0.0-semantically-released",
   "description": "Types for representing responses",
   "author": "Patrick McLaughlin <patrickmclaughlin@bitgo.com>",
   "license": "Apache-2.0",

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-ts/superagent-wrapper",
-  "version": "*",
+  "version": "0.0.0-semantically-released",
   "description": "Make type-safe HTTP requests with superagent",
   "author": "Patrick McLaughlin <patrickmclaughlin@bitgo.com>",
   "license": "Apache-2.0",
@@ -15,7 +15,7 @@
     "test": "nyc --reporter=lcov --reporter=text --reporter=json-summary mocha test/**/*.test.ts --require ts-node/register --exit"
   },
   "dependencies": {
-    "@api-ts/io-ts-http": "*",
+    "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "fp-ts": "2.11.8",
     "io-ts": "2.2.16",
     "superagent": "3.8.3",


### PR DESCRIPTION
`multi-semantic-release`'s readme says to use `*` as the version field for monorepo packages, but this fails in a strange way. This switches them to `0.0.0-semantically-released` as recommended in a Github issue.
    
See: https://github.com/dhoulb/multi-semantic-release/issues/102