### PR TITLE
feat: force simplification of intersection types in io-ts-http

### DIFF
--- a/packages/io-ts-http/src/combinators.ts
+++ b/packages/io-ts-http/src/combinators.ts
@@ -10,6 +10,7 @@ import {
   OptionalizedC,
   OptionalProps,
   RequiredProps,
+  Simplify,
 } from './utils';
 
 export const optional = <C extends t.Mixed>(subCodec: C) =>
@@ -39,7 +40,10 @@ export const optionalized = <P extends t.Props>(props: P): OptionalizedC<P> => {
 export const flattened = <Props extends NestedProps>(
   name: string,
   props: Props,
-): t.Type<Flattened<NestedType<Props>>, NestedOutputType<Props>> => {
+): t.Type<
+  Simplify<Flattened<NestedType<Props>>>,
+  Simplify<NestedOutputType<Props>>
+> => {
   let flatProps: t.Props = {};
   for (const key in props) {
     if (!props.hasOwnProperty(key)) {
@@ -69,7 +73,7 @@ export const flattened = <Props extends NestedProps>(
             }
             flattened = { ...flattened, ...nested[key] };
           }
-          return flattened as Flattened<NestedType<Props>>;
+          return flattened as Simplify<Flattened<NestedType<Props>>>;
         }),
       ),
     (input: any) => {
@@ -86,7 +90,7 @@ export const flattened = <Props extends NestedProps>(
           }
         }
       }
-      return nested as NestedOutputType<Props>;
+      return nested as Simplify<NestedOutputType<Props>>;
     },
   );
 };

--- a/packages/io-ts-http/src/utils.ts
+++ b/packages/io-ts-http/src/utils.ts
@@ -8,8 +8,9 @@ export type PossiblyUndefinedProps<T extends t.Props> = {
   [K in keyof T]: undefined extends t.TypeOf<T[K]> ? K : never;
 }[keyof T];
 
-type Optionalized<T> = Omit<T, PossiblyUndefinedKeys<T>> &
-  Partial<Pick<T, PossiblyUndefinedKeys<T>>>;
+type Optionalized<T> = Simplify<
+  Omit<T, PossiblyUndefinedKeys<T>> & Partial<Pick<T, PossiblyUndefinedKeys<T>>>
+>;
 
 export type OptionalProps<Props extends t.Props> = Pick<
   Props,
@@ -48,3 +49,5 @@ type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (
 ) => any
   ? R
   : never;
+
+export type Simplify<T> = T extends unknown ? { [K in keyof T]: T[K] } : never;


### PR DESCRIPTION
Adds a utility type that forces the TS language server to simplify
intersection types (at least as of 4.7.4). This greatly improves
readability of the codec types produced by io-ts-http

Before:
![image](https://user-images.githubusercontent.com/88669932/179776155-5312535a-8e80-4684-ae58-a64e1fef78a2.png)


After:
![image](https://user-images.githubusercontent.com/88669932/179776063-d2a88ea4-ac59-46ce-8858-a6eb80daa1d0.png)
