### PR TITLE
chore: run `npm audit fix`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4444,9 +4444,10 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4929,7 +4930,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "8.7.0",
+      "version": "8.19.3",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.3.tgz",
+      "integrity": "sha512-0QjmyPtDxSyMWWD8I91QGbrgx9KzbV6C9FK1liEb/K0zppiZkr5KxXc990G+LzPwBHDfRjUBlO9T1qZ08vl9mA==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -4948,6 +4951,7 @@
         "cli-table3",
         "columnify",
         "fastest-levenshtein",
+        "fs-minipass",
         "glob",
         "graceful-fs",
         "hosted-git-info",
@@ -4967,6 +4971,7 @@
         "libnpmteam",
         "libnpmversion",
         "make-fetch-happen",
+        "minimatch",
         "minipass",
         "minipass-pipeline",
         "mkdirp",
@@ -4983,6 +4988,7 @@
         "npm-user-validate",
         "npmlog",
         "opener",
+        "p-map",
         "pacote",
         "parse-conflict-json",
         "proc-log",
@@ -5003,76 +5009,73 @@
         "write-file-atomic"
       ],
       "dev": true,
-      "license": "Artistic-2.0",
-      "workspaces": [
-        "docs",
-        "smoke-tests",
-        "workspaces/*"
-      ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.0.4",
+        "@npmcli/arborist": "^5.6.3",
         "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/config": "^4.1.0",
+        "@npmcli/config": "^4.2.1",
         "@npmcli/fs": "^2.1.0",
-        "@npmcli/map-workspaces": "^2.0.2",
+        "@npmcli/map-workspaces": "^2.0.3",
         "@npmcli/package-json": "^2.0.0",
-        "@npmcli/run-script": "^3.0.1",
+        "@npmcli/run-script": "^4.2.1",
         "abbrev": "~1.1.1",
         "archy": "~1.0.0",
-        "cacache": "^16.0.4",
+        "cacache": "^16.1.3",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.1",
+        "cli-table3": "^0.6.2",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.12",
-        "glob": "^7.2.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
         "graceful-fs": "^4.2.10",
-        "hosted-git-info": "^5.0.0",
-        "ini": "^3.0.0",
+        "hosted-git-info": "^5.2.1",
+        "ini": "^3.0.1",
         "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^6.0.2",
-        "libnpmdiff": "^4.0.2",
-        "libnpmexec": "^4.0.2",
-        "libnpmfund": "^3.0.1",
-        "libnpmhook": "^8.0.2",
-        "libnpmorg": "^4.0.2",
-        "libnpmpack": "^4.0.2",
-        "libnpmpublish": "^6.0.2",
-        "libnpmsearch": "^5.0.2",
-        "libnpmteam": "^4.0.2",
-        "libnpmversion": "^3.0.1",
-        "make-fetch-happen": "^10.1.2",
+        "libnpmaccess": "^6.0.4",
+        "libnpmdiff": "^4.0.5",
+        "libnpmexec": "^4.0.14",
+        "libnpmfund": "^3.0.5",
+        "libnpmhook": "^8.0.4",
+        "libnpmorg": "^4.0.4",
+        "libnpmpack": "^4.1.3",
+        "libnpmpublish": "^6.0.5",
+        "libnpmsearch": "^5.0.4",
+        "libnpmteam": "^4.0.4",
+        "libnpmversion": "^3.0.7",
+        "make-fetch-happen": "^10.2.0",
+        "minimatch": "^5.1.0",
         "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^9.0.0",
-        "nopt": "^5.0.0",
+        "node-gyp": "^9.1.0",
+        "nopt": "^6.0.0",
         "npm-audit-report": "^3.0.0",
         "npm-install-checks": "^5.0.0",
-        "npm-package-arg": "^9.0.2",
-        "npm-pick-manifest": "^7.0.1",
-        "npm-profile": "^6.0.2",
-        "npm-registry-fetch": "^13.1.0",
+        "npm-package-arg": "^9.1.0",
+        "npm-pick-manifest": "^7.0.2",
+        "npm-profile": "^6.2.0",
+        "npm-registry-fetch": "^13.3.1",
         "npm-user-validate": "^1.0.1",
-        "npmlog": "^6.0.1",
+        "npmlog": "^6.0.2",
         "opener": "^1.5.2",
-        "pacote": "^13.1.1",
+        "p-map": "^4.0.0",
+        "pacote": "^13.6.2",
         "parse-conflict-json": "^2.0.2",
         "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
-        "read-package-json": "^5.0.0",
+        "read-package-json": "^5.0.2",
         "read-package-json-fast": "^2.0.3",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.6",
-        "ssri": "^9.0.0",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.1",
         "tar": "^6.1.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
@@ -5086,7 +5089,7 @@
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -5098,6 +5101,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/npm/node_modules/@gar/promisify": {
@@ -5113,34 +5126,37 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "5.0.6",
+      "version": "5.6.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/map-workspaces": "^2.0.0",
+        "@npmcli/map-workspaces": "^2.0.3",
         "@npmcli/metavuln-calculator": "^3.0.1",
         "@npmcli/move-file": "^2.0.0",
         "@npmcli/name-from-folder": "^1.0.1",
         "@npmcli/node-gyp": "^2.0.0",
         "@npmcli/package-json": "^2.0.0",
-        "@npmcli/run-script": "^3.0.0",
-        "bin-links": "^3.0.0",
-        "cacache": "^16.0.0",
+        "@npmcli/query": "^1.2.0",
+        "@npmcli/run-script": "^4.1.3",
+        "bin-links": "^3.0.3",
+        "cacache": "^16.1.3",
         "common-ancestor-path": "^1.0.1",
+        "hosted-git-info": "^5.2.1",
         "json-parse-even-better-errors": "^2.3.1",
         "json-stringify-nice": "^1.1.4",
+        "minimatch": "^5.1.0",
         "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^5.0.0",
+        "nopt": "^6.0.0",
         "npm-install-checks": "^5.0.0",
         "npm-package-arg": "^9.0.0",
-        "npm-pick-manifest": "^7.0.0",
+        "npm-pick-manifest": "^7.0.2",
         "npm-registry-fetch": "^13.0.0",
-        "npmlog": "^6.0.1",
-        "pacote": "^13.0.5",
+        "npmlog": "^6.0.2",
+        "pacote": "^13.6.1",
         "parse-conflict-json": "^2.0.1",
         "proc-log": "^2.0.0",
         "promise-all-reject-late": "^1.0.0",
@@ -5148,7 +5164,7 @@
         "read-package-json-fast": "^2.0.2",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "ssri": "^9.0.0",
         "treeverse": "^2.0.0",
         "walk-up-path": "^1.0.0"
@@ -5170,7 +5186,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "4.1.0",
+      "version": "4.2.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5178,7 +5194,7 @@
         "@npmcli/map-workspaces": "^2.0.2",
         "ini": "^3.0.0",
         "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^5.0.0",
+        "nopt": "^6.0.0",
         "proc-log": "^2.0.0",
         "read-package-json-fast": "^2.0.3",
         "semver": "^7.3.5",
@@ -5201,7 +5217,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "2.1.0",
+      "version": "2.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5214,7 +5230,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5249,23 +5265,32 @@
         "node": ">= 10"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "2.0.2",
+      "version": "2.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/name-from-folder": "^1.0.1",
-        "glob": "^7.2.0",
+        "glob": "^8.0.1",
         "minimatch": "^5.0.1",
         "read-package-json-fast": "^2.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5280,7 +5305,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/move-file": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5331,8 +5356,22 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/query": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-package-arg": "^9.1.0",
+        "postcss-selector-parser": "^6.0.10",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "3.0.2",
+      "version": "4.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5340,7 +5379,8 @@
         "@npmcli/node-gyp": "^2.0.0",
         "@npmcli/promise-spawn": "^3.0.0",
         "node-gyp": "^9.0.0",
-        "read-package-json-fast": "^2.0.3"
+        "read-package-json-fast": "^2.0.3",
+        "which": "^2.0.2"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -5437,7 +5477,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5446,7 +5486,7 @@
         "readable-stream": "^3.6.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/asap": {
@@ -5462,18 +5502,27 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "3.0.1",
+      "version": "3.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cmd-shim": "^5.0.0",
         "mkdirp-infer-owner": "^2.0.0",
-        "npm-normalize-package-bin": "^1.0.0",
+        "npm-normalize-package-bin": "^2.0.0",
         "read-cmd-shim": "^3.0.0",
         "rimraf": "^3.0.0",
         "write-file-atomic": "^4.0.0"
       },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
@@ -5497,7 +5546,7 @@
       }
     },
     "node_modules/npm/node_modules/builtins": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5506,7 +5555,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "16.0.4",
+      "version": "16.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5515,7 +5564,7 @@
         "@npmcli/move-file": "^2.0.0",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.1.0",
-        "glob": "^7.2.0",
+        "glob": "^8.0.1",
         "infer-owner": "^1.0.4",
         "lru-cache": "^7.7.1",
         "minipass": "^3.1.6",
@@ -5528,7 +5577,7 @@
         "rimraf": "^3.0.2",
         "ssri": "^9.0.0",
         "tar": "^6.1.11",
-        "unique-filename": "^1.1.1"
+        "unique-filename": "^2.0.0"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -5594,7 +5643,7 @@
       }
     },
     "node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5605,7 +5654,7 @@
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "colors": "1.4.0"
+        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/npm/node_modules/clone": {
@@ -5656,16 +5705,6 @@
         "color-support": "bin.js"
       }
     },
-    "node_modules/npm/node_modules/colors": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.6.0",
       "dev": true,
@@ -5696,6 +5735,18 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
+    },
+    "node_modules/npm/node_modules/cssesc": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.4",
@@ -5764,7 +5815,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "5.0.0",
+      "version": "5.1.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -5853,7 +5904,7 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "7.2.0",
+      "version": "8.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5861,37 +5912,14 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
@@ -5928,7 +5956,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "5.0.0",
+      "version": "5.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5936,7 +5964,7 @@
         "lru-cache": "^7.5.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
@@ -5960,7 +5988,7 @@
       }
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6047,7 +6075,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6074,7 +6102,7 @@
       }
     },
     "node_modules/npm/node_modules/ip": {
-      "version": "1.1.5",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -6101,7 +6129,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.8.1",
+      "version": "2.10.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6158,19 +6186,19 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff": {
-      "version": "5.0.1",
+      "version": "5.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "5.2.0",
+      "version": "5.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6185,7 +6213,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "4.0.3",
+      "version": "4.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6193,10 +6221,10 @@
         "@npmcli/disparity-colors": "^2.0.0",
         "@npmcli/installed-package-contents": "^1.0.7",
         "binary-extensions": "^2.2.0",
-        "diff": "^5.0.0",
+        "diff": "^5.1.0",
         "minimatch": "^5.0.1",
         "npm-package-arg": "^9.0.1",
-        "pacote": "^13.0.5",
+        "pacote": "^13.6.1",
         "tar": "^6.1.0"
       },
       "engines": {
@@ -6204,22 +6232,24 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "4.0.3",
+      "version": "4.0.14",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^5.0.0",
+        "@npmcli/arborist": "^5.6.3",
         "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/run-script": "^3.0.0",
+        "@npmcli/fs": "^2.1.1",
+        "@npmcli/run-script": "^4.2.0",
         "chalk": "^4.1.0",
         "mkdirp-infer-owner": "^2.0.0",
         "npm-package-arg": "^9.0.1",
-        "npmlog": "^6.0.1",
-        "pacote": "^13.0.5",
+        "npmlog": "^6.0.2",
+        "pacote": "^13.6.1",
         "proc-log": "^2.0.0",
         "read": "^1.0.7",
         "read-package-json-fast": "^2.0.2",
+        "semver": "^7.3.7",
         "walk-up-path": "^1.0.0"
       },
       "engines": {
@@ -6227,19 +6257,19 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "3.0.2",
+      "version": "3.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^5.0.0"
+        "@npmcli/arborist": "^5.6.3"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6252,7 +6282,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6265,21 +6295,21 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "4.0.3",
+      "version": "4.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/run-script": "^3.0.0",
+        "@npmcli/run-script": "^4.1.3",
         "npm-package-arg": "^9.0.1",
-        "pacote": "^13.0.5"
+        "pacote": "^13.6.1"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "6.0.3",
+      "version": "6.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6287,7 +6317,7 @@
         "normalize-package-data": "^4.0.0",
         "npm-package-arg": "^9.0.1",
         "npm-registry-fetch": "^13.0.0",
-        "semver": "^7.1.3",
+        "semver": "^7.3.7",
         "ssri": "^9.0.0"
       },
       "engines": {
@@ -6295,7 +6325,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6307,7 +6337,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6320,23 +6350,23 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "3.0.3",
+      "version": "3.0.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^3.0.0",
-        "@npmcli/run-script": "^3.0.0",
+        "@npmcli/run-script": "^4.1.3",
         "json-parse-even-better-errors": "^2.3.1",
         "proc-log": "^2.0.0",
-        "semver": "^7.3.5"
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "7.7.3",
+      "version": "7.13.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6345,13 +6375,13 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "10.1.2",
+      "version": "10.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
-        "cacache": "^16.0.2",
+        "cacache": "^16.1.0",
         "http-cache-semantics": "^4.1.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -6364,7 +6394,7 @@
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.3",
         "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.1.1",
+        "socks-proxy-agent": "^7.0.0",
         "ssri": "^9.0.0"
       },
       "engines": {
@@ -6372,7 +6402,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "5.0.1",
+      "version": "5.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6384,7 +6414,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "3.1.6",
+      "version": "3.3.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6408,7 +6438,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6531,7 +6561,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "9.0.0",
+      "version": "9.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6554,7 +6584,49 @@
         "node": "^12.22 || ^14.13 || >=16"
       }
     },
-    "node_modules/npm/node_modules/nopt": {
+    "node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
@@ -6569,8 +6641,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/npm/node_modules/nopt": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -6581,7 +6668,7 @@
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
@@ -6597,12 +6684,24 @@
       }
     },
     "node_modules/npm/node_modules/npm-bundled": {
-      "version": "1.1.2",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-normalize-package-bin": "^1.0.1"
+        "npm-normalize-package-bin": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
@@ -6624,12 +6723,13 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "9.0.2",
+      "version": "9.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^5.0.0",
+        "proc-log": "^2.0.1",
         "semver": "^7.3.5",
         "validate-npm-package-name": "^4.0.0"
       },
@@ -6638,15 +6738,15 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "5.0.0",
+      "version": "5.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^7.2.0",
+        "glob": "^8.0.1",
         "ignore-walk": "^5.0.1",
-        "npm-bundled": "^1.1.2",
-        "npm-normalize-package-bin": "^1.0.1"
+        "npm-bundled": "^2.0.0",
+        "npm-normalize-package-bin": "^2.0.0"
       },
       "bin": {
         "npm-packlist": "bin/index.js"
@@ -6655,14 +6755,23 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "7.0.1",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-install-checks": "^5.0.0",
-        "npm-normalize-package-bin": "^1.0.1",
+        "npm-normalize-package-bin": "^2.0.0",
         "npm-package-arg": "^9.0.0",
         "semver": "^7.3.5"
       },
@@ -6670,21 +6779,30 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "6.0.2",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^13.0.0",
+        "npm-registry-fetch": "^13.0.1",
         "proc-log": "^2.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "13.1.0",
+      "version": "13.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6708,18 +6826,18 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "are-we-there-yet": "^3.0.0",
         "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.0",
+        "gauge": "^4.0.3",
         "set-blocking": "^2.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/once": {
@@ -6756,7 +6874,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "13.1.1",
+      "version": "13.6.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6764,7 +6882,7 @@
         "@npmcli/git": "^3.0.0",
         "@npmcli/installed-package-contents": "^1.0.7",
         "@npmcli/promise-spawn": "^3.0.0",
-        "@npmcli/run-script": "^3.0.1",
+        "@npmcli/run-script": "^4.1.0",
         "cacache": "^16.0.0",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.1.0",
@@ -6772,7 +6890,7 @@
         "minipass": "^3.1.6",
         "mkdirp": "^1.0.4",
         "npm-package-arg": "^9.0.0",
-        "npm-packlist": "^5.0.0",
+        "npm-packlist": "^5.1.0",
         "npm-pick-manifest": "^7.0.0",
         "npm-registry-fetch": "^13.0.1",
         "proc-log": "^2.0.0",
@@ -6811,6 +6929,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/npm/node_modules/proc-log": {
@@ -6898,18 +7029,18 @@
       }
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "5.0.0",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^7.2.0",
+        "glob": "^8.0.1",
         "json-parse-even-better-errors": "^2.3.1",
         "normalize-package-data": "^4.0.0",
-        "npm-normalize-package-bin": "^1.0.1"
+        "npm-normalize-package-bin": "^2.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
@@ -6923,6 +7054,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/readable-stream": {
@@ -6975,6 +7115,48 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.2.1",
       "dev": true,
@@ -7003,18 +7185,30 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.3.6",
+      "version": "7.3.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^7.4.0"
+        "lru-cache": "^6.0.0"
       },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
-        "node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/set-blocking": {
@@ -7040,12 +7234,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.6.2",
+      "version": "2.7.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip": "^1.1.5",
+        "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -7054,14 +7248,14 @@
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "6.1.1",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
       },
       "engines": {
         "node": ">= 10"
@@ -7100,7 +7294,7 @@
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "9.0.0",
+      "version": "9.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7197,21 +7391,27 @@
       }
     },
     "node_modules/npm/node_modules/unique-filename": {
-      "version": "1.1.1",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "unique-slug": "^2.0.0"
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/unique-slug": {
-      "version": "2.0.2",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -7288,7 +7488,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7297,7 +7497,7 @@
         "signal-exit": "^3.0.7"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/yallist": {
@@ -8496,9 +8696,10 @@
       }
     },
     "node_modules/semver-regex": {
-      "version": "3.1.3",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -13220,7 +13421,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -13521,72 +13724,77 @@
       "dev": true
     },
     "npm": {
-      "version": "8.7.0",
+      "version": "8.19.3",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.3.tgz",
+      "integrity": "sha512-0QjmyPtDxSyMWWD8I91QGbrgx9KzbV6C9FK1liEb/K0zppiZkr5KxXc990G+LzPwBHDfRjUBlO9T1qZ08vl9mA==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.0.4",
+        "@npmcli/arborist": "^5.6.3",
         "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/config": "^4.1.0",
+        "@npmcli/config": "^4.2.1",
         "@npmcli/fs": "^2.1.0",
-        "@npmcli/map-workspaces": "^2.0.2",
+        "@npmcli/map-workspaces": "^2.0.3",
         "@npmcli/package-json": "^2.0.0",
-        "@npmcli/run-script": "^3.0.1",
+        "@npmcli/run-script": "^4.2.1",
         "abbrev": "~1.1.1",
         "archy": "~1.0.0",
-        "cacache": "^16.0.4",
+        "cacache": "^16.1.3",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.1",
+        "cli-table3": "^0.6.2",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.12",
-        "glob": "^7.2.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
         "graceful-fs": "^4.2.10",
-        "hosted-git-info": "^5.0.0",
-        "ini": "^3.0.0",
+        "hosted-git-info": "^5.2.1",
+        "ini": "^3.0.1",
         "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^6.0.2",
-        "libnpmdiff": "^4.0.2",
-        "libnpmexec": "^4.0.2",
-        "libnpmfund": "^3.0.1",
-        "libnpmhook": "^8.0.2",
-        "libnpmorg": "^4.0.2",
-        "libnpmpack": "^4.0.2",
-        "libnpmpublish": "^6.0.2",
-        "libnpmsearch": "^5.0.2",
-        "libnpmteam": "^4.0.2",
-        "libnpmversion": "^3.0.1",
-        "make-fetch-happen": "^10.1.2",
+        "libnpmaccess": "^6.0.4",
+        "libnpmdiff": "^4.0.5",
+        "libnpmexec": "^4.0.14",
+        "libnpmfund": "^3.0.5",
+        "libnpmhook": "^8.0.4",
+        "libnpmorg": "^4.0.4",
+        "libnpmpack": "^4.1.3",
+        "libnpmpublish": "^6.0.5",
+        "libnpmsearch": "^5.0.4",
+        "libnpmteam": "^4.0.4",
+        "libnpmversion": "^3.0.7",
+        "make-fetch-happen": "^10.2.0",
+        "minimatch": "^5.1.0",
         "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^9.0.0",
-        "nopt": "^5.0.0",
+        "node-gyp": "^9.1.0",
+        "nopt": "^6.0.0",
         "npm-audit-report": "^3.0.0",
         "npm-install-checks": "^5.0.0",
-        "npm-package-arg": "^9.0.2",
-        "npm-pick-manifest": "^7.0.1",
-        "npm-profile": "^6.0.2",
-        "npm-registry-fetch": "^13.1.0",
+        "npm-package-arg": "^9.1.0",
+        "npm-pick-manifest": "^7.0.2",
+        "npm-profile": "^6.2.0",
+        "npm-registry-fetch": "^13.3.1",
         "npm-user-validate": "^1.0.1",
-        "npmlog": "^6.0.1",
+        "npmlog": "^6.0.2",
         "opener": "^1.5.2",
-        "pacote": "^13.1.1",
+        "p-map": "^4.0.0",
+        "pacote": "^13.6.2",
         "parse-conflict-json": "^2.0.2",
         "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
-        "read-package-json": "^5.0.0",
+        "read-package-json": "^5.0.2",
         "read-package-json-fast": "^2.0.3",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.6",
-        "ssri": "^9.0.0",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.1",
         "tar": "^6.1.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
@@ -13596,6 +13804,12 @@
         "write-file-atomic": "^4.0.1"
       },
       "dependencies": {
+        "@colors/colors": {
+          "version": "1.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
         "@gar/promisify": {
           "version": "1.1.3",
           "bundled": true,
@@ -13607,33 +13821,36 @@
           "dev": true
         },
         "@npmcli/arborist": {
-          "version": "5.0.6",
+          "version": "5.6.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "@isaacs/string-locale-compare": "^1.1.0",
             "@npmcli/installed-package-contents": "^1.0.7",
-            "@npmcli/map-workspaces": "^2.0.0",
+            "@npmcli/map-workspaces": "^2.0.3",
             "@npmcli/metavuln-calculator": "^3.0.1",
             "@npmcli/move-file": "^2.0.0",
             "@npmcli/name-from-folder": "^1.0.1",
             "@npmcli/node-gyp": "^2.0.0",
             "@npmcli/package-json": "^2.0.0",
-            "@npmcli/run-script": "^3.0.0",
-            "bin-links": "^3.0.0",
-            "cacache": "^16.0.0",
+            "@npmcli/query": "^1.2.0",
+            "@npmcli/run-script": "^4.1.3",
+            "bin-links": "^3.0.3",
+            "cacache": "^16.1.3",
             "common-ancestor-path": "^1.0.1",
+            "hosted-git-info": "^5.2.1",
             "json-parse-even-better-errors": "^2.3.1",
             "json-stringify-nice": "^1.1.4",
+            "minimatch": "^5.1.0",
             "mkdirp": "^1.0.4",
             "mkdirp-infer-owner": "^2.0.0",
-            "nopt": "^5.0.0",
+            "nopt": "^6.0.0",
             "npm-install-checks": "^5.0.0",
             "npm-package-arg": "^9.0.0",
-            "npm-pick-manifest": "^7.0.0",
+            "npm-pick-manifest": "^7.0.2",
             "npm-registry-fetch": "^13.0.0",
-            "npmlog": "^6.0.1",
-            "pacote": "^13.0.5",
+            "npmlog": "^6.0.2",
+            "pacote": "^13.6.1",
             "parse-conflict-json": "^2.0.1",
             "proc-log": "^2.0.0",
             "promise-all-reject-late": "^1.0.0",
@@ -13641,7 +13858,7 @@
             "read-package-json-fast": "^2.0.2",
             "readdir-scoped-modules": "^1.1.0",
             "rimraf": "^3.0.2",
-            "semver": "^7.3.5",
+            "semver": "^7.3.7",
             "ssri": "^9.0.0",
             "treeverse": "^2.0.0",
             "walk-up-path": "^1.0.0"
@@ -13653,14 +13870,14 @@
           "dev": true
         },
         "@npmcli/config": {
-          "version": "4.1.0",
+          "version": "4.2.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/map-workspaces": "^2.0.2",
             "ini": "^3.0.0",
             "mkdirp-infer-owner": "^2.0.0",
-            "nopt": "^5.0.0",
+            "nopt": "^6.0.0",
             "proc-log": "^2.0.0",
             "read-package-json-fast": "^2.0.3",
             "semver": "^7.3.5",
@@ -13676,7 +13893,7 @@
           }
         },
         "@npmcli/fs": {
-          "version": "2.1.0",
+          "version": "2.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13685,7 +13902,7 @@
           }
         },
         "@npmcli/git": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13707,21 +13924,31 @@
           "requires": {
             "npm-bundled": "^1.1.1",
             "npm-normalize-package-bin": "^1.0.1"
+          },
+          "dependencies": {
+            "npm-bundled": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            }
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "2.0.2",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/name-from-folder": "^1.0.1",
-            "glob": "^7.2.0",
+            "glob": "^8.0.1",
             "minimatch": "^5.0.1",
             "read-package-json-fast": "^2.0.3"
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "3.1.0",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13732,7 +13959,7 @@
           }
         },
         "@npmcli/move-file": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13766,15 +13993,26 @@
             "infer-owner": "^1.0.4"
           }
         },
+        "@npmcli/query": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-package-arg": "^9.1.0",
+            "postcss-selector-parser": "^6.0.10",
+            "semver": "^7.3.7"
+          }
+        },
         "@npmcli/run-script": {
-          "version": "3.0.2",
+          "version": "4.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/node-gyp": "^2.0.0",
             "@npmcli/promise-spawn": "^3.0.0",
             "node-gyp": "^9.0.0",
-            "read-package-json-fast": "^2.0.3"
+            "read-package-json-fast": "^2.0.3",
+            "which": "^2.0.2"
           }
         },
         "@tootallnate/once": {
@@ -13838,7 +14076,7 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13857,16 +14095,23 @@
           "dev": true
         },
         "bin-links": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "cmd-shim": "^5.0.0",
             "mkdirp-infer-owner": "^2.0.0",
-            "npm-normalize-package-bin": "^1.0.0",
+            "npm-normalize-package-bin": "^2.0.0",
             "read-cmd-shim": "^3.0.0",
             "rimraf": "^3.0.0",
             "write-file-atomic": "^4.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "binary-extensions": {
@@ -13883,7 +14128,7 @@
           }
         },
         "builtins": {
-          "version": "5.0.0",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13891,7 +14136,7 @@
           }
         },
         "cacache": {
-          "version": "16.0.4",
+          "version": "16.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13899,7 +14144,7 @@
             "@npmcli/move-file": "^2.0.0",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.1.0",
-            "glob": "^7.2.0",
+            "glob": "^8.0.1",
             "infer-owner": "^1.0.4",
             "lru-cache": "^7.7.1",
             "minipass": "^3.1.6",
@@ -13912,7 +14157,7 @@
             "rimraf": "^3.0.2",
             "ssri": "^9.0.0",
             "tar": "^6.1.11",
-            "unique-filename": "^1.1.1"
+            "unique-filename": "^2.0.0"
           }
         },
         "chalk": {
@@ -13952,11 +14197,11 @@
           }
         },
         "cli-table3": {
-          "version": "0.6.1",
+          "version": "0.6.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "colors": "1.4.0",
+            "@colors/colors": "1.5.0",
             "string-width": "^4.2.0"
           }
         },
@@ -13991,12 +14236,6 @@
           "bundled": true,
           "dev": true
         },
-        "colors": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "columnify": {
           "version": "1.6.0",
           "bundled": true,
@@ -14018,6 +14257,11 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cssesc": {
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
@@ -14069,7 +14313,7 @@
           }
         },
         "diff": {
-          "version": "5.0.0",
+          "version": "5.1.0",
           "bundled": true,
           "dev": true
         },
@@ -14136,35 +14380,15 @@
           }
         },
         "glob": {
-          "version": "7.2.0",
+          "version": "8.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          },
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.11",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "minimatch": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            }
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
           }
         },
         "graceful-fs": {
@@ -14191,7 +14415,7 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "5.0.0",
+          "version": "5.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14214,7 +14438,7 @@
           }
         },
         "https-proxy-agent": {
-          "version": "5.0.0",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14277,7 +14501,7 @@
           "dev": true
         },
         "ini": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true
         },
@@ -14296,7 +14520,7 @@
           }
         },
         "ip": {
-          "version": "1.1.5",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
@@ -14314,7 +14538,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.8.1",
+          "version": "2.10.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14352,17 +14576,17 @@
           "dev": true
         },
         "just-diff": {
-          "version": "5.0.1",
+          "version": "5.1.1",
           "bundled": true,
           "dev": true
         },
         "just-diff-apply": {
-          "version": "5.2.0",
+          "version": "5.4.1",
           "bundled": true,
           "dev": true
         },
         "libnpmaccess": {
-          "version": "6.0.3",
+          "version": "6.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14373,49 +14597,51 @@
           }
         },
         "libnpmdiff": {
-          "version": "4.0.3",
+          "version": "4.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/disparity-colors": "^2.0.0",
             "@npmcli/installed-package-contents": "^1.0.7",
             "binary-extensions": "^2.2.0",
-            "diff": "^5.0.0",
+            "diff": "^5.1.0",
             "minimatch": "^5.0.1",
             "npm-package-arg": "^9.0.1",
-            "pacote": "^13.0.5",
+            "pacote": "^13.6.1",
             "tar": "^6.1.0"
           }
         },
         "libnpmexec": {
-          "version": "4.0.3",
+          "version": "4.0.14",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^5.0.0",
+            "@npmcli/arborist": "^5.6.3",
             "@npmcli/ci-detect": "^2.0.0",
-            "@npmcli/run-script": "^3.0.0",
+            "@npmcli/fs": "^2.1.1",
+            "@npmcli/run-script": "^4.2.0",
             "chalk": "^4.1.0",
             "mkdirp-infer-owner": "^2.0.0",
             "npm-package-arg": "^9.0.1",
-            "npmlog": "^6.0.1",
-            "pacote": "^13.0.5",
+            "npmlog": "^6.0.2",
+            "pacote": "^13.6.1",
             "proc-log": "^2.0.0",
             "read": "^1.0.7",
             "read-package-json-fast": "^2.0.2",
+            "semver": "^7.3.7",
             "walk-up-path": "^1.0.0"
           }
         },
         "libnpmfund": {
-          "version": "3.0.2",
+          "version": "3.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^5.0.0"
+            "@npmcli/arborist": "^5.6.3"
           }
         },
         "libnpmhook": {
-          "version": "8.0.3",
+          "version": "8.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14424,7 +14650,7 @@
           }
         },
         "libnpmorg": {
-          "version": "4.0.3",
+          "version": "4.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14433,29 +14659,29 @@
           }
         },
         "libnpmpack": {
-          "version": "4.0.3",
+          "version": "4.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/run-script": "^3.0.0",
+            "@npmcli/run-script": "^4.1.3",
             "npm-package-arg": "^9.0.1",
-            "pacote": "^13.0.5"
+            "pacote": "^13.6.1"
           }
         },
         "libnpmpublish": {
-          "version": "6.0.3",
+          "version": "6.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "normalize-package-data": "^4.0.0",
             "npm-package-arg": "^9.0.1",
             "npm-registry-fetch": "^13.0.0",
-            "semver": "^7.1.3",
+            "semver": "^7.3.7",
             "ssri": "^9.0.0"
           }
         },
         "libnpmsearch": {
-          "version": "5.0.3",
+          "version": "5.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14463,7 +14689,7 @@
           }
         },
         "libnpmteam": {
-          "version": "4.0.3",
+          "version": "4.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14472,29 +14698,29 @@
           }
         },
         "libnpmversion": {
-          "version": "3.0.3",
+          "version": "3.0.7",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/git": "^3.0.0",
-            "@npmcli/run-script": "^3.0.0",
+            "@npmcli/run-script": "^4.1.3",
             "json-parse-even-better-errors": "^2.3.1",
             "proc-log": "^2.0.0",
-            "semver": "^7.3.5"
+            "semver": "^7.3.7"
           }
         },
         "lru-cache": {
-          "version": "7.7.3",
+          "version": "7.13.2",
           "bundled": true,
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "10.1.2",
+          "version": "10.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "agentkeepalive": "^4.2.1",
-            "cacache": "^16.0.2",
+            "cacache": "^16.1.0",
             "http-cache-semantics": "^4.1.0",
             "http-proxy-agent": "^5.0.0",
             "https-proxy-agent": "^5.0.0",
@@ -14507,12 +14733,12 @@
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^0.6.3",
             "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^6.1.1",
+            "socks-proxy-agent": "^7.0.0",
             "ssri": "^9.0.0"
           }
         },
         "minimatch": {
-          "version": "5.0.1",
+          "version": "5.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14520,7 +14746,7 @@
           }
         },
         "minipass": {
-          "version": "3.1.6",
+          "version": "3.3.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14536,7 +14762,7 @@
           }
         },
         "minipass-fetch": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14619,7 +14845,7 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "9.0.0",
+          "version": "9.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14633,18 +14859,58 @@
             "semver": "^7.3.5",
             "tar": "^6.1.2",
             "which": "^2.0.2"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "glob": {
+              "version": "7.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "nopt": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "abbrev": "1"
+              }
+            }
           }
         },
         "nopt": {
-          "version": "5.0.0",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1"
+            "abbrev": "^1.0.0"
           }
         },
         "normalize-package-data": {
-          "version": "4.0.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14663,11 +14929,18 @@
           }
         },
         "npm-bundled": {
-          "version": "1.1.2",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-normalize-package-bin": "^1.0.1"
+            "npm-normalize-package-bin": "^2.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "npm-install-checks": {
@@ -14684,48 +14957,63 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "9.0.2",
+          "version": "9.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^5.0.0",
+            "proc-log": "^2.0.1",
             "semver": "^7.3.5",
             "validate-npm-package-name": "^4.0.0"
           }
         },
         "npm-packlist": {
-          "version": "5.0.0",
+          "version": "5.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.2.0",
+            "glob": "^8.0.1",
             "ignore-walk": "^5.0.1",
-            "npm-bundled": "^1.1.2",
-            "npm-normalize-package-bin": "^1.0.1"
+            "npm-bundled": "^2.0.0",
+            "npm-normalize-package-bin": "^2.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "npm-pick-manifest": {
-          "version": "7.0.1",
+          "version": "7.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "npm-install-checks": "^5.0.0",
-            "npm-normalize-package-bin": "^1.0.1",
+            "npm-normalize-package-bin": "^2.0.0",
             "npm-package-arg": "^9.0.0",
             "semver": "^7.3.5"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "npm-profile": {
-          "version": "6.0.2",
+          "version": "6.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^13.0.0",
+            "npm-registry-fetch": "^13.0.1",
             "proc-log": "^2.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "13.1.0",
+          "version": "13.3.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14744,13 +15032,13 @@
           "dev": true
         },
         "npmlog": {
-          "version": "6.0.1",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "are-we-there-yet": "^3.0.0",
             "console-control-strings": "^1.1.0",
-            "gauge": "^4.0.0",
+            "gauge": "^4.0.3",
             "set-blocking": "^2.0.0"
           }
         },
@@ -14776,14 +15064,14 @@
           }
         },
         "pacote": {
-          "version": "13.1.1",
+          "version": "13.6.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/git": "^3.0.0",
             "@npmcli/installed-package-contents": "^1.0.7",
             "@npmcli/promise-spawn": "^3.0.0",
-            "@npmcli/run-script": "^3.0.1",
+            "@npmcli/run-script": "^4.1.0",
             "cacache": "^16.0.0",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.1.0",
@@ -14791,7 +15079,7 @@
             "minipass": "^3.1.6",
             "mkdirp": "^1.0.4",
             "npm-package-arg": "^9.0.0",
-            "npm-packlist": "^5.0.0",
+            "npm-packlist": "^5.1.0",
             "npm-pick-manifest": "^7.0.0",
             "npm-registry-fetch": "^13.0.1",
             "proc-log": "^2.0.0",
@@ -14817,6 +15105,15 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
+          }
         },
         "proc-log": {
           "version": "2.0.1",
@@ -14874,14 +15171,21 @@
           "dev": true
         },
         "read-package-json": {
-          "version": "5.0.0",
+          "version": "5.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.2.0",
+            "glob": "^8.0.1",
             "json-parse-even-better-errors": "^2.3.1",
             "normalize-package-data": "^4.0.0",
-            "npm-normalize-package-bin": "^1.0.1"
+            "npm-normalize-package-bin": "^2.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "read-package-json-fast": {
@@ -14925,6 +15229,38 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "glob": {
+              "version": "7.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
           }
         },
         "safe-buffer": {
@@ -14939,11 +15275,21 @@
           "optional": true
         },
         "semver": {
-          "version": "7.3.6",
+          "version": "7.3.7",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^7.4.0"
+            "lru-cache": "^6.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "set-blocking": {
@@ -14962,22 +15308,22 @@
           "dev": true
         },
         "socks": {
-          "version": "2.6.2",
+          "version": "2.7.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip": "^1.1.5",
+            "ip": "^2.0.0",
             "smart-buffer": "^4.2.0"
           }
         },
         "socks-proxy-agent": {
-          "version": "6.1.1",
+          "version": "7.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "agent-base": "^6.0.2",
-            "debug": "^4.3.1",
-            "socks": "^2.6.1"
+            "debug": "^4.3.3",
+            "socks": "^2.6.2"
           }
         },
         "spdx-correct": {
@@ -15009,7 +15355,7 @@
           "dev": true
         },
         "ssri": {
-          "version": "9.0.0",
+          "version": "9.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15079,15 +15425,15 @@
           "dev": true
         },
         "unique-filename": {
-          "version": "1.1.1",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "unique-slug": "^2.0.0"
+            "unique-slug": "^3.0.0"
           }
         },
         "unique-slug": {
-          "version": "2.0.2",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15151,7 +15497,7 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15900,7 +16246,9 @@
       }
     },
     "semver-regex": {
-      "version": "3.1.3",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "dev": true
     },
     "send": {


### PR DESCRIPTION
Not sure why dependabot missed these ones.