### PR TITLE
chore(nix): update Node.js to latest LTS v18

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652290453,
-        "narHash": "sha256-0iXRvx7DP/HIKd5h7b7Y1+JffoDDRCwz4WTVYfsltrs=",
+        "lastModified": 1667921410,
+        "narHash": "sha256-mg7QLVdBN+K3pql5tZDXNady/VlFHWbei03HoDp3bKk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e680b5cf74e550508f1e2be2fcfdee688bbd3b74",
+        "rev": "2c5abd89c7e917acde9077fc4d12596e35b73e17",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
             name = "api-ts-shell";
 
             packages = with pkgs; [
-              nodejs-16_x
+              nodejs
             ];
 
             shellHook = ''


### PR DESCRIPTION
This commit commits the result of running

```
nix flake update
```

and bumps the `nodejs` build input from v16 to latest LTS, which is
currently 18.