### PR TITLE
chore(dependabot): disable updates for known-incompatible dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,7 @@ updates:
     ignore:
       - dependency-name: io-ts
         versions: ['2.x']
+      - dependency-name: typescript
+        versions: ['^4.8']
+      - dependency-name: ts-morph
+        versions: ['>=16']


### PR DESCRIPTION
All of these dependencies stem from io-ts 2.1.3 not being compatible with
TypeScript 4.8.

Closes Ticket: BG-57084