### PR TITLE
fix: use consistent format for path parameters between server and client

### DIFF
--- a/packages/express-wrapper/src/index.ts
+++ b/packages/express-wrapper/src/index.ts
@@ -14,6 +14,8 @@ import {
   ResponseType,
 } from '@api-ts/io-ts-http';
 
+import { apiTsPathToExpress } from './path';
+
 export type Function<R extends HttpRoute> = (
   input: RequestType<R>,
 ) => ResponseType<R> | Promise<ResponseType<R>>;
@@ -141,7 +143,8 @@ export function createServer<Spec extends ApiSpec>(
       );
       const handlers = [...stack.slice(0, stack.length - 1), handler];
 
-      router[method](httpRoute.path, handlers);
+      const expressPath = apiTsPathToExpress(httpRoute.path);
+      router[method](expressPath, handlers);
     }
   }
 

--- a/packages/express-wrapper/src/path.ts
+++ b/packages/express-wrapper/src/path.ts
@@ -1,0 +1,8 @@
+// Converts an io-ts-http path to an express one
+// assumes that only simple path parameters are present and the wildcard features in express
+// arent used.
+
+const PATH_PARAM = /{(\w+)}/g;
+
+export const apiTsPathToExpress = (inputPath: string) =>
+  inputPath.replace(PATH_PARAM, ':$1');

--- a/packages/express-wrapper/test/path.test.ts
+++ b/packages/express-wrapper/test/path.test.ts
@@ -1,0 +1,21 @@
+import test from 'ava';
+
+import { apiTsPathToExpress } from '../src/path';
+
+test('should pass through paths with no parameters', (t) => {
+  const input = '/foo/bar';
+  const output = apiTsPathToExpress(input);
+  t.deepEqual(output, input);
+});
+
+test('should translate a path segment that specifies a parameter', (t) => {
+  const input = '/foo/{bar}';
+  const output = apiTsPathToExpress(input);
+  t.deepEqual(output, '/foo/:bar');
+});
+
+test('should translate multiple path segments', (t) => {
+  const input = '/foo/{bar}/baz/{id}';
+  const output = apiTsPathToExpress(input);
+  t.deepEqual(output, '/foo/:bar/baz/:id');
+});


### PR DESCRIPTION
This is technically a breaking change, but on the other hand this was the original intended behavior.

Ticket: BG-46917