### PR TITLE
Structural superagent dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -944,6 +944,7 @@
     },
     "node_modules/@types/cookiejar": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -989,6 +990,7 @@
     },
     "node_modules/@types/node": {
       "version": "12.20.48",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -1027,6 +1029,7 @@
     },
     "node_modules/@types/superagent": {
       "version": "4.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/cookiejar": "*",
@@ -1035,6 +1038,7 @@
     },
     "node_modules/@types/supertest": {
       "version": "2.0.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/superagent": "*"
@@ -1252,6 +1256,7 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ava": {
@@ -1744,6 +1749,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -2186,6 +2192,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2230,6 +2237,7 @@
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2447,10 +2455,12 @@
     },
     "node_modules/cookiejar": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -2620,6 +2630,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2987,6 +2998,7 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -3010,6 +3022,7 @@
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -3135,6 +3148,7 @@
     },
     "node_modules/form-data": {
       "version": "2.5.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3147,6 +3161,7 @@
     },
     "node_modules/formidable": {
       "version": "1.2.6",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -3218,6 +3233,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/gensync": {
@@ -3246,6 +3262,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -3387,6 +3404,7 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -3404,6 +3422,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3833,6 +3852,7 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -4531,6 +4551,7 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -11264,6 +11285,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.12.0",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11829,6 +11851,7 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/process-on-spawn": {
@@ -11886,6 +11909,7 @@
     },
     "node_modules/qs": {
       "version": "6.10.3",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.4"
@@ -12088,6 +12112,7 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -12101,6 +12126,7 @@
     },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/readdirp": {
@@ -12474,6 +12500,7 @@
     },
     "node_modules/semver": {
       "version": "7.3.7",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -12659,6 +12686,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -13023,6 +13051,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -13030,6 +13059,7 @@
     },
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-argv": {
@@ -13110,6 +13140,7 @@
     },
     "node_modules/superagent": {
       "version": "3.8.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "component-emitter": "^1.2.0",
@@ -13129,6 +13160,7 @@
     },
     "node_modules/superagent/node_modules/debug": {
       "version": "3.2.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -13136,6 +13168,7 @@
     },
     "node_modules/superagent/node_modules/mime": {
       "version": "1.6.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -13191,6 +13224,7 @@
     },
     "node_modules/supertest": {
       "version": "6.1.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "methods": "^1.1.2",
@@ -13202,6 +13236,7 @@
     },
     "node_modules/supertest/node_modules/form-data": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -13214,6 +13249,7 @@
     },
     "node_modules/supertest/node_modules/mime": {
       "version": "2.6.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -13224,6 +13260,7 @@
     },
     "node_modules/supertest/node_modules/readable-stream": {
       "version": "3.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -13236,6 +13273,7 @@
     },
     "node_modules/supertest/node_modules/superagent": {
       "version": "6.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "component-emitter": "^1.3.0",
@@ -13805,6 +13843,7 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -14032,6 +14071,7 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -14263,23 +14303,23 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@api-ts/io-ts-http": "0.0.0-semantically-released",
-        "@types/superagent": "4.1.5",
-        "@types/supertest": "2.0.11",
         "fp-ts": "2.11.8",
-        "io-ts": "2.1.3",
-        "superagent": "3.8.3",
-        "supertest": "6.1.6"
+        "io-ts": "2.1.3"
       },
       "devDependencies": {
         "@types/chai": "4.2.12",
         "@types/express": "4.17.13",
         "@types/mocha": "9.1.1",
+        "@types/superagent": "4.1.5",
+        "@types/supertest": "2.0.11",
         "body-parser": "1.20.0",
         "chai": "4.2.0",
         "express": "4.17.1",
         "io-ts-types": "0.5.16",
         "mocha": "10.0.0",
         "nyc": "15.1.0",
+        "superagent": "3.8.3",
+        "supertest": "6.1.6",
         "ts-node": "10.7.0",
         "typescript": "4.6.4"
       }
@@ -15438,7 +15478,8 @@
       }
     },
     "@types/cookiejar": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true
     },
     "@types/express": {
       "version": "4.17.13",
@@ -15476,7 +15517,8 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.48"
+      "version": "12.20.48",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -15508,6 +15550,7 @@
     },
     "@types/superagent": {
       "version": "4.1.5",
+      "dev": true,
       "requires": {
         "@types/cookiejar": "*",
         "@types/node": "*"
@@ -15515,6 +15558,7 @@
     },
     "@types/supertest": {
       "version": "2.0.11",
+      "dev": true,
       "requires": {
         "@types/superagent": "*"
       }
@@ -15639,7 +15683,8 @@
       "dev": true
     },
     "asynckit": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "dev": true
     },
     "ava": {
       "version": "4.2.0",
@@ -15957,6 +16002,7 @@
     },
     "call-bind": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -16229,6 +16275,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -16257,7 +16304,8 @@
       }
     },
     "component-emitter": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -16414,10 +16462,12 @@
       "version": "1.0.6"
     },
     "cookiejar": {
-      "version": "2.1.3"
+      "version": "2.1.3",
+      "dev": true
     },
     "core-util-is": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -16522,7 +16572,8 @@
       }
     },
     "delayed-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2"
@@ -16766,7 +16817,8 @@
       }
     },
     "extend": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "dev": true
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -16783,7 +16835,8 @@
       }
     },
     "fast-safe-stringify": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "fastq": {
       "version": "1.13.0",
@@ -16866,6 +16919,7 @@
     },
     "form-data": {
       "version": "2.5.1",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -16873,7 +16927,8 @@
       }
     },
     "formidable": {
-      "version": "1.2.6"
+      "version": "1.2.6",
+      "dev": true
     },
     "forwarded": {
       "version": "0.2.0"
@@ -16910,7 +16965,8 @@
       "dev": true
     },
     "function-bind": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -16926,6 +16982,7 @@
     },
     "get-intrinsic": {
       "version": "1.1.1",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -17013,6 +17070,7 @@
     },
     "has": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -17021,7 +17079,8 @@
       "version": "4.0.0"
     },
     "has-symbols": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "dev": true
     },
     "hasha": {
       "version": "5.2.2",
@@ -17261,7 +17320,8 @@
       "dev": true
     },
     "isarray": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -17706,6 +17766,7 @@
     },
     "lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -22359,7 +22420,8 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.0"
+      "version": "1.12.0",
+      "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
@@ -22682,7 +22744,8 @@
       }
     },
     "process-nextick-args": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "process-on-spawn": {
       "version": "1.0.0",
@@ -22720,6 +22783,7 @@
     },
     "qs": {
       "version": "6.10.3",
+      "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -22849,6 +22913,7 @@
     },
     "readable-stream": {
       "version": "2.3.7",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -22860,7 +22925,8 @@
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.1.2"
+          "version": "5.1.2",
+          "dev": true
         }
       }
     },
@@ -23096,6 +23162,7 @@
     },
     "semver": {
       "version": "7.3.7",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -23216,6 +23283,7 @@
     },
     "side-channel": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -23458,12 +23526,14 @@
     },
     "string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.1.2"
+          "version": "5.1.2",
+          "dev": true
         }
       }
     },
@@ -23508,6 +23578,7 @@
     },
     "superagent": {
       "version": "3.8.3",
+      "dev": true,
       "requires": {
         "component-emitter": "^1.2.0",
         "cookiejar": "^2.1.0",
@@ -23523,12 +23594,14 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "mime": {
-          "version": "1.6.0"
+          "version": "1.6.0",
+          "dev": true
         }
       }
     },
@@ -23565,6 +23638,7 @@
     },
     "supertest": {
       "version": "6.1.6",
+      "dev": true,
       "requires": {
         "methods": "^1.1.2",
         "superagent": "^6.1.0"
@@ -23572,6 +23646,7 @@
       "dependencies": {
         "form-data": {
           "version": "3.0.1",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -23579,10 +23654,12 @@
           }
         },
         "mime": {
-          "version": "2.6.0"
+          "version": "2.6.0",
+          "dev": true
         },
         "readable-stream": {
           "version": "3.6.0",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -23591,6 +23668,7 @@
         },
         "superagent": {
           "version": "6.1.0",
+          "dev": true,
           "requires": {
             "component-emitter": "^1.3.0",
             "cookiejar": "^2.1.2",
@@ -23928,7 +24006,8 @@
       "dev": true
     },
     "util-deprecate": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1"
@@ -24076,7 +24155,8 @@
       "dev": true
     },
     "yallist": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2",

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -18,14 +18,12 @@
   },
   "dependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
-    "@types/superagent": "4.1.5",
-    "@types/supertest": "2.0.11",
     "fp-ts": "2.11.8",
-    "io-ts": "2.1.3",
-    "superagent": "3.8.3",
-    "supertest": "6.1.6"
+    "io-ts": "2.1.3"
   },
   "devDependencies": {
+    "@types/superagent": "4.1.5",
+    "@types/supertest": "2.0.11",
     "@types/chai": "4.2.12",
     "@types/express": "4.17.13",
     "@types/mocha": "9.1.1",
@@ -35,6 +33,8 @@
     "io-ts-types": "0.5.16",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
+    "superagent": "3.8.3",
+    "supertest": "6.1.6",
     "ts-node": "10.7.0",
     "typescript": "4.6.4"
   },


### PR DESCRIPTION
`@api-ts/superagent-wrapper` only actually uses a small subset of superagent's functionality. This PR adds the necessary type declarations so that it can be compatible with the widest possible range of superagent versions.