### PR TITLE
fix(openapi-generator): do not calculate relative paths from input files

### DIFF
--- a/packages/openapi-generator/src/cli.ts
+++ b/packages/openapi-generator/src/cli.ts
@@ -59,13 +59,10 @@ const app = command({
     }),
   },
   handler: async ({ input, output, tsConfig, name, includeInternal }) => {
-    const baseDir = p.dirname(tsConfig);
-    const relativeInput = p.relative(baseDir, input);
-
     const api = pipe(
       componentsForProject({
         virtualFiles: {},
-        index: relativeInput,
+        index: input,
         tsConfig,
         name,
         includeInternal,


### PR DESCRIPTION
This commit removes the code to calculate a relative path between the
directory containing the tsconfig.json file and the input file. This
permits a copy of @api-ts/openapi-generator installed in one location
to use files from a project in a different location as inputs without
crashing.

Full bug report below.

What I did
----------

```
$ npx openapi-generator \
  --input ../lib/grooble/src/index.ts \
  --output api.json \
  --tsconfig ../lib/grooble/tsconfig.json \
  --name "Grooble"
```

What I Expected to Happen
-------------------------

I expected the openapi-generator to create a file named `api.json`
with the OpenAPI spec described by `../lib/grooble/src/index.ts`.

What Actually Happens
---------------------

```
Error processing project: src/index.ts not in project
```

with a non-zero exit code.

What Actually Happens (with These Changes)
------------------------------------------

The openapi-generator successfully creates a file named `api.json`
with the OpenAPI spec described by `../lib/grooble/src/index.ts`.

However, I'm not sure why this code was added in the  first place!
So please review thorougly to see if this will regresss some use-cases
not captured by the tests.

Ticket: BG-41531