### PR TITLE
fix: disable workspace update when running multi-semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm test
 
       - name: Release
-        run: npx multi-semantic-release
+        run: npx --userconfig .npmrc-release multi-semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc-release
+++ b/.npmrc-release
@@ -1,0 +1,1 @@
+workspaces-update = false


### PR DESCRIPTION
See: https://docs.npmjs.com/cli/v8/using-npm/config#workspaces-update

My guess here is that the side effects of this on-by-default config option conflict with the version handling of `multi-semantic-release`. I can get `npm version` to work with this change but haven't tried it in CI yet.

Ticket: (is there one for this yet?)