### PR TITLE
chore(dependabot): disable transitive upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
       - dependencies
       - npm
     allow:
-      - dependency-type: all
+      - dependency-type: direct
     ignore:
       - dependency-name: io-ts
         versions: ['2.x']


### PR DESCRIPTION
The level of churn introduced by indirect dependency upgrades is
introducing an unwelcome amount of toil and inflating the repository
size.