### PR TITLE
fix: put .npmrc at default location for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,13 @@ jobs:
       - name: Test
         run: npm test
 
+      # DISCUSS: Use `jq` or just a small node script to create/modify `.npmrc` in case
+      # one gets added in the future
+      - name: Prepare Release
+        run: mv .npmrc-release .npmrc
+
       - name: Release
-        run: npx --userconfig .npmrc-release multi-semantic-release
+        run: npx multi-semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This file should be respected by `semantic-release` according to their
documentation.

See: https://github.com/semantic-release/semantic-release/blob/8fda7fd423d24e7b425fbee83790f49dd0478e2d/docs/support/FAQ.md#can-i-use-npmrc-options