### PR TITLE
chore(semantic-release): enable the GitHub plugin

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,6 +2,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semrel-extra/npm"
+    "@semrel-extra/npm",
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
The GitHub plugin[^1] publishes GitHub releases and comments on PRs and
issues.

This should be a baby step towards keeping developers aware of the
changes in each release.

[^1]: https://github.com/semantic-release/github