### PR TITLE
fix: attempt to handle response types more cleanly

### DIFF
--- a/packages/express-wrapper/src/index.ts
+++ b/packages/express-wrapper/src/index.ts
@@ -11,9 +11,9 @@ import { apiTsPathToExpress } from './path';
 import { decodeRequestAndEncodeResponse, RouteHandler } from './request';
 import { defaultResponseEncoder, ResponseEncoder } from './response';
 
-export { middlewareFn } from './middleware';
-export type { ResponseEncoder, NumericOrKeyedResponseType } from './response';
-export { routeHandler } from './request';
+export { middlewareFn, MiddlewareChain, MiddlewareChainOutput } from './middleware';
+export type { ResponseEncoder, KeyedResponseType } from './response';
+export { routeHandler, ServiceFunction } from './request';
 
 const isHttpVerb = (verb: string): verb is 'get' | 'put' | 'post' | 'delete' =>
   verb === 'get' || verb === 'put' || verb === 'post' || verb === 'delete';

--- a/packages/express-wrapper/src/request.ts
+++ b/packages/express-wrapper/src/request.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import * as E from 'fp-ts/Either';
 import * as PathReporter from 'io-ts/lib/PathReporter';
 
-import { HttpRoute, RequestType } from '@api-ts/io-ts-http';
+import { HttpRoute, RequestType, ResponseType } from '@api-ts/io-ts-http';
 
 import {
   runMiddlewareChain,
@@ -16,11 +16,11 @@ import {
   MiddlewareChain,
   MiddlewareChainOutput,
 } from './middleware';
-import type { NumericOrKeyedResponseType, ResponseEncoder } from './response';
+import type { KeyedResponseType, ResponseEncoder } from './response';
 
-export type ServiceFunction<R extends HttpRoute, Input = RequestType<R>> = (
-  input: Input,
-) => NumericOrKeyedResponseType<R> | Promise<NumericOrKeyedResponseType<R>>;
+export type ServiceFunction<R extends HttpRoute, Input = RequestType<R>> =
+  | ((input: Input) => ResponseType<R> | Promise<ResponseType<R>>)
+  | ((input: Input) => KeyedResponseType<R> | Promise<KeyedResponseType<R>>);
 
 // The first two alternatives are here to maintain backwards compatibility
 export type RouteHandler<R extends HttpRoute> =
@@ -109,7 +109,10 @@ export const decodeRequestAndEncodeResponse = (
         return;
       }
 
-      let rawResponse: NumericOrKeyedResponseType<HttpRoute> | undefined;
+      let rawResponse:
+        | ResponseType<HttpRoute>
+        | KeyedResponseType<HttpRoute>
+        | undefined;
       try {
         const handlerParams =
           MiddlewareBrand in handler

--- a/packages/express-wrapper/src/response.ts
+++ b/packages/express-wrapper/src/response.ts
@@ -8,20 +8,18 @@ import {
   ResponseType,
 } from '@api-ts/io-ts-http';
 
-export type NumericOrKeyedResponseType<R extends HttpRoute> =
-  | ResponseType<R>
-  | {
-      [Key in keyof R['response'] & keyof HttpToKeyStatus]: {
-        type: HttpToKeyStatus[Key];
-        payload: t.TypeOf<R['response'][Key]>;
-      };
-    }[keyof R['response'] & keyof HttpToKeyStatus];
+export type KeyedResponseType<R extends HttpRoute> = {
+  [Key in keyof R['response'] & keyof HttpToKeyStatus]: {
+    type: HttpToKeyStatus[Key];
+    payload: t.TypeOf<R['response'][Key]>;
+  };
+}[keyof R['response'] & keyof HttpToKeyStatus];
 
 // TODO: Use HKT (using fp-ts or a similar workaround method, or who knows maybe they'll add
 // official support) to allow for polymorphic ResponseType<_>.
 export type ResponseEncoder = (
   route: HttpRoute,
-  serviceFnResponse: NumericOrKeyedResponseType<HttpRoute>,
+  serviceFnResponse: ResponseType<HttpRoute>,
 ) => express.RequestHandler;
 
 export const defaultResponseEncoder: ResponseEncoder =

--- a/packages/io-ts-http/src/httpResponse.ts
+++ b/packages/io-ts-http/src/httpResponse.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 
 export type HttpResponse = {
-  [K: number]: t.Mixed;
+  [K: number | string]: t.Mixed;
 };
 
 export type ResponseTypeForStatus<


### PR DESCRIPTION
Redefines a "service function" so that the return type is either all
numeric or all keyed. This is a bit of a guess, but the hope is that it
resolves some of the weird typechecking issues we are seeing around
response types.