### PR TITLE
fix: elide empty descriptions when allowed by the spec

### DIFF
--- a/packages/openapi-generator/corpus/test-array-property.ts
+++ b/packages/openapi-generator/corpus/test-array-property.ts
@@ -33,7 +33,6 @@ export const Routes = h.apiSpec({
     "/test": {
       "get": {
         "summary": "MyRoute",
-        "description": "",
         "parameters": [],
         "responses": {
           "200": {

--- a/packages/openapi-generator/corpus/test-boolean-literal.ts
+++ b/packages/openapi-generator/corpus/test-boolean-literal.ts
@@ -33,7 +33,6 @@ export const Routes = h.apiSpec({
     "/test": {
       "get": {
         "summary": "MyRoute",
-        "description": "",
         "parameters": [],
         "responses": {
           "200": {

--- a/packages/openapi-generator/corpus/test-discriminated-union.ts
+++ b/packages/openapi-generator/corpus/test-discriminated-union.ts
@@ -36,7 +36,6 @@ export const Routes = h.apiSpec({
     "/test": {
       "get": {
         "summary": "MyRoute",
-        "description": "",
         "parameters": [],
         "responses": {
           "200": {

--- a/packages/openapi-generator/corpus/test-intersection-flattening.ts
+++ b/packages/openapi-generator/corpus/test-intersection-flattening.ts
@@ -33,7 +33,6 @@ export const Routes = h.apiSpec({
     "/test": {
       "get": {
         "summary": "MyRoute",
-        "description": "",
         "parameters": [],
         "responses": {
           "200": {

--- a/packages/openapi-generator/corpus/test-multi-route.ts
+++ b/packages/openapi-generator/corpus/test-multi-route.ts
@@ -68,7 +68,6 @@ export const Routes = h.apiSpec({
     "/test/{id}/first": {
       "get": {
         "summary": "FirstRoute",
-        "description": "",
         "parameters": [
           {
             "name": "horse",
@@ -115,7 +114,6 @@ export const Routes = h.apiSpec({
     "/test/{id}/second": {
       "get": {
         "summary": "SecondRoute",
-        "description": "",
         "parameters": [
           {
             "name": "horse",

--- a/packages/openapi-generator/corpus/test-multi-union.ts
+++ b/packages/openapi-generator/corpus/test-multi-union.ts
@@ -33,7 +33,6 @@ export const Routes = h.apiSpec({
     "/test": {
       "get": {
         "summary": "MyRoute",
-        "description": "",
         "parameters": [],
         "responses": {
           "200": {

--- a/packages/openapi-generator/corpus/test-null-param.ts
+++ b/packages/openapi-generator/corpus/test-null-param.ts
@@ -33,7 +33,6 @@ export const Routes = h.apiSpec({
     "/test": {
       "get": {
         "summary": "MyRoute",
-        "description": "",
         "parameters": [],
         "responses": {
           "200": {

--- a/packages/openapi-generator/corpus/test-optional-property.ts
+++ b/packages/openapi-generator/corpus/test-optional-property.ts
@@ -38,11 +38,9 @@ export const Routes = h.apiSpec({
     "/test": {
       "get": {
         "summary": "MyRoute",
-        "description": "",
         "parameters": [
           {
             "name": "req",
-            "description": "",
             "schema": {
               "type": "string"
             },
@@ -51,7 +49,6 @@ export const Routes = h.apiSpec({
           },
           {
             "name": "opt",
-            "description": "",
             "schema": {
               "type": "string"
             },

--- a/packages/openapi-generator/corpus/test-record-type.ts
+++ b/packages/openapi-generator/corpus/test-record-type.ts
@@ -33,7 +33,6 @@ export const Routes = h.apiSpec({
     "/test": {
       "get": {
         "summary": "MyRoute",
-        "description": "",
         "parameters": [],
         "responses": {
           "200": {

--- a/packages/openapi-generator/corpus/test-single-route-multi-method.ts
+++ b/packages/openapi-generator/corpus/test-single-route-multi-method.ts
@@ -59,7 +59,6 @@ export const Routes = h.apiSpec({
     "/test/{id}": {
       "get": {
         "summary": "FirstRoute",
-        "description": "",
         "parameters": [
           {
             "name": "id",
@@ -86,7 +85,6 @@ export const Routes = h.apiSpec({
       },
       "post": {
         "summary": "SecondRoute",
-        "description": "",
         "parameters": [
           {
             "name": "id",

--- a/packages/openapi-generator/corpus/test-string-union.ts
+++ b/packages/openapi-generator/corpus/test-string-union.ts
@@ -33,7 +33,6 @@ export const Routes = h.apiSpec({
     "/test": {
       "get": {
         "summary": "MyRoute",
-        "description": "",
         "parameters": [],
         "responses": {
           "200": {

--- a/packages/openapi-generator/corpus/test-unknown-property.ts
+++ b/packages/openapi-generator/corpus/test-unknown-property.ts
@@ -40,7 +40,6 @@ export const Routes = h.apiSpec({
     "/test/{id}": {
       "post": {
         "summary": "MyRoute",
-        "description": "",
         "parameters": [
           {
             "name": "id",

--- a/packages/openapi-generator/corpus/test-version-tag.ts
+++ b/packages/openapi-generator/corpus/test-version-tag.ts
@@ -38,7 +38,6 @@ export const Routes = h.apiSpec({
     "/test": {
       "get": {
         "summary": "MyRoute",
-        "description": "",
         "parameters": [],
         "responses": {
           "200": {

--- a/packages/openapi-generator/src/route.ts
+++ b/packages/openapi-generator/src/route.ts
@@ -101,7 +101,9 @@ const parametersFromCodecOutputSym = (paramIn: 'query' | 'path') =>
               schema,
               required,
               in: paramIn,
-              description: description[description.length - 1] ?? '',
+              ...(description.length > 0
+                ? { description: description[description.length - 1] }
+                : {}),
             })),
           ),
         ),
@@ -150,7 +152,7 @@ const routeSummary = (init: Node) => {
   }
 };
 
-const routeDescription = (init: Node) => {
+const routeDescription = (init: Node): { description?: string; isPrivate: boolean } => {
   return pipe(
     E.fromNullable('No symbol for initializer')(init.getSymbol()),
     E.chain((sym) =>
@@ -158,7 +160,7 @@ const routeDescription = (init: Node) => {
         (sym.getAliasedSymbol() ?? sym).getValueDeclaration(),
       ),
     ),
-    E.chain((decl) => {
+    E.chain((decl): E.Either<string, { description?: string; isPrivate: boolean }> => {
       let current: Node | undefined = decl;
       while (current !== undefined) {
         const comments = current.getLeadingCommentRanges();
@@ -182,7 +184,7 @@ const routeDescription = (init: Node) => {
       }
       return E.left('no comment found');
     }),
-    E.getOrElse(() => ({ description: '', isPrivate: false })),
+    E.getOrElseW(() => ({ isPrivate: false })),
   );
 };
 


### PR DESCRIPTION
The description field in responses appears to be required. Is there
a reasonable default we can use for these? Perhaps the http status name?