### PR TITLE
fix(deps): @types packages are necessary for types inferencing

### DIFF
--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
+    "@types/superagent": "4.1.5",
+    "@types/supertest": "2.0.11",
     "fp-ts": "2.11.8",
     "io-ts": "2.1.3",
     "superagent": "3.8.3",
@@ -25,8 +27,6 @@
     "@types/chai": "4.2.12",
     "@types/express": "4.17.13",
     "@types/mocha": "9.1.1",
-    "@types/superagent": "4.1.5",
-    "@types/supertest": "2.0.11",
     "body-parser": "1.20.0",
     "chai": "4.2.0",
     "express": "4.17.1",


### PR DESCRIPTION
so add @types/superagent and @types/supertest to dependencies so that
downstream users get the expected type-inferencing out of the box