### PR TITLE
feat: constrain api spec keys to HTTP methods

### DIFF
--- a/packages/express-wrapper/src/request.ts
+++ b/packages/express-wrapper/src/request.ts
@@ -112,7 +112,7 @@ export const handleRequest = (
   httpRoute: HttpRoute,
   handler: RouteHandler<HttpRoute>,
   responseEncoder: ResponseEncoder,
-): TypedRequestHandler<ApiSpec, string, string> => {
+): TypedRequestHandler<ApiSpec> => {
   return createNamedFunction(
     'decodeRequestAndEncodeResponse' + httpRoute.method + apiName,
     async (req, res, next) => {

--- a/packages/typed-express-router/test/server.test.ts
+++ b/packages/typed-express-router/test/server.test.ts
@@ -556,3 +556,21 @@ test('should invoke custom encode error function when an unknown keyed status is
   test.is(response.original.status, 500);
   test.is(response.body, 'Custom encode error');
 });
+
+const ExplicitUndefinedApiSpec = apiSpec({
+  empty: {
+    get: undefined,
+  },
+});
+
+test('should throw on explicitly undefined route definition', async (t) => {
+  const router = createRouter(ExplicitUndefinedApiSpec);
+
+  t.throws(() => {
+    router.get('empty', [
+      (_req, res) => {
+        res.send(200);
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
This also fixes a bit of unsoundness in the types that derived from
`ApiSpec`. Runtime checks are added for things like explicitly undefined
keys on the optional properties (not always preventable depending on
tsconfig).