### PR TITLE
fix: use `whatwg-url` instead of `url`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -819,6 +819,21 @@
         "@types/superagent": "*"
       }
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
+      "dev": true
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-4F6szvZP3FM5HvJAmcInXBfrAhvM4tLIc8MO1nXwabG5TZVOLxVmAXRpICqXYd3lBlomSRGmLCopYV+yTocgpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "license": "MIT",
@@ -8102,6 +8117,14 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/q": {
       "version": "1.5.1",
       "dev": true,
@@ -10332,7 +10355,8 @@
       "dependencies": {
         "@api-ts/io-ts-http": "0.0.0-semantically-released",
         "fp-ts": "2.13.1",
-        "io-ts": "2.1.3"
+        "io-ts": "2.1.3",
+        "whatwg-url": "11.0.0"
       },
       "devDependencies": {
         "@types/chai": "4.3.4",
@@ -10340,6 +10364,7 @@
         "@types/mocha": "10.0.1",
         "@types/superagent": "4.1.15",
         "@types/supertest": "2.0.12",
+        "@types/whatwg-url": "11.0.0",
         "body-parser": "1.20.1",
         "c8": "7.12.0",
         "chai": "4.3.7",
@@ -10350,6 +10375,17 @@
         "supertest": "6.3.2",
         "ts-node": "10.9.1",
         "typescript": "4.7.4"
+      }
+    },
+    "packages/superagent-wrapper/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/superagent-wrapper/node_modules/typescript": {
@@ -10363,6 +10399,26 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "packages/superagent-wrapper/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/superagent-wrapper/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/typed-express-router": {
@@ -10498,6 +10554,7 @@
         "@types/mocha": "10.0.1",
         "@types/superagent": "4.1.15",
         "@types/supertest": "2.0.12",
+        "@types/whatwg-url": "11.0.0",
         "body-parser": "1.20.1",
         "c8": "7.12.0",
         "chai": "4.3.7",
@@ -10509,14 +10566,37 @@
         "superagent": "8.0.3",
         "supertest": "6.3.2",
         "ts-node": "10.9.1",
-        "typescript": "4.7.4"
+        "typescript": "4.7.4",
+        "whatwg-url": "11.0.0"
       },
       "dependencies": {
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
         "typescript": {
           "version": "4.7.4",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
           "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
           "dev": true
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
         }
       }
     },
@@ -11145,6 +11225,21 @@
       "dev": true,
       "requires": {
         "@types/superagent": "*"
+      }
+    },
+    "@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
+      "dev": true
+    },
+    "@types/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-4F6szvZP3FM5HvJAmcInXBfrAhvM4tLIc8MO1nXwabG5TZVOLxVmAXRpICqXYd3lBlomSRGmLCopYV+yTocgpQ==",
+      "dev": true,
+      "requires": {
+        "@types/webidl-conversions": "*"
       }
     },
     "accepts": {
@@ -15965,6 +16060,11 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -19,20 +19,22 @@
   "dependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "fp-ts": "2.13.1",
-    "io-ts": "2.1.3"
+    "io-ts": "2.1.3",
+    "whatwg-url": "11.0.0"
   },
   "devDependencies": {
-    "@types/superagent": "4.1.15",
-    "@types/supertest": "2.0.12",
     "@types/chai": "4.3.4",
     "@types/express": "4.17.14",
     "@types/mocha": "10.0.1",
+    "@types/superagent": "4.1.15",
+    "@types/supertest": "2.0.12",
+    "@types/whatwg-url": "11.0.0",
     "body-parser": "1.20.1",
+    "c8": "7.12.0",
     "chai": "4.3.7",
     "express": "4.18.2",
     "io-ts-types": "0.5.19",
     "mocha": "10.1.0",
-    "c8": "7.12.0",
     "superagent": "8.0.3",
     "supertest": "6.3.2",
     "ts-node": "10.9.1",

--- a/packages/superagent-wrapper/src/request.ts
+++ b/packages/superagent-wrapper/src/request.ts
@@ -2,7 +2,7 @@ import * as h from '@api-ts/io-ts-http';
 import * as E from 'fp-ts/Either';
 import * as t from 'io-ts';
 import * as PathReporter from 'io-ts/lib/PathReporter';
-import { URL } from 'url';
+import { URL } from 'whatwg-url';
 import { pipe } from 'fp-ts/function';
 
 type SuccessfulResponses<Route extends h.HttpRoute> = {


### PR DESCRIPTION
Explicitly pulls in `whatwg-url` for url parsing, which should result in consistent behavior across the various environments that this library may be deployed in. This should resolve #314