### PR TITLE
BREAKING CHANGE: make `optionalized` strip explicit `undefined` values

### DIFF
--- a/packages/io-ts-http/src/utils.ts
+++ b/packages/io-ts-http/src/utils.ts
@@ -1,5 +1,17 @@
 import type * as t from 'io-ts';
 
+type Defined<T> = T extends undefined ? never : T;
+
+export type DefinedValues<T> = {
+  [K in keyof T]: Defined<T[K]>;
+};
+
+type DefinedProps<Props extends t.Props> = {
+  [K in keyof Props]: Props[K] extends t.Type<infer A, infer O, infer I>
+    ? t.Type<Defined<A>, O, I>
+    : never;
+};
+
 type PossiblyUndefinedKeys<T> = {
   [K in keyof T]: undefined extends T[K] ? K : never;
 }[keyof T];
@@ -9,12 +21,12 @@ export type PossiblyUndefinedProps<T extends t.Props> = {
 }[keyof T];
 
 type Optionalized<T> = Simplify<
-  Omit<T, PossiblyUndefinedKeys<T>> & Partial<Pick<T, PossiblyUndefinedKeys<T>>>
+  Omit<T, PossiblyUndefinedKeys<T>> &
+    Partial<DefinedValues<Pick<T, PossiblyUndefinedKeys<T>>>>
 >;
 
-export type OptionalProps<Props extends t.Props> = Pick<
-  Props,
-  PossiblyUndefinedProps<Props>
+export type OptionalProps<Props extends t.Props> = DefinedProps<
+  Pick<Props, PossiblyUndefinedProps<Props>>
 >;
 
 export type RequiredProps<Props extends t.Props> = Omit<

--- a/packages/io-ts-http/test/combinators.test.ts
+++ b/packages/io-ts-http/test/combinators.test.ts
@@ -93,11 +93,22 @@ describe('optionalized', () => {
   it('does not add explicit undefined properties when encoding', () =>
     assertEncodes(codec, { a: 'a', b: 1 }));
 
-  it('keeps explicit undefined properties when encoding', () => {
+  it('strips explicit undefined properties when decoding', () => {
     const optionalCodec = c.optionalized({
       a: c.optional(t.number),
+      b: t.string,
     });
-    assertEncodes(optionalCodec, { a: undefined });
+    const expected = { b: 'foo' };
+    assertDecodes(optionalCodec, { a: undefined, b: 'foo' }, expected);
+  });
+
+  it('strips explicit undefined properties when encoding', () => {
+    const optionalCodec = c.optionalized({
+      a: c.optional(t.number),
+      b: t.string,
+    });
+    const expected = { b: 'foo' };
+    assertEncodes(optionalCodec, { a: undefined, b: 'foo' }, expected);
   });
 
   it('decodes explicit null properties', () => {


### PR DESCRIPTION
`optionalized` determines which properties to make optional by checking if the codec associated with the property accepts `undefined`. As a result, it is impossible to use it to define types that have optional properties whose type isn't a union containing `undefined`. When `exactOptionalPropertyTypes` is `false` this isn't a big deal, because all optional properties are implicitly treated this way. However, it would be nice to be able to take advantage of the cleaner types enabled by `exactOptionalPropertyTypes`.

This change offers a potential solution by changing the behavior of `optionalized` such that it always deletes any properties that are explicitly set to `undefined`. This is a breaking change, but seems unlikely to cause issues in practice. If the previous behavior is needed, it is always possible to use
`t.intersection([t.type(...),t.partial(...)])`.

This change also solves an inconsistency in `io-ts-http` exposed when `exactOptionalPropertyTypes` is enabled, as reported in #272. The `httpRequest` function is implemented with `flatten`, which currently passes all keys to `optionalized`. At the same time, `GenericHttpRequest` is defined using `Record` types whose codomains do not include `undefined`. With `exactOptionalPropertyTypes` enabled, this results in an error if, for example, an optional query parameter is defined on an `httpRequest` because of how `optionalized` forces all optional properties to be able to be explicitly `undefined`. Rather than adding `t.undefined` to all the records, this change presents an alternative that keeps the `GenericHttpRequest` type as simple as possible.