### PR TITLE
fix(pages): correct the baseUrl configuration

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -14,7 +14,7 @@ const config = {
   title: 'api-ts home',
   tagline: 'Type- and runtime- safe TypeScript APIs',
   url: 'https://bitgo.github.io/api-ts/',
-  baseUrl: '/',
+  baseUrl: '/api-ts/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
As suggested by the docusaurus error on the current GitHub Pages
deployment.