### PR TITLE
ci: add required runs-on property

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -15,6 +15,8 @@ concurrency:
 
 jobs:
   build-docs:
+    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -42,6 +44,7 @@ jobs:
 
   deploy-docs:
     needs: build-docs
+    runs-on: ubuntu-latest
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:


### PR DESCRIPTION
```
Required property is missing: runs-on .github/workflows/deploy-github-pages.yml
```

Shown [here](https://github.com/BitGo/api-ts/actions/runs/3018450880)