### PR TITLE
fix: relax io-ts-types constraint

### DIFF
--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -22,7 +22,7 @@
     "@api-ts/response": "0.0.0-semantically-released",
     "fp-ts": "^2.0.0",
     "io-ts": "2.1.3",
-    "io-ts-types": "0.5.19"
+    "io-ts-types": "^0.5.16"
   },
   "devDependencies": {
     "@types/chai": "4.3.4",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -25,7 +25,7 @@
     "comment-parser": "1.3.1",
     "fp-ts": "2.13.1",
     "io-ts": "2.1.3",
-    "io-ts-types": "0.5.19",
+    "io-ts-types": "^0.5.16",
     "openapi-types": "12.1.0",
     "ts-morph": "14.0.0",
     "typescript": "4.7.4"

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -33,7 +33,7 @@
     "c8": "7.12.0",
     "chai": "4.3.7",
     "express": "4.18.2",
-    "io-ts-types": "0.5.19",
+    "io-ts-types": "^0.5.16",
     "mocha": "10.2.0",
     "superagent": "8.0.5",
     "supertest": "6.3.3",


### PR DESCRIPTION
The existing constraint on io-ts-types version 0.5.19 prevents upgrading without resolving loads of package dependency issues in monorepos using 0.5.16 for example.