### PR TITLE
Add router-returning function to express-wrapper

### DIFF
--- a/packages/express-wrapper/src/index.ts
+++ b/packages/express-wrapper/src/index.ts
@@ -21,46 +21,59 @@ export type { ResponseEncoder } from './response';
 const isHttpVerb = (verb: string): verb is 'get' | 'put' | 'post' | 'delete' =>
   verb === 'get' || verb === 'put' || verb === 'post' || verb === 'delete';
 
-export const createServerWithResponseEncoder =
-  (encoder: ResponseEncoder) =>
-  <Spec extends ApiSpec>(
-    spec: ApiSpec,
-    configureExpressApplication: (app: express.Application) => {
-      [ApiName in keyof Spec]: {
-        [Method in keyof Spec[ApiName]]: RouteHandler<Spec[ApiName][Method]>;
-      };
-    },
-  ) => {
-    const app: express.Application = express();
-    const routes = configureExpressApplication(app);
-
-    const router = express.Router();
-    for (const apiName of Object.keys(spec)) {
-      const resource = spec[apiName] as Spec[string];
-      for (const method of Object.keys(resource)) {
-        if (!isHttpVerb(method)) {
-          continue;
-        }
-        const httpRoute: HttpRoute = resource[method]!;
-        const routeHandler = routes[apiName]![method]!;
-        const expressRouteHandler = decodeRequestAndEncodeResponse(
-          apiName,
-          httpRoute,
-          // FIXME: TS is complaining that `routeHandler` is not necessarily guaranteed to be a
-          // `ServiceFunction`, because subtypes of Spec[string][string] can have arbitrary extra keys.
-          getServiceFunction(routeHandler as any),
-          encoder,
-        );
-        const handlers = [...getMiddleware(routeHandler), expressRouteHandler];
-
-        const expressPath = apiTsPathToExpress(httpRoute.path);
-        router[method](expressPath, handlers);
-      }
-    }
-
-    app.use(router);
-
-    return app;
+type CreateRouterProps<Spec extends ApiSpec> = {
+  spec: Spec;
+  routeHandlers: {
+    [ApiName in keyof Spec]: {
+      [Method in keyof Spec[ApiName]]: RouteHandler<Spec[ApiName][Method]>;
+    };
   };
+  encoder?: ResponseEncoder;
+};
 
-export const createServer = createServerWithResponseEncoder(defaultResponseEncoder);
+export function routerForApiSpec<Spec extends ApiSpec>({
+  spec,
+  routeHandlers,
+  encoder = defaultResponseEncoder,
+}: CreateRouterProps<Spec>) {
+  const router = express.Router();
+  for (const apiName of Object.keys(spec)) {
+    const resource = spec[apiName] as Spec[string];
+    for (const method of Object.keys(resource)) {
+      if (!isHttpVerb(method)) {
+        continue;
+      }
+      const httpRoute: HttpRoute = resource[method]!;
+      const routeHandler = routeHandlers[apiName]![method]!;
+      const expressRouteHandler = decodeRequestAndEncodeResponse(
+        apiName,
+        httpRoute,
+        // FIXME: TS is complaining that `routeHandler` is not necessarily guaranteed to be a
+        // `ServiceFunction`, because subtypes of Spec[string][string] can have arbitrary extra keys.
+        getServiceFunction(routeHandler as any),
+        encoder,
+      );
+      const handlers = [...getMiddleware(routeHandler), expressRouteHandler];
+
+      const expressPath = apiTsPathToExpress(httpRoute.path);
+      router[method](expressPath, handlers);
+    }
+  }
+
+  return router;
+}
+
+export const createServer = <Spec extends ApiSpec>(
+  spec: Spec,
+  configureExpressApplication: (app: express.Application) => {
+    [ApiName in keyof Spec]: {
+      [Method in keyof Spec[ApiName]]: RouteHandler<Spec[ApiName][Method]>;
+    };
+  },
+) => {
+  const app = express();
+  const routeHandlers = configureExpressApplication(app);
+  const router = routerForApiSpec({ spec, routeHandlers });
+  app.use(router);
+  return app;
+};


### PR DESCRIPTION
For existing applications that do large amounts of express
configuration, it is often cleaner to just obtain a router instance and
add it to the existing express stack. This assists with incremental
adoption of api-ts