### PR TITLE
fix: use `unknown` in `sendEncoded`

### DIFF
--- a/packages/typed-express-router/src/index.ts
+++ b/packages/typed-express-router/src/index.ts
@@ -81,7 +81,7 @@ export function wrapRouter<Spec extends ApiSpec>(
               (req as any).decoded = decoded;
               (res as any).sendEncoded = (
                 status: keyof typeof route['response'],
-                payload: any,
+                payload: unknown,
               ) => {
                 try {
                   const codec = route.response[status];


### PR DESCRIPTION
Small change to bump the patch version of `typed-express-router`