### PR TITLE
ci: only run release job in BitGo's GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     name: Release
+    if: github.repository_owner == 'BitGo'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
When I pulled upstream/master and pushed to my fork's master branch,
the release job ran and failed because I did not have the NPM_TOKEN
configured in my GitHub Actions.

This commit prevents the release workflow from running in GitHub
Actions of forks.