### PR TITLE
fix: loosen constraint on fp-ts version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10222,7 +10222,7 @@
       "dependencies": {
         "@api-ts/io-ts-http": "0.0.0-semantically-released",
         "express": "4.18.2",
-        "fp-ts": "2.13.1",
+        "fp-ts": "^2.0.0",
         "io-ts": "2.1.3"
       },
       "devDependencies": {
@@ -10352,7 +10352,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@api-ts/io-ts-http": "0.0.0-semantically-released",
-        "fp-ts": "2.13.1",
+        "fp-ts": "^2.0.0",
         "io-ts": "2.1.3",
         "whatwg-url": "11.0.0"
       },
@@ -10427,7 +10427,7 @@
         "@api-ts/io-ts-http": "0.0.0-semantically-released",
         "@types/express": "4.17.15",
         "express": "4.18.2",
-        "fp-ts": "2.13.1",
+        "fp-ts": "^2.0.0",
         "io-ts": "2.1.3"
       },
       "devDependencies": {
@@ -10465,7 +10465,7 @@
         "ava": "5.1.0",
         "c8": "7.12.0",
         "express": "4.18.2",
-        "fp-ts": "2.13.1",
+        "fp-ts": "^2.0.0",
         "io-ts": "2.1.3",
         "ts-node": "10.9.1",
         "typescript": "4.7.4"
@@ -10562,7 +10562,7 @@
         "c8": "7.12.0",
         "chai": "4.3.7",
         "express": "4.18.2",
-        "fp-ts": "2.13.1",
+        "fp-ts": "^2.0.0",
         "io-ts": "2.1.3",
         "io-ts-types": "0.5.19",
         "mocha": "10.2.0",
@@ -10613,7 +10613,7 @@
         "ava": "5.1.0",
         "c8": "7.12.0",
         "express": "4.18.2",
-        "fp-ts": "2.13.1",
+        "fp-ts": "^2.0.0",
         "io-ts": "2.1.3",
         "ts-node": "10.9.1",
         "typescript": "4.7.4"

--- a/packages/express-wrapper/package.json
+++ b/packages/express-wrapper/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "express": "4.18.2",
-    "fp-ts": "2.13.1",
+    "fp-ts": "^2.0.0",
     "io-ts": "2.1.3"
   },
   "devDependencies": {

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
-    "fp-ts": "2.13.1",
+    "fp-ts": "^2.0.0",
     "io-ts": "2.1.3",
     "whatwg-url": "11.0.0"
   },

--- a/packages/superagent-wrapper/src/request.ts
+++ b/packages/superagent-wrapper/src/request.ts
@@ -3,7 +3,7 @@ import * as E from 'fp-ts/Either';
 import * as t from 'io-ts';
 import * as PathReporter from 'io-ts/lib/PathReporter';
 import { URL } from 'whatwg-url';
-import { pipe } from 'fp-ts/function';
+import { pipe } from 'fp-ts/pipeable';
 
 type SuccessfulResponses<Route extends h.HttpRoute> = {
   [R in keyof Route['response']]: {

--- a/packages/typed-express-router/package.json
+++ b/packages/typed-express-router/package.json
@@ -20,7 +20,7 @@
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "@types/express": "4.17.15",
     "express": "4.18.2",
-    "fp-ts": "2.13.1",
+    "fp-ts": "^2.0.0",
     "io-ts": "2.1.3"
   },
   "devDependencies": {

--- a/packages/typed-express-router/src/index.ts
+++ b/packages/typed-express-router/src/index.ts
@@ -5,7 +5,7 @@
 import { ApiSpec, HttpRoute, KeyToHttpStatus } from '@api-ts/io-ts-http';
 import express from 'express';
 import * as E from 'fp-ts/Either';
-import { pipe } from 'fp-ts/function';
+import { pipe } from 'fp-ts/pipeable';
 import { defaultOnDecodeError, defaultOnEncodeError } from './errors';
 import { apiTsPathToExpress } from './path';
 import {


### PR DESCRIPTION
Widen io-ts-http's dependency on fp-ts from an exact version to
`^2.0.0`. This fosters deduplication of fp-ts and lets each consumer
choose which fp-ts version to use.