### PR TITLE
chore(dependabot): ignore patch versions of @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,7 @@ updates:
         versions: ['^4.8']
       - dependency-name: ts-morph
         versions: ['>=16']
+      # Ignore all @types/nodes patch updates, since
+      # this package updates so frequently
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-patch']


### PR DESCRIPTION
To reduce toil. This package releases all the time, and since we
use such a small subset of the offered types, it's probabilistically
unlikely to impact us.