### PR TITLE
ci: use consistent concurrency limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ name: CI
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   api-ts:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -7,8 +7,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}
 
 # Following the reference documentation
 # https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,6 +4,10 @@ name: Format
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [master, alpha, beta, next, next-major]
 
+# Only allow one release workflow to execute at a time, since each release
+# workflow uses shared resources (git tags, package registries)
+concurrency: ${{ github.workflow }}
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
For release workflows:

- ensure there is only one workflow running concurrently
- do not skip any workflows

This is because releases act on shared resources (the deployed
environment, or git tags), so this concurrency limit acts as a mutex.

For CI (pre-merge) workflows:

- ensure only one workflow runs per branch
- cancel in-progress workflows

This is because we only care about the results of the latest workflows
to run, which act as required status checks. The impact is faster
reported status-check results, because of less queueing.

Ticket: 0