### PR TITLE
chore: use nix flakes with direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use nix
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
+.direnv/
 .drone.yml
 .nyc_output/
+.turbo/
+coverage/
 dist/
 node_modules/
-coverage/
-.turbo/


### PR DESCRIPTION
Requires a fairly recent version of nix (I'm on 2.8.0) and opting in
to the following experimental features:

```
nix-command flakes
```