### PR TITLE
chore: configure dependabot to upgrade npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Enable npm updates
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+      # UTC
+      time: '08:00'
+    reviewers:
+      - '@BitGo/internal-tools'
+    labels:
+      - dependencies


### PR DESCRIPTION
I'm not sure if this will work immediately or if we need to find a setting to enable dependabot for this repository. Time will tell!

I'm basing this into master because dependabot probably looks for configuration only on the default branch.

Closes #35