### PR TITLE
doc: add a readme badge with CI status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # API-TS
 
+![Build Status](https://github.com/BitGo/api-ts/actions/workflows/ci.yml/badge.svg?branch=master)
+
 **Disclaimer: This project is currently in an alpha state. Documentation is actively
 being worked on.**
 


### PR DESCRIPTION
Instructions followed from this webpage:
https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge

CLOSES TICKET: BG-43006