### PR TITLE
fix: expose middleware handler

### DIFF
--- a/packages/express-wrapper/src/middleware.ts
+++ b/packages/express-wrapper/src/middleware.ts
@@ -8,7 +8,7 @@ export type MiddlewareFn<T extends {}> = (
   res: express.Response,
 ) => Promise<T>;
 
-type MiddlewareHandler<T extends {} = {}> = {
+export type MiddlewareHandler<T extends {} = {}> = {
   (req: express.Request, res: express.Response, next: express.NextFunction): void;
   [MiddlewareBrand]: T;
 };


### PR DESCRIPTION
Access to the middleware handler type is a necessity for building type safe middleware chains