### PR TITLE
chore: reduce frequency of dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
       - npm
     allow:
       - dependency-type: direct
+    versioning-strategy: increase-if-necessary
     ignore:
       - dependency-name: io-ts
         versions: ['2.x']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
       - dependencies
       - npm
     allow:
-      - dependency-type: all
+      - dependency-type: direct
     ignore:
       - dependency-name: io-ts
         versions: ['2.x']


### PR DESCRIPTION
- disable transitive updates

  This will prevent lockfile-only updates.

- only bump semver ranges when necessary

  This should prevent PRs like #359 and #360 from introducing regressions.

  Relevant docs:
  https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy