### PR TITLE
chore: consider docs-changes to be patch releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,12 @@
 {
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [{ "type": "docs", "release": "patch" }]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semrel-extra/npm",
     [


### PR DESCRIPTION
Since our docstrings and our README.md files ship with the code,
we should publish a new version when these docs are updated.

This change will at least satisfy those requirements, and also possible
ship some new patch version for other docs that aren't visible in
the published artifact, but that sounds okay to me.

You can see on the commit-analyzer readme that the default `preset`
is `angular`[^1] (so no changes there, just making this explicit), and
explicit rules are additve to the base presets[^2].

[^1]: https://github.com/semantic-release/commit-analyzer#configuration
[^2]: https://github.com/semantic-release/commit-analyzer#releaserules