### PR TITLE
refactor: use OutputOf to mirror expected order of type arguments

### DIFF
--- a/packages/io-ts-http/src/httpRequest.ts
+++ b/packages/io-ts-http/src/httpRequest.ts
@@ -12,7 +12,7 @@ export const GenericHttpRequest = optionalized({
 
 export type HttpRequestCodec<T> = t.Type<
   T,
-  t.TypeOf<typeof GenericHttpRequest>,
+  t.OutputOf<typeof GenericHttpRequest>,
   unknown
 >;
 


### PR DESCRIPTION
Change the type-level function wrapping the second type-argument to
`t.Type` from `TypeOf` to `OutputOf`, to match the expected order
of io-ts type-arguments: `A, O, I`.

This has no change in type or behavior, since in this case `TypeOf`
and `OutputOf` behave the same. However, this change should improve
readability.