### PR TITLE
fix: check for compiler errors before emitting an openapi spec

### DIFF
--- a/packages/openapi-generator/corpus/test-single-route.ts
+++ b/packages/openapi-generator/corpus/test-single-route.ts
@@ -2,7 +2,6 @@
 
 /// file: other.ts
 
-import * as t from 'io-ts';
 import { NumberFromString } from 'io-ts-types';
 
 /**

--- a/packages/openapi-generator/dummyProject/empty.ts
+++ b/packages/openapi-generator/dummyProject/empty.ts
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// It silences a compiler warning about no files included when there are only virtual ones

--- a/packages/openapi-generator/dummyProject/tsconfig.json
+++ b/packages/openapi-generator/dummyProject/tsconfig.json
@@ -17,7 +17,8 @@
     "skipLibCheck": false,
     "sourceMap": true,
     "strict": true,
-    "target": "es2021"
+    "target": "es2021",
+    "rootDir": "."
   },
-  "include": ["./index.ts"]
+  "include": ["."]
 }

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf -- dist",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "test": "c8 --all --src src ava test/test-corpus.ts"
+    "test": "c8 --all --src src ava test/corpusFiles/*.ts"
   },
   "dependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -47,7 +47,7 @@
         "test/": "dist/test/"
       }
     },
-    "timeout": "1m"
+    "timeout": "2m"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/openapi-generator/test/corpusFiles/check-one-to-one-file-match.ts
+++ b/packages/openapi-generator/test/corpusFiles/check-one-to-one-file-match.ts
@@ -1,0 +1,26 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import test from 'ava';
+
+const basenameNoExtension = (file: string) => path.basename(file).split('.')[0];
+
+test('every file in the corpus has a corresponding test file', async (t) => {
+  const testDefinitionFiles = await fs.readdirSync(
+    path.resolve(__dirname, '..', '..', '..', 'corpus'),
+  );
+  const definitionSet = new Set(testDefinitionFiles.map(basenameNoExtension));
+
+  const testRunnerFiles = await fs.readdirSync(path.resolve(__dirname));
+  const runnerSet = new Set(
+    testRunnerFiles
+      .map(basenameNoExtension)
+      .filter((file) => file !== basenameNoExtension(__filename)),
+  );
+
+  t.deepEqual(
+    runnerSet,
+    definitionSet,
+    'Corpus definition files should match test runner files 1:1',
+  );
+});

--- a/packages/openapi-generator/test/corpusFiles/test-array-property.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-array-property.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-array-property');

--- a/packages/openapi-generator/test/corpusFiles/test-boolean-literal.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-boolean-literal.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-boolean-literal');

--- a/packages/openapi-generator/test/corpusFiles/test-discriminated-union.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-discriminated-union.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-discriminated-union');

--- a/packages/openapi-generator/test/corpusFiles/test-intersection-flattening.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-intersection-flattening.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-intersection-flattening');

--- a/packages/openapi-generator/test/corpusFiles/test-multi-route.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-multi-route.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-multi-route');

--- a/packages/openapi-generator/test/corpusFiles/test-multi-union.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-multi-union.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-multi-union');

--- a/packages/openapi-generator/test/corpusFiles/test-null-param.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-null-param.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-null-param');

--- a/packages/openapi-generator/test/corpusFiles/test-optional-property.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-optional-property.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-optional-property');

--- a/packages/openapi-generator/test/corpusFiles/test-record-type.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-record-type.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-record-type');

--- a/packages/openapi-generator/test/corpusFiles/test-single-route-multi-method.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-single-route-multi-method.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-single-route-multi-method');

--- a/packages/openapi-generator/test/corpusFiles/test-single-route.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-single-route.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-single-route');

--- a/packages/openapi-generator/test/corpusFiles/test-string-union.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-string-union.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-string-union');

--- a/packages/openapi-generator/test/corpusFiles/test-unknown-property.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-unknown-property.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-unknown-property');

--- a/packages/openapi-generator/test/corpusFiles/test-version-tag.ts
+++ b/packages/openapi-generator/test/corpusFiles/test-version-tag.ts
@@ -1,0 +1,4 @@
+// TODO: Find way to not need these files for parallelization
+import { testCorpusFile } from '../test-corpus';
+
+testCorpusFile('test-version-tag');

--- a/packages/openapi-generator/test/test-corpus.ts
+++ b/packages/openapi-generator/test/test-corpus.ts
@@ -11,7 +11,8 @@ import { TestCase, TestCasesFromString } from './test-case';
 // System under test
 import { componentsForProject } from '../src/project';
 
-const TEST_CONFIG = path.join(__dirname, '..', '..', 'dummyProject', 'tsconfig.json');
+const ROOT_DIR = path.resolve(__dirname, '..', '..', 'dummyProject');
+const TEST_CONFIG = path.join(ROOT_DIR, 'tsconfig.json');
 
 const ENTRYPOINT = 'index.ts' as NonEmptyString;
 
@@ -20,7 +21,8 @@ const evaluateTestCase = test.macro({
     const fileContentsByFilename = testCase.inputs.reduce<
       Record<NonEmptyString, NonEmptyString>
     >(
-      (acc, { filename, contents }) => Object.assign(acc, { [filename]: contents }),
+      (acc, { filename, contents }) =>
+        Object.assign(acc, { [path.join(ROOT_DIR, filename)]: contents }),
       {},
     );
 

--- a/packages/openapi-generator/test/test-corpus.ts
+++ b/packages/openapi-generator/test/test-corpus.ts
@@ -11,6 +11,7 @@ import { TestCase, TestCasesFromString } from './test-case';
 // System under test
 import { componentsForProject } from '../src/project';
 
+const TEST_CORPUS_DIR = path.resolve(__dirname, '..', '..', 'corpus');
 const ROOT_DIR = path.resolve(__dirname, '..', '..', 'dummyProject');
 const TEST_CONFIG = path.join(ROOT_DIR, 'tsconfig.json');
 
@@ -18,6 +19,9 @@ const ENTRYPOINT = 'index.ts' as NonEmptyString;
 
 const evaluateTestCase = test.macro({
   async exec(t, testCase: TestCase) {
+    // Wait for the event loop to tick once
+    await new Promise((resolve) => setImmediate(resolve));
+
     const fileContentsByFilename = testCase.inputs.reduce<
       Record<NonEmptyString, NonEmptyString>
     >(
@@ -62,16 +66,7 @@ const evaluateTestCases = (filename: string) => {
   }
 };
 
-const main = () => {
-  // ava runs with cwd in the package root
-  const corpusDirectory = 'corpus';
-  const corpusFilenames = fs
-    .readdirSync(corpusDirectory)
-    .map((filename) => path.join(corpusDirectory, filename));
-
-  for (const filename of corpusFilenames) {
-    evaluateTestCases(filename);
-  }
+export const testCorpusFile = (name: string) => {
+  const filename = path.join(TEST_CORPUS_DIR, `${name}.ts`);
+  evaluateTestCases(filename);
 };
-
-main();


### PR DESCRIPTION
Queries the typescript compiler for any errors before proceeding with
openapi generation. This catches issues such as `node_modules` not being
present, as it'll result in errors like "cannot resolve `io-ts`". It
also should preemptively catch other problems that we haven't
anticipated yet. There is a noticeable performance hit from this, but I
feel it is worth the trade-off for correctness.