### PR TITLE
fix: add headers to response table

### DIFF
--- a/packages/response/src/index.ts
+++ b/packages/response/src/index.ts
@@ -1,4 +1,5 @@
-// ----------------------------|--------------------|------------
+// HTTP                        | GRPC               | Response
+// ----------------------------|--------------------|---------------------------
 // 400 (bad request)           | INVALID_ARGUMENT   | Response.invalidRequest
 // 401 (unauthorized)          | UNAUTHENTICATED    | Response.unauthenticated
 // 403 (forbidden)             | PERMISSION_DENIED  | Response.permissionDenied


### PR DESCRIPTION
The real motivation for this is to trigger a semantic release of
`@api-ts/response`