### PR TITLE
feat(express-wrapper): allow custom response encoders

### DIFF
--- a/packages/express-wrapper/src/index.ts
+++ b/packages/express-wrapper/src/index.ts
@@ -14,43 +14,53 @@ import {
   getServiceFunction,
   RouteHandler,
 } from './request';
+import { defaultResponseEncoder, ResponseEncoder } from './response';
+
+export type { ResponseEncoder } from './response';
 
 const isHttpVerb = (verb: string): verb is 'get' | 'put' | 'post' | 'delete' =>
   verb === 'get' || verb === 'put' || verb === 'post' || verb === 'delete';
 
-export function createServer<Spec extends ApiSpec>(
-  spec: Spec,
-  configureExpressApplication: (app: express.Application) => {
-    [ApiName in keyof Spec]: {
-      [Method in keyof Spec[ApiName]]: RouteHandler<Spec[ApiName][Method]>;
-    };
-  },
-) {
-  const app: express.Application = express();
-  const routes = configureExpressApplication(app);
+export const createServerWithResponseEncoder =
+  (encoder: ResponseEncoder) =>
+  <Spec extends ApiSpec>(
+    spec: ApiSpec,
+    configureExpressApplication: (app: express.Application) => {
+      [ApiName in keyof Spec]: {
+        [Method in keyof Spec[ApiName]]: RouteHandler<Spec[ApiName][Method]>;
+      };
+    },
+  ) => {
+    const app: express.Application = express();
+    const routes = configureExpressApplication(app);
 
-  const router = express.Router();
-  for (const apiName of Object.keys(spec)) {
-    const resource = spec[apiName] as Spec[string];
-    for (const method of Object.keys(resource)) {
-      if (!isHttpVerb(method)) {
-        continue;
+    const router = express.Router();
+    for (const apiName of Object.keys(spec)) {
+      const resource = spec[apiName] as Spec[string];
+      for (const method of Object.keys(resource)) {
+        if (!isHttpVerb(method)) {
+          continue;
+        }
+        const httpRoute: HttpRoute = resource[method]!;
+        const routeHandler = routes[apiName]![method]!;
+        const expressRouteHandler = decodeRequestAndEncodeResponse(
+          apiName,
+          httpRoute,
+          // FIXME: TS is complaining that `routeHandler` is not necessarily guaranteed to be a
+          // `ServiceFunction`, because subtypes of Spec[string][string] can have arbitrary extra keys.
+          getServiceFunction(routeHandler as any),
+          encoder,
+        );
+        const handlers = [...getMiddleware(routeHandler), expressRouteHandler];
+
+        const expressPath = apiTsPathToExpress(httpRoute.path);
+        router[method](expressPath, handlers);
       }
-      const httpRoute: HttpRoute = resource[method]!;
-      const routeHandler = routes[apiName]![method]!;
-      const expressRouteHandler = decodeRequestAndEncodeResponse(
-        apiName,
-        httpRoute as any, // TODO: wat
-        getServiceFunction(routeHandler),
-      );
-      const handlers = [...getMiddleware(routeHandler), expressRouteHandler];
-
-      const expressPath = apiTsPathToExpress(httpRoute.path);
-      router[method](expressPath, handlers);
     }
-  }
 
-  app.use(router);
+    app.use(router);
 
-  return app;
-}
+    return app;
+  };
+
+export const createServer = createServerWithResponseEncoder(defaultResponseEncoder);

--- a/packages/express-wrapper/src/response.ts
+++ b/packages/express-wrapper/src/response.ts
@@ -1,0 +1,50 @@
+import express from 'express';
+import * as t from 'io-ts';
+
+import {
+  HttpRoute,
+  HttpToKeyStatus,
+  KeyToHttpStatus,
+  ResponseType,
+} from '@api-ts/io-ts-http';
+
+export type NumericOrKeyedResponseType<R extends HttpRoute> =
+  | ResponseType<R>
+  | {
+      [Key in keyof R['response'] & keyof HttpToKeyStatus]: {
+        type: HttpToKeyStatus[Key];
+        payload: t.TypeOf<R['response'][Key]>;
+      };
+    }[keyof R['response'] & keyof HttpToKeyStatus];
+
+// TODO: Use HKT (using fp-ts or a similar workaround method, or who knows maybe they'll add
+// official support) to allow for polymorphic ResponseType<_>.
+export type ResponseEncoder = (
+  route: HttpRoute,
+  serviceFnResponse: NumericOrKeyedResponseType<HttpRoute>,
+  expressRes: express.Response,
+) => void;
+
+export const defaultResponseEncoder: ResponseEncoder = (
+  route,
+  serviceFnResponse,
+  expressRes,
+) => {
+  const { type, payload } = serviceFnResponse;
+  const status = typeof type === 'number' ? type : (KeyToHttpStatus as any)[type];
+  if (status === undefined) {
+    console.warn('Unknown status code returned');
+    expressRes.status(500).end();
+    return;
+  }
+  const responseCodec = route.response[status];
+  if (responseCodec === undefined || !responseCodec.is(payload)) {
+    console.warn(
+      "Unable to encode route's return value, did you return the expected type?",
+    );
+    expressRes.status(500).end();
+    return;
+  }
+
+  expressRes.status(status).json(responseCodec.encode(payload)).end();
+};


### PR DESCRIPTION
Fixes a soundness issue with NumericOrKeyedResponseType when instantiated with the maximally-wide HttpRoute, and is the beginning of allowing for customizing the way responses are encoded and then actually sent to Express.