### PR TITLE
change the way `response` is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14108,6 +14108,7 @@
       "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "dependencies": {
+        "@api-ts/response": "0.0.0-semantically-released",
         "fp-ts": "2.11.8",
         "io-ts": "2.1.3",
         "io-ts-types": "0.5.16",
@@ -14521,6 +14522,7 @@
     "@api-ts/io-ts-http": {
       "version": "file:packages/io-ts-http",
       "requires": {
+        "@api-ts/response": "0.0.0-semantically-released",
         "@types/chai": "4.2.12",
         "@types/mocha": "9.0.0",
         "@types/node": "14.18.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14108,7 +14108,6 @@
       "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "dependencies": {
-        "@api-ts/response": "0.0.0-semantically-released",
         "fp-ts": "2.11.8",
         "io-ts": "2.1.3",
         "io-ts-types": "0.5.16",
@@ -14522,7 +14521,6 @@
     "@api-ts/io-ts-http": {
       "version": "file:packages/io-ts-http",
       "requires": {
-        "@api-ts/response": "0.0.0-semantically-released",
         "@types/chai": "4.2.12",
         "@types/mocha": "9.0.0",
         "@types/node": "14.18.9",

--- a/packages/express-wrapper/src/request.ts
+++ b/packages/express-wrapper/src/request.ts
@@ -1,0 +1,103 @@
+/**
+ * express-wrapper
+ * A simple, type-safe web server
+ */
+
+import express from 'express';
+import * as t from 'io-ts';
+import * as PathReporter from 'io-ts/lib/PathReporter';
+
+import {
+  HttpRoute,
+  HttpToKeyStatus,
+  KeyToHttpStatus,
+  RequestType,
+  ResponseType,
+} from '@api-ts/io-ts-http';
+
+type NumericOrKeyedResponseType<R extends HttpRoute> =
+  | ResponseType<R>
+  | {
+      [S in keyof R['response']]: S extends keyof HttpToKeyStatus
+        ? {
+            type: HttpToKeyStatus[S];
+            payload: t.TypeOf<R['response'][S]>;
+          }
+        : never;
+    }[keyof R['response']];
+
+export type ServiceFunction<R extends HttpRoute> = (
+  input: RequestType<R>,
+) => NumericOrKeyedResponseType<R> | Promise<NumericOrKeyedResponseType<R>>;
+
+export type RouteHandler<R extends HttpRoute> =
+  | ServiceFunction<R>
+  | { middleware: express.RequestHandler[]; handler: ServiceFunction<R> };
+
+export const getServiceFunction = <R extends HttpRoute>(
+  routeHandler: RouteHandler<R>,
+): ServiceFunction<R> =>
+  'handler' in routeHandler ? routeHandler.handler : routeHandler;
+
+export const getMiddleware = <R extends HttpRoute>(
+  routeHandler: RouteHandler<R>,
+): express.RequestHandler[] =>
+  'middleware' in routeHandler ? routeHandler.middleware : [];
+
+/**
+ * Dynamically assign a function name to avoid anonymous functions in stack traces
+ * https://stackoverflow.com/a/69465672
+ */
+const createNamedFunction = <F extends (...args: any) => void>(
+  name: string,
+  fn: F,
+): F => Object.defineProperty(fn, 'name', { value: name });
+
+export const decodeRequestAndEncodeResponse = <Route extends HttpRoute>(
+  apiName: string,
+  httpRoute: Route,
+  handler: ServiceFunction<Route>,
+): express.RequestHandler => {
+  return createNamedFunction(
+    'decodeRequestAndEncodeResponse' + httpRoute.method + apiName,
+    async (req, res) => {
+      const maybeRequest = httpRoute.request.decode(req);
+      if (maybeRequest._tag === 'Left') {
+        console.log('Request failed to decode');
+        const validationErrors = PathReporter.failure(maybeRequest.left);
+        const validationErrorMessage = validationErrors.join('\n');
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.write(JSON.stringify({ error: validationErrorMessage }));
+        res.end();
+        return;
+      }
+
+      let rawResponse: NumericOrKeyedResponseType<Route> | undefined;
+      try {
+        rawResponse = await handler(maybeRequest.right);
+      } catch (err) {
+        console.warn('Error in route handler:', err);
+        res.status(500).end();
+        return;
+      }
+
+      const { type, payload } = rawResponse;
+      const status = typeof type === 'number' ? type : (KeyToHttpStatus as any)[type];
+      if (status === undefined) {
+        console.warn('Unknown status code returned');
+        res.status(500).end();
+        return;
+      }
+      const responseCodec = httpRoute.response[status];
+      if (responseCodec === undefined || !responseCodec.is(payload)) {
+        console.warn(
+          "Unable to encode route's return value, did you return the expected type?",
+        );
+        res.status(500).end();
+        return;
+      }
+
+      res.status(status).json(responseCodec.encode(payload)).end();
+    },
+  );
+};

--- a/packages/express-wrapper/test/server.test.ts
+++ b/packages/express-wrapper/test/server.test.ts
@@ -99,7 +99,7 @@ const CreateHelloWorld = async (parameters: {
 
 const GetHelloWorld = async (params: { id: string }) =>
   ({
-    type: 200,
+    type: 'ok',
     payload: params,
   } as const);
 
@@ -110,8 +110,8 @@ test('should offer a delightful developer experience', async (t) => {
     app.use(appMiddleware);
     return {
       'hello.world': {
-        put: [routeMiddleware, CreateHelloWorld],
-        get: [GetHelloWorld],
+        put: { middleware: [routeMiddleware], handler: CreateHelloWorld },
+        get: GetHelloWorld,
       },
     };
   });
@@ -139,8 +139,8 @@ test('should handle io-ts-http formatted path parameters', async (t) => {
     app.use(appMiddleware);
     return {
       'hello.world': {
-        put: [routeMiddleware, CreateHelloWorld],
-        get: [GetHelloWorld],
+        put: { middleware: [routeMiddleware], handler: CreateHelloWorld },
+        get: GetHelloWorld,
       },
     };
   });
@@ -163,8 +163,8 @@ test('should invoke app-level middleware', async (t) => {
     app.use(appMiddleware);
     return {
       'hello.world': {
-        put: [CreateHelloWorld],
-        get: [GetHelloWorld],
+        put: CreateHelloWorld,
+        get: GetHelloWorld,
       },
     };
   });
@@ -186,8 +186,8 @@ test('should invoke route-level middleware', async (t) => {
     app.use(express.json());
     return {
       'hello.world': {
-        put: [routeMiddleware, CreateHelloWorld],
-        get: [GetHelloWorld],
+        put: { middleware: [routeMiddleware], handler: CreateHelloWorld },
+        get: GetHelloWorld,
       },
     };
   });
@@ -209,8 +209,8 @@ test('should infer status code from response type', async (t) => {
     app.use(express.json());
     return {
       'hello.world': {
-        put: [CreateHelloWorld],
-        get: [GetHelloWorld],
+        put: CreateHelloWorld,
+        get: GetHelloWorld,
       },
     };
   });
@@ -232,8 +232,8 @@ test('should return a 400 when request fails to decode', async (t) => {
     app.use(express.json());
     return {
       'hello.world': {
-        put: [CreateHelloWorld],
-        get: [GetHelloWorld],
+        put: CreateHelloWorld,
+        get: GetHelloWorld,
       },
     };
   });

--- a/packages/io-ts-http/docs/httpRoute.md
+++ b/packages/io-ts-http/docs/httpRoute.md
@@ -21,7 +21,7 @@ httpRoute({
     },
   }),
   response: {
-    ok: t.string,
+    200: t.string,
   },
 });
 ```
@@ -38,7 +38,7 @@ httpRoute({
     },
   }),
   response: {
-    ok: t.string,
+    200: t.string,
   },
 });
 ```
@@ -64,7 +64,7 @@ const Route = httpRoute({
     },
   }),
   response: {
-    ok: t.string,
+    200: t.string,
   },
 });
 
@@ -86,8 +86,8 @@ const response: string = await routeApiClient({ id: 1337 });
 ### `response`
 
 Declares the potential responses that a route may return along with the codec associated
-to each response. The possible response keys can be found in the `io-ts-response`
-package. Incoming responses are assumed to be JSON.
+to each response. Response keys correspond to HTTP status codes. Incoming responses are
+assumed to be JSON.
 
 ```typescript
 const Route = httpRoute({
@@ -95,13 +95,13 @@ const Route = httpRoute({
   method: 'GET',
   request: httpRequest({}),
   response: {
-    ok: t.type({
+    200: t.type({
       foo: t.string,
     }),
-    notFound: t.type({
+    404: t.type({
       message: t.string,
     }),
-    invalidRequest: t.type({
+    400: t.type({
       message: t.string,
     }),
   },
@@ -154,7 +154,7 @@ const StringBodyRoute = httpRoute({
     }),
   ]),
   response: {
-    ok: t.string,
+    200: t.string,
   },
 });
 
@@ -191,7 +191,7 @@ const UnionRoute = httpRoute({
     }),
   ]),
   response: {
-    ok: string,
+    200: string,
   },
 });
 

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -17,7 +17,6 @@
     "test": "nyc --reporter=lcov --reporter=text --reporter=json-summary mocha test/**/*.test.ts --require ts-node/register --exit"
   },
   "dependencies": {
-    "@api-ts/response": "0.0.0-semantically-released",
     "fp-ts": "2.11.8",
     "io-ts": "2.1.3",
     "io-ts-types": "0.5.16",

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -17,6 +17,7 @@
     "test": "nyc --reporter=lcov --reporter=text --reporter=json-summary mocha test/**/*.test.ts --require ts-node/register --exit"
   },
   "dependencies": {
+    "@api-ts/response": "0.0.0-semantically-released",
     "fp-ts": "2.11.8",
     "io-ts": "2.1.3",
     "io-ts-types": "0.5.16",

--- a/packages/io-ts-http/src/httpResponse.ts
+++ b/packages/io-ts-http/src/httpResponse.ts
@@ -1,43 +1,8 @@
 import * as t from 'io-ts';
 
-import { Status } from '@api-ts/response';
-
 export type HttpResponse = {
-  [K in Status]?: t.Mixed;
+  [K: number]: t.Mixed;
 };
-
-export type KnownResponses<Response extends HttpResponse> = {
-  [K in keyof Response]: K extends Status
-    ? undefined extends Response[K]
-      ? never
-      : K
-    : never;
-}[keyof Response];
-
-export const HttpResponseCodes = {
-  ok: 200,
-  invalidRequest: 400,
-  unauthenticated: 401,
-  permissionDenied: 403,
-  notFound: 404,
-  rateLimitExceeded: 429,
-  internalError: 500,
-  serviceUnavailable: 503,
-} as const;
-
-export type HttpResponseCodes = typeof HttpResponseCodes;
-
-// Create a type-level assertion that the HttpResponseCodes map contains every key
-// in the Status union of string literals, and no unexpected keys. Violations of
-// this assertion will cause compile-time errors.
-//
-// Thanks to https://stackoverflow.com/a/67027737
-type ShapeOf<T> = Record<keyof T, any>;
-type AssertKeysEqual<X extends ShapeOf<Y>, Y extends ShapeOf<X>> = never;
-type _AssertHttpStatusCodeIsDefinedForAllResponses = AssertKeysEqual<
-  { [K in Status]: number },
-  HttpResponseCodes
->;
 
 export type ResponseTypeForStatus<
   Response extends HttpResponse,

--- a/packages/io-ts-http/src/httpRoute.ts
+++ b/packages/io-ts-http/src/httpRoute.ts
@@ -1,8 +1,7 @@
 import * as t from 'io-ts';
 
-import { HttpResponse, KnownResponses } from './httpResponse';
-import { httpRequest, HttpRequestCodec } from './httpRequest';
-import { Status } from '@api-ts/response';
+import { HttpResponse } from './httpResponse';
+import { HttpRequestCodec } from './httpRequest';
 
 export type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
@@ -13,17 +12,15 @@ export type HttpRoute = {
   readonly response: HttpResponse;
 };
 
-type ResponseItem<Status, Codec extends t.Mixed | undefined> = Codec extends t.Mixed
-  ? {
-      type: Status;
-      payload: t.TypeOf<Codec>;
-    }
-  : never;
-
 export type RequestType<T extends HttpRoute> = t.TypeOf<T['request']>;
 export type ResponseType<T extends HttpRoute> = {
-  [K in KnownResponses<T['response']>]: ResponseItem<K, T['response'][K]>;
-}[KnownResponses<T['response']>];
+  [K in keyof T['response']]: T['response'][K] extends t.Mixed
+    ? {
+        type: K;
+        payload: t.TypeOf<T['response'][K]>;
+      }
+    : never;
+}[keyof T['response']];
 
 export type ApiSpec = {
   [Key: string]: {

--- a/packages/io-ts-http/src/index.ts
+++ b/packages/io-ts-http/src/index.ts
@@ -8,3 +8,4 @@ export * from './httpResponse';
 export * from './httpRequest';
 export * from './httpRoute';
 export * from './queryParams';
+export * from './statusCode';

--- a/packages/io-ts-http/src/statusCode.ts
+++ b/packages/io-ts-http/src/statusCode.ts
@@ -1,0 +1,27 @@
+// TODO: Enforce consistency at the type level
+
+export const HttpToKeyStatus = {
+  200: 'ok',
+  400: 'invalidRequest',
+  401: 'unauthenticated',
+  403: 'permissionDenied',
+  404: 'notFound',
+  429: 'rateLimitExceeded',
+  500: 'internalError',
+  503: 'serviceUnavailable',
+} as const;
+
+export type HttpToKeyStatus = typeof HttpToKeyStatus;
+
+export const KeyToHttpStatus = {
+  ok: 200,
+  invalidRequest: 400,
+  unauthenticated: 401,
+  permissionDenied: 403,
+  notFound: 404,
+  rateLimitExceeded: 429,
+  internalError: 500,
+  serviceUnavailable: 503,
+} as const;
+
+export type KeyToHttpStatus = typeof KeyToHttpStatus;

--- a/packages/openapi-generator/corpus/test-array-property.ts
+++ b/packages/openapi-generator/corpus/test-array-property.ts
@@ -10,7 +10,7 @@ const MyRoute = h.httpRoute({
   method: 'GET',
   request: h.httpRequest({}),
   response: {
-    ok: t.array(t.string),
+    200: t.array(t.string),
   },
 });
 

--- a/packages/openapi-generator/corpus/test-boolean-literal.ts
+++ b/packages/openapi-generator/corpus/test-boolean-literal.ts
@@ -10,7 +10,7 @@ const MyRoute = h.httpRoute({
   method: 'GET',
   request: h.httpRequest({}),
   response: {
-    ok: t.literal(false),
+    200: t.literal(false),
   },
 });
 

--- a/packages/openapi-generator/corpus/test-discriminated-union.ts
+++ b/packages/openapi-generator/corpus/test-discriminated-union.ts
@@ -10,7 +10,10 @@ const MyRoute = h.httpRoute({
   method: 'GET',
   request: h.httpRequest({}),
   response: {
-    ok: t.union([t.type({ key: t.literal('foo') }), t.type({ key: t.literal('bar') })]),
+    200: t.union([
+      t.type({ key: t.literal('foo') }),
+      t.type({ key: t.literal('bar') }),
+    ]),
   },
 } as const);
 

--- a/packages/openapi-generator/corpus/test-intersection-flattening.ts
+++ b/packages/openapi-generator/corpus/test-intersection-flattening.ts
@@ -10,7 +10,7 @@ const MyRoute = h.httpRoute({
   method: 'GET',
   request: h.httpRequest({}),
   response: {
-    ok: t.intersection([t.type({ foo: t.string }), t.type({ bar: t.string })]),
+    200: t.intersection([t.type({ foo: t.string }), t.type({ bar: t.string })]),
   },
 });
 

--- a/packages/openapi-generator/corpus/test-multi-route.ts
+++ b/packages/openapi-generator/corpus/test-multi-route.ts
@@ -22,7 +22,7 @@ const FirstRoute = h.httpRoute({
     },
   }),
   response: {
-    ok: t.string,
+    200: t.string,
   },
 } as const);
 
@@ -42,7 +42,7 @@ const SecondRoute = h.httpRoute({
     },
   }),
   response: {
-    ok: t.string,
+    200: t.string,
   },
 });
 

--- a/packages/openapi-generator/corpus/test-multi-union.ts
+++ b/packages/openapi-generator/corpus/test-multi-union.ts
@@ -10,7 +10,7 @@ const MyRoute = h.httpRoute({
   method: 'GET',
   request: h.httpRequest({}),
   response: {
-    ok: t.union([t.literal('foo'), t.literal(42), t.type({ message: t.string })]),
+    200: t.union([t.literal('foo'), t.literal(42), t.type({ message: t.string })]),
   },
 } as const);
 

--- a/packages/openapi-generator/corpus/test-null-param.ts
+++ b/packages/openapi-generator/corpus/test-null-param.ts
@@ -10,7 +10,7 @@ const MyRoute = h.httpRoute({
   method: 'GET',
   request: h.httpRequest({}),
   response: {
-    ok: t.null,
+    200: t.null,
   },
 });
 

--- a/packages/openapi-generator/corpus/test-optional-property.ts
+++ b/packages/openapi-generator/corpus/test-optional-property.ts
@@ -15,7 +15,7 @@ const MyRoute = h.httpRoute({
     },
   }),
   response: {
-    ok: t.string,
+    200: t.string,
   },
 });
 

--- a/packages/openapi-generator/corpus/test-record-type.ts
+++ b/packages/openapi-generator/corpus/test-record-type.ts
@@ -10,7 +10,7 @@ const MyRoute = h.httpRoute({
   method: 'GET',
   request: h.httpRequest({}),
   response: {
-    ok: t.record(t.string, t.string),
+    200: t.record(t.string, t.string),
   },
 });
 

--- a/packages/openapi-generator/corpus/test-single-route-multi-method.ts
+++ b/packages/openapi-generator/corpus/test-single-route-multi-method.ts
@@ -16,7 +16,7 @@ const FirstRoute = h.httpRoute({
     },
   }),
   response: {
-    ok: t.string,
+    200: t.string,
   },
 } as const);
 
@@ -35,7 +35,7 @@ const SecondRoute = h.httpRoute({
     },
   }),
   response: {
-    ok: t.string,
+    200: t.string,
   },
 });
 

--- a/packages/openapi-generator/corpus/test-single-route.ts
+++ b/packages/openapi-generator/corpus/test-single-route.ts
@@ -39,8 +39,8 @@ const MyRoute = h.httpRoute({
     },
   }),
   response: {
-    ok: t.number,
-    invalidRequest: t.type({ foo: t.string, bar: t.number }),
+    200: t.number,
+    400: t.type({ foo: t.string, bar: t.number }),
   },
 });
 

--- a/packages/openapi-generator/corpus/test-string-union.ts
+++ b/packages/openapi-generator/corpus/test-string-union.ts
@@ -10,7 +10,7 @@ const MyRoute = h.httpRoute({
   method: 'GET',
   request: h.httpRequest({}),
   response: {
-    ok: t.keyof({ foo: 1, bar: 1, baz: 1 }),
+    200: t.keyof({ foo: 1, bar: 1, baz: 1 }),
   },
 } as const);
 

--- a/packages/openapi-generator/corpus/test-unknown-property.ts
+++ b/packages/openapi-generator/corpus/test-unknown-property.ts
@@ -15,7 +15,7 @@ const MyRoute = h.httpRoute({
     },
   }),
   response: {
-    ok: t.type({
+    200: t.type({
       foo: t.unknown,
     }),
   },

--- a/packages/openapi-generator/corpus/test-version-tag.ts
+++ b/packages/openapi-generator/corpus/test-version-tag.ts
@@ -10,7 +10,7 @@ const MyRoute = h.httpRoute({
   method: 'GET',
   request: h.httpRequest({}),
   response: {
-    ok: t.string,
+    200: t.string,
   },
 });
 

--- a/packages/openapi-generator/src/route.ts
+++ b/packages/openapi-generator/src/route.ts
@@ -1,4 +1,3 @@
-import { HttpResponseCodes } from '@api-ts/io-ts-http';
 import { parse as parseComment } from 'comment-parser';
 import { flow, pipe } from 'fp-ts/function';
 import * as E from 'fp-ts/Either';
@@ -247,11 +246,8 @@ export const schemaForRouteNode = (memo: any) => (node: Expression<ts.Expression
               RE.bindTo('schema'),
               RE.bind('code', () => {
                 const name = sym.getName();
-                const statusCode = HttpResponseCodes.hasOwnProperty(name)
-                  ? HttpResponseCodes[name as keyof typeof HttpResponseCodes]
-                  : undefined;
                 return RE.fromEither(
-                  E.fromNullable(`unknown response type '${name}`)(statusCode),
+                  E.fromNullable('undefined response code name')(name),
                 );
               }),
             ),

--- a/packages/superagent-wrapper/test/request.test.ts
+++ b/packages/superagent-wrapper/test/request.test.ts
@@ -25,7 +25,7 @@ const PostTestRoute = h.httpRoute({
     },
   }),
   response: {
-    ok: t.type({
+    200: t.type({
       id: t.number,
       foo: t.string,
       bar: t.number,
@@ -39,7 +39,7 @@ const HeaderGetTestRoute = h.httpRoute({
   method: 'GET',
   request: h.httpRequest({}),
   response: {
-    ok: t.type({
+    200: t.type({
       value: t.string,
     }),
   },
@@ -79,7 +79,7 @@ testApp.post('/test/:id', (req, res) => {
       error: 'bad request',
     });
   } else {
-    const response = PostTestRoute.response['ok'].encode({
+    const response = PostTestRoute.response[200].encode({
       ...params,
       baz: true,
     });
@@ -89,7 +89,7 @@ testApp.post('/test/:id', (req, res) => {
 
 testApp.get(HeaderGetTestRoute.path, (req, res) => {
   res.send(
-    HeaderGetTestRoute.response['ok'].encode({
+    HeaderGetTestRoute.response[200].encode({
       value: String(req.headers['x-custom'] ?? ''),
     }),
   );


### PR DESCRIPTION
This PR does two main things:

1) Remove the `response` library from several places, cleaning up several parts of the codebase
2) Allow the `response` library to still be used for creating http-agnostic service functions

On the second point, I tried a few approaches before ultimately punting on it and just extending the "decode request and encode response" function in `express-wrapper` to handle either raw HTTP status codes or `response` ones.