### PR TITLE
chore: update io-ts-types to 0.5.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3418,8 +3418,9 @@
       }
     },
     "node_modules/io-ts-types": {
-      "version": "0.5.16",
-      "license": "MIT",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.17.tgz",
+      "integrity": "sha512-W0zrePsFWAyBdvHj4b/LU4HaHfDiKQ0DvSYDeE5hgXYaEtTEqcyNTLGRcFSa32lZAQFQzyQRDVtN+B7MyBaXAw==",
       "peerDependencies": {
         "fp-ts": "^2.0.0",
         "io-ts": "^2.0.0",
@@ -10137,7 +10138,7 @@
         "@api-ts/response": "0.0.0-semantically-released",
         "fp-ts": "2.12.3",
         "io-ts": "2.1.3",
-        "io-ts-types": "0.5.16"
+        "io-ts-types": "0.5.17"
       },
       "devDependencies": {
         "@types/chai": "4.3.3",
@@ -10327,7 +10328,7 @@
         "comment-parser": "1.3.1",
         "fp-ts": "2.12.3",
         "io-ts": "2.1.3",
-        "io-ts-types": "0.5.16",
+        "io-ts-types": "0.5.17",
         "openapi-types": "12.0.2",
         "ts-morph": "14.0.0",
         "typescript": "4.7.4"
@@ -10395,7 +10396,7 @@
         "c8": "7.11.2",
         "chai": "4.3.6",
         "express": "4.17.1",
-        "io-ts-types": "0.5.16",
+        "io-ts-types": "0.5.17",
         "mocha": "10.0.0",
         "superagent": "8.0.1",
         "supertest": "6.2.3",
@@ -10968,7 +10969,7 @@
         "chai": "4.3.6",
         "fp-ts": "2.12.3",
         "io-ts": "2.1.3",
-        "io-ts-types": "0.5.16",
+        "io-ts-types": "0.5.17",
         "mocha": "10.0.0",
         "ts-node": "10.9.1",
         "typescript": "4.7.4"
@@ -11103,7 +11104,7 @@
         "comment-parser": "1.3.1",
         "fp-ts": "2.12.3",
         "io-ts": "2.1.3",
-        "io-ts-types": "0.5.16",
+        "io-ts-types": "0.5.17",
         "openapi-types": "12.0.2",
         "parser-ts": "0.6.16",
         "ts-morph": "14.0.0",
@@ -11147,7 +11148,7 @@
         "express": "4.17.1",
         "fp-ts": "2.12.3",
         "io-ts": "2.1.3",
-        "io-ts-types": "0.5.16",
+        "io-ts-types": "0.5.17",
         "mocha": "10.0.0",
         "superagent": "8.0.1",
         "supertest": "6.2.3",
@@ -13811,7 +13812,9 @@
       "requires": {}
     },
     "io-ts-types": {
-      "version": "0.5.16",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.17.tgz",
+      "integrity": "sha512-W0zrePsFWAyBdvHj4b/LU4HaHfDiKQ0DvSYDeE5hgXYaEtTEqcyNTLGRcFSa32lZAQFQzyQRDVtN+B7MyBaXAw==",
       "requires": {}
     },
     "ipaddr.js": {

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -22,7 +22,7 @@
     "@api-ts/response": "0.0.0-semantically-released",
     "fp-ts": "2.12.3",
     "io-ts": "2.1.3",
-    "io-ts-types": "0.5.16"
+    "io-ts-types": "0.5.17"
   },
   "devDependencies": {
     "@types/chai": "4.3.3",

--- a/packages/io-ts-http/test/httpRequest.test.ts
+++ b/packages/io-ts-http/test/httpRequest.test.ts
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+import * as NEA from 'fp-ts/NonEmptyArray';
 import * as t from 'io-ts';
 import { nonEmptyArray, JsonFromString, NumberFromString } from 'io-ts-types';
 import { assertRight } from './utils';
@@ -12,7 +13,7 @@ const example = {
   },
   query: {
     test: 'foo',
-    multiTest: ['a', 'b', 'c'],
+    multiTest: NEA.fromReadonlyNonEmptyArray(['a', 'b', 'c']),
     encodedJson: '{"jsonKey":null}',
     optionalParam: 'hello',
   },
@@ -58,7 +59,7 @@ describe('httpRequest', () => {
     assert.deepStrictEqual(output, {
       id: 1,
       test: 'foo',
-      multiTest: ['a', 'b', 'c'],
+      multiTest: NEA.fromReadonlyNonEmptyArray(['a', 'b', 'c']),
       // tslint:disable-next-line: no-null-keyword
       encodedJson: { jsonKey: null },
       optionalParam: 'hello',

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -25,7 +25,7 @@
     "comment-parser": "1.3.1",
     "fp-ts": "2.12.3",
     "io-ts": "2.1.3",
-    "io-ts-types": "0.5.16",
+    "io-ts-types": "0.5.17",
     "openapi-types": "12.0.2",
     "ts-morph": "14.0.0",
     "typescript": "4.7.4"

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -30,7 +30,7 @@
     "body-parser": "1.20.0",
     "chai": "4.3.6",
     "express": "4.17.1",
-    "io-ts-types": "0.5.16",
+    "io-ts-types": "0.5.17",
     "mocha": "10.0.0",
     "c8": "7.11.2",
     "superagent": "8.0.1",


### PR DESCRIPTION
This version has a breaking change where the `nonEmptyArray` now returns an actual `NonEmptyArray` type. This broke some tests but was easily rectified. Aside from tests, the only type used from `io-ts-types` is the `Json` one, so this shouldn't break consumers of this library.

This package is also used in `superagent-wrapper` and `openapi-generator`, where it also shouldn't cause backwards-compatibility issues.