### PR TITLE
chore: remove go from flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,6 @@
 
             packages = with pkgs; [
               nodejs-16_x
-              go
             ];
 
             shellHook = ''


### PR DESCRIPTION
Not sure how this snuck in there, but it is not needed to build anything