### PR TITLE
refactor: use Object.key to enumerate enumerable property names

### DIFF
--- a/packages/io-ts-http/src/combinators.ts
+++ b/packages/io-ts-http/src/combinators.ts
@@ -19,10 +19,7 @@ export const optional = <C extends t.Mixed>(subCodec: C) =>
 export const optionalized = <P extends t.Props>(props: P): OptionalizedC<P> => {
   const requiredProps: t.Props = {};
   const optionalProps: t.Props = {};
-  for (const key in props) {
-    if (!props.hasOwnProperty(key)) {
-      continue;
-    }
+  for (const key of Object.keys(props)) {
     const codec = props[key]!;
     const isOptional = codec.is(undefined);
     if (isOptional) {


### PR DESCRIPTION
This improves readability, requires less code, and saves runtime cycles
compared to enumerating over all keys and short-circuiting for the  non-
enumerable keys.

MDN shows this implementation to be widely supported[^1] so it should
not be a breaking change.

[^1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#browser_compatibility