### PR TITLE
build: enable exactOptionalPropertyTypes in io-ts-http

### DIFF
--- a/packages/io-ts-http/tsconfig.json
+++ b/packages/io-ts-http/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*", "test/**/*"],
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "exactOptionalPropertyTypes": true
   },
   "references": [
     {


### PR DESCRIPTION
Enable this strict compiler setting, related to
https://github.com/BitGo/api-ts/pull/274