### PR TITLE
Upgrade @types/superagent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -790,9 +790,10 @@
       }
     },
     "node_modules/@types/superagent": {
-      "version": "4.1.5",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.15.tgz",
+      "integrity": "sha512-mu/N4uvfDN2zVQQ5AYJI/g4qxn2bHB6521t1UuH09ShNWjebTqN0ZFuYK9uYjcgmI0dTQEs+Owi1EO6U0OkOZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/cookiejar": "*",
         "@types/node": "*"
@@ -10287,7 +10288,7 @@
         "@types/chai": "4.3.3",
         "@types/express": "4.17.13",
         "@types/mocha": "10.0.0",
-        "@types/superagent": "4.1.5",
+        "@types/superagent": "4.1.15",
         "@types/supertest": "2.0.12",
         "body-parser": "1.20.0",
         "c8": "7.11.2",
@@ -11021,7 +11022,7 @@
         "@types/chai": "4.3.3",
         "@types/express": "4.17.13",
         "@types/mocha": "10.0.0",
-        "@types/superagent": "4.1.5",
+        "@types/superagent": "4.1.15",
         "@types/supertest": "2.0.12",
         "body-parser": "1.20.0",
         "c8": "7.11.2",
@@ -11980,7 +11981,9 @@
       }
     },
     "@types/superagent": {
-      "version": "4.1.5",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.15.tgz",
+      "integrity": "sha512-mu/N4uvfDN2zVQQ5AYJI/g4qxn2bHB6521t1UuH09ShNWjebTqN0ZFuYK9uYjcgmI0dTQEs+Owi1EO6U0OkOZQ==",
       "dev": true,
       "requires": {
         "@types/cookiejar": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@semantic-release/github": "8.0.6",
         "@semantic-release/npm": "9.0.1",
         "@semrel-extra/npm": "1.2.0",
+        "@types/node": "18.8.2",
         "lint-staged": "13.0.3",
         "multi-semantic-release": "3.0.1",
         "pre-commit": "1.2.2",
@@ -225,6 +226,13 @@
         "find-up": "^4.1.0",
         "fs-extra": "^8.1.0"
       }
+    },
+    "node_modules/@manypkg/find-root/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@manypkg/find-root/node_modules/fs-extra": {
       "version": "8.1.0",
@@ -755,7 +763,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.48",
+      "version": "18.8.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -11536,6 +11546,12 @@
         "fs-extra": "^8.1.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "12.20.55",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "8.1.0",
           "dev": true,
@@ -11953,7 +11969,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.48"
+      "version": "18.8.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@semantic-release/github": "8.0.6",
     "@semantic-release/npm": "9.0.1",
     "@semrel-extra/npm": "1.2.0",
+    "@types/node": "18.8.2",
     "lint-staged": "13.0.3",
     "multi-semantic-release": "3.0.1",
     "pre-commit": "1.2.2",

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -22,7 +22,7 @@
     "io-ts": "2.1.3"
   },
   "devDependencies": {
-    "@types/superagent": "4.1.5",
+    "@types/superagent": "4.1.15",
     "@types/supertest": "2.0.12",
     "@types/chai": "4.3.3",
     "@types/express": "4.17.13",


### PR DESCRIPTION
This commit adds `@types/node` as a dependency to the root package
manifest.

This pacifies the following compilation error:

```
Error: @api-ts/response:build: ../../node_modules/@types/superagent/index.d.ts(23,10):
          error TS2305: Module '"buffer"' has no exported member 'Blob'.
```

which seems to be caused by a too-old version of `@types/node` being installed.

This too-old version of `@types/node` is installed because 
`@types/superagent` depends on `"@types/node": "*"` (citation
needed, but this is what we see in our `package-lock.json`
file[^1]). This `"*"` means "any installed version will do".
Unfortunately, we have one installed version of `@types/node`:

```
$ npm ls @types/node
└─┬ multi-semantic-release@3.0.1
  └─┬ @manypkg/get-packages@1.1.3
    └─┬ @manypkg/find-root@1.1.0
      └── @types/node@12.20.48
```

which is version 12.20.48, a dependency of multi-semantic-release.

This version of `@types/node` is incompatible with the Node.js runtimes
we're using (currently 14, 16, and 18).

This commit circumvents this old version of node being the one picked
up by `@types/superagent` by forcing a second, more recent version of
`@types/node` to be downloaded and take import-priority over the old
version.

[^1]: https://github.com/BitGo/api-ts/blob/23e2993cf8d5c8e58f9b2bd4b15a2182dacc3fa5/package-lock.json#L798
