### PR TITLE
chore: remove @semantic-release/github

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,12 +8,6 @@
       }
     ],
     "@semantic-release/release-notes-generator",
-    "@semrel-extra/npm",
-    [
-      "@semantic-release/github",
-      {
-        "assignees": ["@BitGo/internal-tools"]
-      }
-    ]
+    "@semrel-extra/npm"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/**"
       ],
       "devDependencies": {
-        "@semantic-release/github": "8.0.6",
         "@semantic-release/npm": "9.0.1",
         "@semrel-extra/npm": "1.2.0",
         "@types/node": "18.11.7",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "pre-commit": "lint-staged",
   "devDependencies": {
-    "@semantic-release/github": "8.0.6",
     "@semantic-release/npm": "9.0.1",
     "@semrel-extra/npm": "1.2.0",
     "@types/node": "18.11.7",


### PR DESCRIPTION
We were only using this semantic-release extension to add reviewers
to PRs, but we have this behavior implemented already using GitHub
code owners.