### PR TITLE
fix: add npm >6 requirement to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,9 @@
         "prettier": "2.5.1",
         "turbo": "1.6.3",
         "typescript": "4.6.4"
+      },
+      "engines": {
+        "npm": ">6"
       }
     },
     "node_modules/@api-ts/express-wrapper": {

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "prettier": "2.5.1",
     "turbo": "1.6.3",
     "typescript": "4.6.4"
+  },
+  "engines": {
+    "npm": ">6"
   }
 }


### PR DESCRIPTION
This project uses NPM workspaces that are only supported by version 7 and above