### PR TITLE
fix: loosen constraint on fp-ts version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10255,7 +10255,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@api-ts/response": "0.0.0-semantically-released",
-        "fp-ts": "2.13.1",
+        "fp-ts": "^2.0.0",
         "io-ts": "2.1.3",
         "io-ts-types": "0.5.19"
       },
@@ -10268,6 +10268,11 @@
         "ts-node": "10.9.1",
         "typescript": "4.7.4"
       }
+    },
+    "packages/io-ts-http/node_modules/fp-ts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.0.0.tgz",
+      "integrity": "sha512-oz8L+EZiztqGVLhgdL+63b4hpfdJkEKH/4vRoS/AuUwYqmn7vHAzWMu1jtoYfB0pPxo5UioWVT2XOuftyivUSQ=="
     },
     "packages/io-ts-http/node_modules/typescript": {
       "version": "4.7.4",
@@ -10482,7 +10487,7 @@
         "@types/mocha": "10.0.1",
         "c8": "7.12.0",
         "chai": "4.3.7",
-        "fp-ts": "2.13.1",
+        "fp-ts": "^2.0.0",
         "io-ts": "2.1.3",
         "io-ts-types": "0.5.19",
         "mocha": "10.2.0",
@@ -10490,6 +10495,11 @@
         "typescript": "4.7.4"
       },
       "dependencies": {
+        "fp-ts": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.0.0.tgz",
+          "integrity": "sha512-oz8L+EZiztqGVLhgdL+63b4hpfdJkEKH/4vRoS/AuUwYqmn7vHAzWMu1jtoYfB0pPxo5UioWVT2XOuftyivUSQ=="
+        },
         "typescript": {
           "version": "4.7.4",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@api-ts/response": "0.0.0-semantically-released",
-    "fp-ts": "2.13.1",
+    "fp-ts": "^2.0.0",
     "io-ts": "2.1.3",
     "io-ts-types": "0.5.19"
   },

--- a/packages/io-ts-http/src/combinators.ts
+++ b/packages/io-ts-http/src/combinators.ts
@@ -1,4 +1,4 @@
-import { pipe } from 'fp-ts/function';
+import { pipe } from 'fp-ts/pipeable';
 import * as E from 'fp-ts/Either';
 import * as R from 'fp-ts/Record';
 import * as t from 'io-ts';


### PR DESCRIPTION
Widen io-ts-http's dependency on fp-ts from an exact version to
`^2.0.0`. This fosters deduplication of fp-ts and lets each consumer
choose which fp-ts version to use.