### PR TITLE
fix: list @types/express as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -691,7 +691,6 @@
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -706,7 +705,6 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -719,7 +717,6 @@
     },
     "node_modules/@types/express": {
       "version": "4.17.13",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -730,7 +727,6 @@
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.17.28",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -745,7 +741,6 @@
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimist": {
@@ -760,7 +755,6 @@
     },
     "node_modules/@types/node": {
       "version": "12.20.48",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -775,12 +769,10 @@
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/retry": {
@@ -790,7 +782,6 @@
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -10834,6 +10825,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@api-ts/io-ts-http": "0.0.0-semantically-released",
+        "@types/express": "4.17.13",
         "express": "4.17.2",
         "fp-ts": "2.12.3",
         "io-ts": "2.1.3"
@@ -10841,7 +10833,6 @@
       "devDependencies": {
         "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
         "@ava/typescript": "3.0.1",
-        "@types/express": "4.17.13",
         "ava": "4.3.3",
         "c8": "7.12.0",
         "ts-node": "10.9.1",
@@ -11894,7 +11885,6 @@
     },
     "@types/body-parser": {
       "version": "1.19.2",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -11908,7 +11898,6 @@
     },
     "@types/connect": {
       "version": "3.4.35",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -11919,7 +11908,6 @@
     },
     "@types/express": {
       "version": "4.17.13",
-      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -11929,7 +11917,6 @@
     },
     "@types/express-serve-static-core": {
       "version": "4.17.28",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -11941,8 +11928,7 @@
       "dev": true
     },
     "@types/mime": {
-      "version": "1.3.2",
-      "dev": true
+      "version": "1.3.2"
     },
     "@types/minimist": {
       "version": "1.2.2",
@@ -11953,8 +11939,7 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.48",
-      "dev": true
+      "version": "12.20.48"
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -11965,12 +11950,10 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.7",
-      "dev": true
+      "version": "6.9.7"
     },
     "@types/range-parser": {
-      "version": "1.2.4",
-      "dev": true
+      "version": "1.2.4"
     },
     "@types/retry": {
       "version": "0.12.1",
@@ -11978,7 +11961,6 @@
     },
     "@types/serve-static": {
       "version": "1.13.10",
-      "dev": true,
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"

--- a/packages/typed-express-router/package.json
+++ b/packages/typed-express-router/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
+    "@types/express": "4.17.13",
     "express": "4.17.2",
     "fp-ts": "2.12.3",
     "io-ts": "2.1.3"
@@ -25,7 +26,6 @@
   "devDependencies": {
     "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
     "@ava/typescript": "3.0.1",
-    "@types/express": "4.17.13",
     "ava": "4.3.3",
     "c8": "7.12.0",
     "ts-node": "10.9.1",


### PR DESCRIPTION
Since the `typed-express-router` exports types from `@types/express` (through [WrappedRouter], defined [here]) we need to make the `@types/express` types visible to consumers of the library. That requires placing `@types/express` in the `dependencies` section of the `typed-express-router` `package.json`, as described by [StackOverflow] and the [TypeScript Documentation].

However, currently `@types/express` is [listed] under `devDependencies`, not `dependencies`.

Closes Ticket: BG-57590

[wrappedrouter]: https://github.com/ericcrosson-bitgo/api-ts/blob/f2fe78bb49ea617d1bea44405601ad694fe88615/packages/typed-express-router/src/index.ts#L29
[here]: https://github.com/ericcrosson-bitgo/api-ts/blob/0898ccecdcebdcf98cff0fded260ae9b8a905825/packages/typed-express-router/src/types.ts#L119
[stackoverflow]: https://stackoverflow.com/a/46011417
[typescript documentation]: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies
[listed]: https://github.com/ericcrosson-bitgo/api-ts/blob/530e1550fe90e25fcbc57429d26f17e54b8fd546/packages/typed-express-router/package.json#L28