### PR TITLE
ci(setup-node): use lts/-n aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['12', '14', 'lts/*']
+        node-version: [lts/-2, lts/-1, lts/*]
 
     name: Node.js ${{ matrix.node-version }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: npm
-          node-version: 'lts/*'
+          node-version: lts/*
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Use a feature[^1] rolled out in setup-node v3.3.0 to test against
the last 3 LTS versions of Node.js, whatever numeric versions those
happen to be.

This will make it possible to define (once) required status checks
that expect all tests to pass for all current-LTS versions of Node.js.

[^1]: https://github.com/actions/setup-node/releases/tag/v3.3.0