### PR TITLE
feat: produce helpful error messages on httpRequest codec errors

### DIFF
--- a/packages/io-ts-http/src/utils.ts
+++ b/packages/io-ts-http/src/utils.ts
@@ -26,10 +26,6 @@ export type OptionalizedC<Props extends t.Props> = t.IntersectionC<
   [t.TypeC<RequiredProps<Props>>, t.PartialC<OptionalProps<Props>>]
 >;
 
-export type OutputConstrainedProps<O> = {
-  [K: string]: t.Type<any, O, unknown>;
-};
-
 export type NestedProps = {
   [K: string]: t.Props;
 };


### PR DESCRIPTION
Attempts to produce a helpful error message when invalid codecs are passed to `httpRequest`.
It is a workaround inspired by [this comment](https://github.com/microsoft/TypeScript/pull/40468#issuecomment-1162386217)

Before:
![image](https://user-images.githubusercontent.com/88669932/179791538-18c21604-22c3-47df-827d-2bf28a4e96af.png)

After:
![image](https://user-images.githubusercontent.com/88669932/179791990-741f73dd-adb6-48e0-acba-0eafb1c734a0.png)

In this case the "before" error isn't too bad, but this technique could be useful in other places.
