### PR TITLE
chore(semantic-release): do not consider docs changes as patch releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,12 +1,6 @@
 {
   "plugins": [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        "preset": "angular",
-        "releaseRules": [{ "type": "docs", "release": "patch" }]
-      }
-    ],
+    "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semrel-extra/npm"
   ]


### PR DESCRIPTION
The motivation for treating the `docs` commit type as patch releases
is that our readmes are published to npm, so if we make a change
to a readme, use the `docs` commit type, and merge to master, we
will push the most recent documentation to npm.

I have since grown to dislike this approach, since it has notable
downsides:

1. increased toil for downstream users who monitor new releases
2. release notes don't include docs changes

   The release-notes-generator semantic-release plugin requires
   some (still unknown to me) configuration to mirror this
   commit-analyzer configuration. Without this, the two plugins
   are misaligned and will generate releases that apparently have no
   content.

I consider this to add more confusion than process was meant to solve.

Consequently, revert the customization to the commit-analyzer plugin
and when we need a docs change to create a new release, we can use the
following commit header:

```
fix(docs): <commit message>
```