### PR TITLE
chore(dependabot): change target branch to beta

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,4 @@ updates:
       - '@BitGo/internal-tools'
     labels:
       - dependencies
+    target-branch: beta


### PR DESCRIPTION
As described in this link[^1]. We should revert this diff when we're
ready to merge `beta` into `master`.

[^1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch