### PR TITLE
chore(dependabot): ignore io-ts v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,6 @@ updates:
       - dependencies
       - npm
     target-branch: beta
+    ignore:
+      - dependency-name: io-ts
+        versions: ['2.x']


### PR DESCRIPTION
io-ts has deviated from semantic versioning, and introduced breaking
changes after 2.1.3. In this sense, 2.1.3 is considered stable and
all higher 2.x versions are considered experimental.

This commit disables dependabot updates to io-ts for all 2.x versions
as upgrading off of 2.1.3 will be a breaking change for most users.

We should instead look to upgrade with a conscious breaking change
if/when io-ts v3 stabilizes.