### PR TITLE
fix: loosen version constraint on io-ts-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10257,7 +10257,7 @@
         "@api-ts/response": "0.0.0-semantically-released",
         "fp-ts": "^2.0.0",
         "io-ts": "2.1.3",
-        "io-ts-types": "0.5.19"
+        "io-ts-types": "^0.5.15"
       },
       "devDependencies": {
         "@types/chai": "4.3.4",
@@ -10273,6 +10273,17 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.0.0.tgz",
       "integrity": "sha512-oz8L+EZiztqGVLhgdL+63b4hpfdJkEKH/4vRoS/AuUwYqmn7vHAzWMu1jtoYfB0pPxo5UioWVT2XOuftyivUSQ=="
+    },
+    "packages/io-ts-http/node_modules/io-ts-types": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.15.tgz",
+      "integrity": "sha512-SOKog7vxnrGybn92jxrLC7E6LSRC3nHzS4dadD1BK9cAiWyqXHerpbLq9zR3ZtQCJyNsSalpDPS1I4Jk2yzafg==",
+      "peerDependencies": {
+        "fp-ts": "^2.0.0",
+        "io-ts": "^2.0.0",
+        "monocle-ts": "^2.0.0",
+        "newtype-ts": "^0.3.2"
+      }
     },
     "packages/io-ts-http/node_modules/typescript": {
       "version": "4.7.4",
@@ -10489,7 +10500,7 @@
         "chai": "4.3.7",
         "fp-ts": "^2.0.0",
         "io-ts": "2.1.3",
-        "io-ts-types": "0.5.19",
+        "io-ts-types": "^0.5.15",
         "mocha": "10.2.0",
         "ts-node": "10.9.1",
         "typescript": "4.7.4"
@@ -10499,6 +10510,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.0.0.tgz",
           "integrity": "sha512-oz8L+EZiztqGVLhgdL+63b4hpfdJkEKH/4vRoS/AuUwYqmn7vHAzWMu1jtoYfB0pPxo5UioWVT2XOuftyivUSQ=="
+        },
+        "io-ts-types": {
+          "version": "0.5.15",
+          "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.15.tgz",
+          "integrity": "sha512-SOKog7vxnrGybn92jxrLC7E6LSRC3nHzS4dadD1BK9cAiWyqXHerpbLq9zR3ZtQCJyNsSalpDPS1I4Jk2yzafg==",
+          "requires": {}
         },
         "typescript": {
           "version": "4.7.4",

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -22,7 +22,7 @@
     "@api-ts/response": "0.0.0-semantically-released",
     "fp-ts": "^2.0.0",
     "io-ts": "2.1.3",
-    "io-ts-types": "0.5.19"
+    "io-ts-types": "^0.5.15"
   },
   "devDependencies": {
     "@types/chai": "4.3.4",


### PR DESCRIPTION
The most recent feature of io-ts-types that io-ts-http relies on is
`Json`, which was added in io-ts-types@0.5.15.