### PR TITLE
build: treat tsconfig.json as an input for all turborepo tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "baseBranch": "origin/master",
+  "globalDependencies": ["tsconfig.json"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
The issue can be reproduced with the following steps

1. From a clean repository state, run `npm ci && npm run build`
2. Modify `/tsconfig.json`
3. Run `npm run build` and turborepo considers the cache from (1) valid

This commit adds `tsconfig.json` to turborepo's `globalDependencies`[^1]
setting to invalidate the turborepo cache when `/tsconfig.json` is
changed. This means all turbo tasks (we have `build` and `test`)
consider `/tsconfig.json` to be a build input. If we had other tasks,
this might not be the desired behavior.

It may also be possible to use turborepo's `inputs`[^2] setting,
but this looked more confusing.

[^1]: https://turbo.build/repo/docs/reference/configuration#globaldependencies
[^2]: https://turbo.build/repo/docs/reference/configuration#inputs