### PR TITLE
docs: replace API-TS with api-ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# API-TS
+# api-ts
 
 ![Build Status](https://github.com/BitGo/api-ts/actions/workflows/release.yml/badge.svg?branch=master&event=push)
 


### PR DESCRIPTION
We seem to be using api-ts in most places, which is consistent with the
npmjs package name and kinder on the pinkies to type.

This commit replaces API-TS with api-ts and formalizes this convention.

Ticket: api-ts-is-spelled-with-lowercase-letters