### PR TITLE
chore: remove explicit peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5027,6 +5027,7 @@
     "node_modules/monocle-ts": {
       "version": "2.3.10",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }
@@ -8541,6 +8542,7 @@
     "node_modules/newtype-ts": {
       "version": "0.3.4",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "fp-ts": "^2.0.0",
         "monocle-ts": "^2.0.0"
@@ -14111,9 +14113,7 @@
         "@api-ts/response": "0.0.0-semantically-released",
         "fp-ts": "2.11.8",
         "io-ts": "2.1.3",
-        "io-ts-types": "0.5.16",
-        "monocle-ts": "2.3.10",
-        "newtype-ts": "0.3.4"
+        "io-ts-types": "0.5.16"
       },
       "devDependencies": {
         "@types/chai": "4.2.12",
@@ -14187,8 +14187,6 @@
         "express": "4.17.1",
         "io-ts-types": "0.5.16",
         "mocha": "9.0.3",
-        "monocle-ts": "2.3.10",
-        "newtype-ts": "0.3.4",
         "nyc": "15.1.0",
         "ts-node": "9.0.0",
         "typescript": "4.5.5"
@@ -14531,8 +14529,6 @@
         "io-ts": "2.1.3",
         "io-ts-types": "0.5.16",
         "mocha": "9.0.3",
-        "monocle-ts": "2.3.10",
-        "newtype-ts": "0.3.4",
         "nyc": "15.1.0",
         "ts-node": "10.4.0",
         "typescript": "4.5.5"
@@ -14585,8 +14581,6 @@
         "io-ts": "2.1.3",
         "io-ts-types": "0.5.16",
         "mocha": "9.0.3",
-        "monocle-ts": "2.3.10",
-        "newtype-ts": "0.3.4",
         "nyc": "15.1.0",
         "superagent": "3.8.3",
         "supertest": "6.1.6",
@@ -17997,6 +17991,7 @@
     },
     "monocle-ts": {
       "version": "2.3.10",
+      "peer": true,
       "requires": {}
     },
     "ms": {
@@ -20484,6 +20479,7 @@
     },
     "newtype-ts": {
       "version": "0.3.4",
+      "peer": true,
       "requires": {}
     },
     "node-emoji": {

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -20,9 +20,7 @@
     "@api-ts/response": "0.0.0-semantically-released",
     "fp-ts": "2.11.8",
     "io-ts": "2.1.3",
-    "io-ts-types": "0.5.16",
-    "monocle-ts": "2.3.10",
-    "newtype-ts": "0.3.4"
+    "io-ts-types": "0.5.16"
   },
   "devDependencies": {
     "@types/chai": "4.2.12",

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -33,8 +33,6 @@
     "express": "4.17.1",
     "io-ts-types": "0.5.16",
     "mocha": "9.0.3",
-    "monocle-ts": "2.3.10",
-    "newtype-ts": "0.3.4",
     "nyc": "15.1.0",
     "ts-node": "9.0.0",
     "typescript": "4.5.5"


### PR DESCRIPTION
We currently list monocle-ts and newtype-ts as explicit dependencies,
since these two packages are peer dependencies of io-ts-types[^1]
and npm 6 doesn't automatically install peer dependencies (like npm
7 does).

This commit removes the explicit peer dependencies, because when npm 7+
is used the behavior will be the same. Additionally, in npm 6 these
to packages won't be installed but they aren't needed, so there will
be no breaking change.

[^1]: https://github.com/gcanti/io-ts-types/blob/master/package.json#L40-L41