### PR TITLE
fix: use methods from io-ts-http

### DIFF
--- a/packages/typed-express-router/src/types.ts
+++ b/packages/typed-express-router/src/types.ts
@@ -1,8 +1,13 @@
-import { ApiSpec, HttpRoute, RequestType } from '@api-ts/io-ts-http';
+import {
+  ApiSpec,
+  HttpRoute,
+  Method as HttpMethod,
+  RequestType,
+} from '@api-ts/io-ts-http';
 import express from 'express';
 import * as t from 'io-ts';
 
-export type Methods = 'get' | 'post' | 'put' | 'delete';
+export type Methods = Lowercase<HttpMethod>;
 
 export type RouteAt<
   Spec extends ApiSpec,


### PR DESCRIPTION
multi-semantic-release skipped publishing `typed-express-router` because there were no changes between the tag and merge commit. This is a small change that should cause a release.