### PR TITLE
feat: make superagent/test a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1256,7 +1256,8 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ava": {
       "version": "4.2.0",
@@ -2191,6 +2192,7 @@
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2234,7 +2236,8 @@
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2451,7 +2454,8 @@
     },
     "node_modules/cookiejar": {
       "version": "2.1.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -2625,6 +2629,7 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2991,7 +2996,8 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
@@ -3014,7 +3020,8 @@
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -3140,6 +3147,7 @@
     "node_modules/form-data": {
       "version": "2.5.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -3152,6 +3160,7 @@
     "node_modules/formidable": {
       "version": "1.2.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
@@ -13115,6 +13124,7 @@
     "node_modules/superagent": {
       "version": "3.8.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "component-emitter": "^1.2.0",
         "cookiejar": "^2.1.0",
@@ -13134,6 +13144,7 @@
     "node_modules/superagent/node_modules/debug": {
       "version": "3.2.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -13141,6 +13152,7 @@
     "node_modules/superagent/node_modules/mime": {
       "version": "1.6.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -13196,6 +13208,7 @@
     "node_modules/supertest": {
       "version": "6.1.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "methods": "^1.1.2",
         "superagent": "^6.1.0"
@@ -13207,6 +13220,7 @@
     "node_modules/supertest/node_modules/form-data": {
       "version": "3.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -13219,6 +13233,7 @@
     "node_modules/supertest/node_modules/mime": {
       "version": "2.6.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -13229,6 +13244,7 @@
     "node_modules/supertest/node_modules/readable-stream": {
       "version": "3.6.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -13241,6 +13257,7 @@
     "node_modules/supertest/node_modules/superagent": {
       "version": "6.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.2",
@@ -14267,9 +14284,7 @@
       "dependencies": {
         "@api-ts/io-ts-http": "0.0.0-semantically-released",
         "fp-ts": "2.11.8",
-        "io-ts": "2.1.3",
-        "superagent": "3.8.3",
-        "supertest": "6.1.6"
+        "io-ts": "2.1.3"
       },
       "devDependencies": {
         "@types/chai": "4.2.12",
@@ -14285,6 +14300,10 @@
         "nyc": "15.1.0",
         "ts-node": "10.7.0",
         "typescript": "4.6.4"
+      },
+      "peerDependencies": {
+        "superagent": "3.8.3",
+        "supertest": "6.1.6"
       }
     },
     "packages/superagent-wrapper/node_modules/bytes": {
@@ -14609,8 +14628,6 @@
         "io-ts-types": "0.5.16",
         "mocha": "10.0.0",
         "nyc": "15.1.0",
-        "superagent": "3.8.3",
-        "supertest": "6.1.6",
         "ts-node": "10.7.0",
         "typescript": "4.6.4"
       },
@@ -15645,7 +15662,8 @@
       "dev": true
     },
     "asynckit": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "peer": true
     },
     "ava": {
       "version": "4.2.0",
@@ -16235,6 +16253,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
+      "peer": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -16263,7 +16282,8 @@
       }
     },
     "component-emitter": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "peer": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -16420,7 +16440,8 @@
       "version": "1.0.6"
     },
     "cookiejar": {
-      "version": "2.1.3"
+      "version": "2.1.3",
+      "peer": true
     },
     "core-util-is": {
       "version": "1.0.3"
@@ -16528,7 +16549,8 @@
       }
     },
     "delayed-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "peer": true
     },
     "depd": {
       "version": "1.1.2"
@@ -16772,7 +16794,8 @@
       }
     },
     "extend": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "peer": true
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -16789,7 +16812,8 @@
       }
     },
     "fast-safe-stringify": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "peer": true
     },
     "fastq": {
       "version": "1.13.0",
@@ -16872,6 +16896,7 @@
     },
     "form-data": {
       "version": "2.5.1",
+      "peer": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -16879,7 +16904,8 @@
       }
     },
     "formidable": {
-      "version": "1.2.6"
+      "version": "1.2.6",
+      "peer": true
     },
     "forwarded": {
       "version": "0.2.0"
@@ -23514,6 +23540,7 @@
     },
     "superagent": {
       "version": "3.8.3",
+      "peer": true,
       "requires": {
         "component-emitter": "^1.2.0",
         "cookiejar": "^2.1.0",
@@ -23529,12 +23556,14 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
+          "peer": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "mime": {
-          "version": "1.6.0"
+          "version": "1.6.0",
+          "peer": true
         }
       }
     },
@@ -23571,6 +23600,7 @@
     },
     "supertest": {
       "version": "6.1.6",
+      "peer": true,
       "requires": {
         "methods": "^1.1.2",
         "superagent": "^6.1.0"
@@ -23578,6 +23608,7 @@
       "dependencies": {
         "form-data": {
           "version": "3.0.1",
+          "peer": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -23585,10 +23616,12 @@
           }
         },
         "mime": {
-          "version": "2.6.0"
+          "version": "2.6.0",
+          "peer": true
         },
         "readable-stream": {
           "version": "3.6.0",
+          "peer": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -23597,6 +23630,7 @@
         },
         "superagent": {
           "version": "6.1.0",
+          "peer": true,
           "requires": {
             "component-emitter": "^1.3.0",
             "cookiejar": "^2.1.2",

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -17,9 +17,7 @@
   "dependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "fp-ts": "2.11.8",
-    "io-ts": "2.1.3",
-    "superagent": "3.8.3",
-    "supertest": "6.1.6"
+    "io-ts": "2.1.3"
   },
   "devDependencies": {
     "@types/chai": "4.2.12",
@@ -35,6 +33,10 @@
     "nyc": "15.1.0",
     "ts-node": "10.7.0",
     "typescript": "4.6.4"
+  },
+  "peerDependencies": {
+    "superagent": "3.8.3",
+    "supertest": "6.1.6"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
superagent-wrapper works with these packages, but shouldn't be pulling
them in itself.