### PR TITLE
feat(express-wrapper): allow middleware to add request properties

### DIFF
--- a/packages/express-wrapper/src/index.ts
+++ b/packages/express-wrapper/src/index.ts
@@ -8,15 +8,12 @@ import express from 'express';
 import { ApiSpec, HttpRoute } from '@api-ts/io-ts-http';
 
 import { apiTsPathToExpress } from './path';
-import {
-  decodeRequestAndEncodeResponse,
-  getMiddleware,
-  getServiceFunction,
-  RouteHandler,
-} from './request';
+import { decodeRequestAndEncodeResponse, RouteHandler } from './request';
 import { defaultResponseEncoder, ResponseEncoder } from './response';
 
+export { middlewareFn } from './middleware';
 export type { ResponseEncoder, NumericOrKeyedResponseType } from './response';
+export { routeHandler } from './request';
 
 const isHttpVerb = (verb: string): verb is 'get' | 'put' | 'post' | 'delete' =>
   verb === 'get' || verb === 'put' || verb === 'post' || verb === 'delete';
@@ -50,13 +47,12 @@ export function routerForApiSpec<Spec extends ApiSpec>({
         httpRoute,
         // FIXME: TS is complaining that `routeHandler` is not necessarily guaranteed to be a
         // `ServiceFunction`, because subtypes of Spec[string][string] can have arbitrary extra keys.
-        getServiceFunction(routeHandler as any),
+        routeHandler as RouteHandler<any>,
         encoder,
       );
-      const handlers = [...getMiddleware(routeHandler), expressRouteHandler];
 
       const expressPath = apiTsPathToExpress(httpRoute.path);
-      router[method](expressPath, handlers);
+      router[method](expressPath, expressRouteHandler);
     }
   }
 

--- a/packages/express-wrapper/src/middleware.ts
+++ b/packages/express-wrapper/src/middleware.ts
@@ -1,0 +1,206 @@
+import * as express from 'express';
+
+export const MiddlewareBrand = Symbol();
+export type MiddlewareBrand = typeof MiddlewareBrand;
+
+export type MiddlewareFn<T extends {}> = (
+  req: express.Request,
+  res: express.Response,
+) => Promise<T>;
+
+type MiddlewareHandler<T extends {} = {}> = {
+  (req: express.Request, res: express.Response, next: express.NextFunction): void;
+  [MiddlewareBrand]: T;
+};
+
+export type MiddlewareRequestHandler = express.RequestHandler | MiddlewareHandler;
+
+type MiddlewareOutput<T extends MiddlewareRequestHandler> = T extends {
+  [MiddlewareBrand]: infer R;
+}
+  ? R
+  : {};
+
+type MiddlewareNextFn = (error?: unknown, middlewareResult?: {}) => void;
+
+/**
+ * Creates an express request handler that also adds properties to the incoming decoded request. Any existing properties
+ * with conflicting names will be replaced.
+ *
+ * @param fn - an async function that reads the express req/res and returns the desired additional properties.
+ * @returns
+ */
+export function middlewareFn<T extends {}>(fn: MiddlewareFn<T>): MiddlewareHandler<T> {
+  const result: express.RequestHandler = (req, res, next: MiddlewareNextFn) => {
+    fn(req, res)
+      .then((result) => next(undefined, result))
+      .catch((err) => next(err));
+  };
+  return result as MiddlewareHandler<T>;
+}
+
+type MiddlewareResult<Input extends {}, T> = T extends MiddlewareRequestHandler
+  ? Omit<Input, keyof MiddlewareOutput<T>> & MiddlewareOutput<T>
+  : never;
+
+export type MiddlewareChain =
+  | []
+  | [MiddlewareRequestHandler]
+  | [MiddlewareRequestHandler, MiddlewareRequestHandler]
+  | [MiddlewareRequestHandler, MiddlewareRequestHandler, MiddlewareRequestHandler]
+  | [
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+    ]
+  | [
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+    ]
+  | [
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+    ]
+  | [
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+      MiddlewareRequestHandler,
+    ];
+
+export type MiddlewareChainOutput<
+  Input,
+  Chain extends MiddlewareChain,
+> = Chain extends []
+  ? Input
+  : Chain extends [infer A]
+  ? MiddlewareResult<Input, A>
+  : Chain extends [infer A, infer B]
+  ? MiddlewareResult<MiddlewareResult<Input, A>, B>
+  : Chain extends [infer A, infer B, infer C]
+  ? MiddlewareResult<MiddlewareResult<MiddlewareResult<Input, A>, B>, C>
+  : Chain extends [infer A, infer B, infer C, infer D]
+  ? MiddlewareResult<
+      MiddlewareResult<MiddlewareResult<MiddlewareResult<Input, A>, B>, C>,
+      D
+    >
+  : Chain extends [infer A, infer B, infer C, infer D, infer E]
+  ? MiddlewareResult<
+      MiddlewareResult<
+        MiddlewareResult<MiddlewareResult<MiddlewareResult<Input, A>, B>, C>,
+        D
+      >,
+      E
+    >
+  : Chain extends [infer A, infer B, infer C, infer D, infer E, infer F]
+  ? MiddlewareResult<
+      MiddlewareResult<
+        MiddlewareResult<
+          MiddlewareResult<MiddlewareResult<MiddlewareResult<Input, A>, B>, C>,
+          D
+        >,
+        E
+      >,
+      F
+    >
+  : Chain extends [infer A, infer B, infer C, infer D, infer E, infer F, infer G]
+  ? MiddlewareResult<
+      MiddlewareResult<
+        MiddlewareResult<
+          MiddlewareResult<
+            MiddlewareResult<MiddlewareResult<MiddlewareResult<Input, A>, B>, C>,
+            D
+          >,
+          E
+        >,
+        F
+      >,
+      G
+    >
+  : never;
+
+/**
+ * Runs a middleware chain, and adds any properties returned by middleware..
+ *
+ * @param input - the decoded request properties
+ * @param chain - the middleware chain
+ * @param req - express request object
+ * @param res - express response object
+ * @returns `input` with possible additional properties as specified by the middleware chain
+ */
+export async function runMiddlewareChain<
+  Input extends {},
+  Chain extends MiddlewareChain,
+>(
+  input: Input,
+  chain: Chain,
+  req: express.Request,
+  res: express.Response,
+): Promise<MiddlewareChainOutput<Input, Chain>> {
+  let result: {} = input;
+  for (const middleware of chain) {
+    const middlewareResult: {} = await new Promise((resolve, reject) => {
+      const next = (value?: unknown, middlewareResult?: {}) => {
+        if (value !== undefined) {
+          reject(value);
+        } else if (middlewareResult !== undefined) {
+          resolve(middlewareResult);
+        } else {
+          resolve({});
+        }
+      };
+
+      try {
+        middleware(req, res, next);
+      } catch (err) {
+        reject(err);
+      }
+    });
+
+    result = { ...result, ...middlewareResult };
+  }
+
+  return result as MiddlewareChainOutput<Input, Chain>;
+}
+
+/**
+ * Runs a middleware chain, but does not modify the decoded request (input) with properties from any middleware.
+ * This primarily exists to preserve backwards-compatible behavior for RouteHandlers defined without the `routeHandler` function.
+ *
+ * @param input - the decoded request properties (just passed through)
+ * @param chain - the middleware chain
+ * @param req - express request object
+ * @param res - express response object
+ * @returns `input` unmodified
+ */
+export async function runMiddlewareChainIgnoringResults<
+  Input,
+  Chain extends MiddlewareChain,
+>(
+  input: Input,
+  chain: Chain,
+  req: express.Request,
+  res: express.Response,
+): Promise<Input> {
+  for (const middleware of chain) {
+    await new Promise((resolve, reject) => {
+      try {
+        middleware(req, res, resolve);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+  return input;
+}

--- a/packages/express-wrapper/src/request.ts
+++ b/packages/express-wrapper/src/request.ts
@@ -4,19 +4,70 @@
  */
 
 import express from 'express';
+import * as E from 'fp-ts/Either';
 import * as PathReporter from 'io-ts/lib/PathReporter';
 
 import { HttpRoute, RequestType } from '@api-ts/io-ts-http';
 
+import {
+  runMiddlewareChain,
+  runMiddlewareChainIgnoringResults,
+  MiddlewareBrand,
+  MiddlewareChain,
+  MiddlewareChainOutput,
+} from './middleware';
 import type { NumericOrKeyedResponseType, ResponseEncoder } from './response';
 
-export type ServiceFunction<R extends HttpRoute> = (
-  input: RequestType<R>,
+export type ServiceFunction<R extends HttpRoute, Input = RequestType<R>> = (
+  input: Input,
 ) => NumericOrKeyedResponseType<R> | Promise<NumericOrKeyedResponseType<R>>;
 
+// The first two alternatives are here to maintain backwards compatibility
 export type RouteHandler<R extends HttpRoute> =
   | ServiceFunction<R>
-  | { middleware: express.RequestHandler[]; handler: ServiceFunction<R> };
+  | {
+      middleware: MiddlewareChain;
+      handler: ServiceFunction<
+        R,
+        MiddlewareChainOutput<RequestType<R>, MiddlewareChain>
+      >;
+    }
+  | {
+      middleware: MiddlewareChain;
+      handler: ServiceFunction<R>;
+      // Marks this handler as being created via the `routeHandler` function, which enforces the types between
+      // the middleware chain and the route handler that is accepts the additional properties
+      [MiddlewareBrand]: true;
+    };
+
+/**
+ * Produce a route handler that can use additional properties provided by middleware
+ *
+ * @param middleware a list of express request handlers. Ones created via `middlewareFn` will add additional properties to the decoded request
+ * @returns a route handler for an api spec
+ */
+export function routeHandler<R extends HttpRoute>({
+  handler,
+}: {
+  handler: ServiceFunction<R>;
+}): RouteHandler<R>;
+
+export function routeHandler<R extends HttpRoute, Chain extends MiddlewareChain>({
+  middleware,
+  handler,
+}: {
+  middleware: Chain;
+  handler: ServiceFunction<R, MiddlewareChainOutput<RequestType<R>, Chain>>;
+}): RouteHandler<R>;
+
+export function routeHandler<R extends HttpRoute>({
+  middleware,
+  handler,
+}: any): RouteHandler<R> {
+  // This function wouldn't be needed if TS had value/object level existential quantification, but since it doesn't we enforce the relationship
+  // between the middleware chain and the handler's input params with this function and then assert the result.
+  return { middleware, handler, [MiddlewareBrand]: true } as RouteHandler<R>;
+}
 
 export const getServiceFunction = <R extends HttpRoute>(
   routeHandler: RouteHandler<R>,
@@ -25,8 +76,7 @@ export const getServiceFunction = <R extends HttpRoute>(
 
 export const getMiddleware = <R extends HttpRoute>(
   routeHandler: RouteHandler<R>,
-): express.RequestHandler[] =>
-  'middleware' in routeHandler ? routeHandler.middleware : [];
+): MiddlewareChain => ('middleware' in routeHandler ? routeHandler.middleware : []);
 
 /**
  * Dynamically assign a function name to avoid anonymous functions in stack traces
@@ -40,15 +90,14 @@ const createNamedFunction = <F extends (...args: any) => void>(
 export const decodeRequestAndEncodeResponse = (
   apiName: string,
   httpRoute: HttpRoute,
-  handler: ServiceFunction<HttpRoute>,
+  handler: RouteHandler<HttpRoute>,
   responseEncoder: ResponseEncoder,
 ): express.RequestHandler => {
   return createNamedFunction(
     'decodeRequestAndEncodeResponse' + httpRoute.method + apiName,
     async (req, res, next) => {
       const maybeRequest = httpRoute.request.decode(req);
-      if (maybeRequest._tag === 'Left') {
-        console.log('Request failed to decode');
+      if (E.isLeft(maybeRequest)) {
         const validationErrors = PathReporter.failure(maybeRequest.left);
         const validationErrorMessage = validationErrors.join('\n');
         res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -59,7 +108,25 @@ export const decodeRequestAndEncodeResponse = (
 
       let rawResponse: NumericOrKeyedResponseType<HttpRoute> | undefined;
       try {
-        rawResponse = await handler(maybeRequest.right);
+        const handlerParams =
+          MiddlewareBrand in handler
+            ? await runMiddlewareChain(
+                maybeRequest.right,
+                getMiddleware(handler),
+                req,
+                res,
+              )
+            : await runMiddlewareChainIgnoringResults(
+                E.getOrElseW(() => {
+                  throw Error('Request failed to decode');
+                })(maybeRequest),
+                getMiddleware(handler),
+                req,
+                res,
+              );
+        const serviceFn = getServiceFunction(handler);
+
+        rawResponse = await serviceFn(handlerParams);
       } catch (err) {
         console.warn('Error in route handler:', err);
         res.status(500).end();

--- a/packages/express-wrapper/test/middleware.test.ts
+++ b/packages/express-wrapper/test/middleware.test.ts
@@ -1,0 +1,96 @@
+import test from 'ava';
+import express from 'express';
+
+import { middlewareFn, runMiddlewareChain } from '../src/middleware';
+
+// None of these test functions actually use the `req` or `res`, so they can be unsafely stubbed like this
+const REQ = {} as express.Request;
+const RES = {} as express.Response;
+
+const noopMiddleware: express.RequestHandler = (_req, _res, next) => {
+  next();
+};
+
+const errorMiddleware: express.RequestHandler = (_req, _res, next) => {
+  next(new Error('aaaah'));
+};
+
+const altErrorMiddleware: express.RequestHandler = (_req, _res, next) => {
+  next(new Error('noooo'));
+};
+
+const addParamMiddleware = middlewareFn(async () => ({
+  addedValue: 1337,
+}));
+
+const addAltParamMiddleware = middlewareFn(async () => ({
+  addedValue: 'hello',
+}));
+
+test('should work with normal express middleware', async (t) => {
+  const result = await runMiddlewareChain({ foo: 'test' }, [noopMiddleware], REQ, RES);
+  t.deepEqual(result, { foo: 'test' });
+});
+
+test('should handle errors passed to next()', async (t) => {
+  await t.throwsAsync(
+    runMiddlewareChain({ foo: 'test' }, [errorMiddleware], null as any, null as any),
+  );
+});
+
+test('should work with middleware that return values', async (t) => {
+  const result = await runMiddlewareChain(
+    { foo: 'test' },
+    [addParamMiddleware],
+    REQ,
+    RES,
+  );
+  t.deepEqual(result, { foo: 'test', addedValue: 1337 });
+});
+
+test('express and value-producing middleware should work together in any order', async (t) => {
+  const result = await runMiddlewareChain(
+    { foo: 'test' },
+    [noopMiddleware, addParamMiddleware],
+    REQ,
+    RES,
+  );
+  t.deepEqual(result, { foo: 'test', addedValue: 1337 });
+
+  const resultB = await runMiddlewareChain(
+    { foo: 'test' },
+    [addParamMiddleware, noopMiddleware],
+    REQ,
+    RES,
+  );
+  t.deepEqual(resultB, { foo: 'test', addedValue: 1337 });
+});
+
+test('middlewares that set the same value should use the last one in the chain', async (t) => {
+  const result = await runMiddlewareChain(
+    { foo: 'test' },
+    [addParamMiddleware, addAltParamMiddleware],
+    REQ,
+    RES,
+  );
+  t.deepEqual(result, { foo: 'test', addedValue: 'hello' });
+
+  const resultB = await runMiddlewareChain(
+    { foo: 'test' },
+    [addAltParamMiddleware, addParamMiddleware],
+    REQ,
+    RES,
+  );
+  t.deepEqual(resultB, { foo: 'test', addedValue: 1337 });
+});
+
+test('error-producing middleware should not run subsequent middleware', async (t) => {
+  await t.throwsAsync(
+    runMiddlewareChain(
+      { foo: 'test' },
+      [errorMiddleware, altErrorMiddleware],
+      null as any,
+      null as any,
+    ),
+  );
+});


### PR DESCRIPTION
This adds the capability for middleware to define additional properties that get added on to the decoded request object. This is done with the addition of a new exported helper function named `middlewareFn`. It accepts a function with the signature:

```
(req: express.Request, res: express.Response) => Promise<Output>
```

Notice that it is `async` rather than using Express's `next` convention. Properties of `Output` are merged in with the decoded request.

This change should be backwards compatible with existing use of `express-wrapper`. Middleware functions just go in the pipeline alongside normal express middleware. However, it introduces a middleware array length constraint of 8. This is just how much I wanted to write out for now, it can be expanded or we can try to figure out recursive tuple expansion in TS if it needs to be longer.

Hopefully resolves #134 

TODO:
- [x] Tests
- [x] Document `middlewareFn`