### PR TITLE
ci(semantic-release): include which package was published in PR comments

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,6 +3,11 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semrel-extra/npm",
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successComment": ":tada: This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.gitTag}</br></br>The release is available on [${releaseInfos[0].name}](${releaseInfos[0].url}) :tada:</br></br>Your **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package::rocket:"
+      }
+    ]
   ]
 }


### PR DESCRIPTION
The stock semantic-release tool assumes that one git repository maps
to one npm package. api-ts is using a monorepo, which breaks that
assumption. The multi-semantic-release package (msr) has let us use
semantic-release to publish multiple packages from a single repository,
but msr still invokes the default @semantic-release/github plugin
which does not include the package name in the default comment template.

This means on issues and PRs that cause multiple releases (for example,
a library causes itself to release and a depending package in the same
monorepo to release), we see multiple comments like the following[^1]:

```
This PR is included in version 1.0.1 :tada:
```

```
This PR is included in version 1.1.2 :tada:
```

which is both confusing and unhelpful.

This commit augments the PR comment template to include the name of the
released package in the comment, so when multiple comments are placed on
a single issue, there will be no confusion about _what_ package release
is being referenced.

This implementation has some limitations, because the custom-message
code flow uses lodash templates, which (try as I might) do not appear
as powerful as JavaScript code:

- no support for multiple registries

  This implemenation assumes your package will only publish to one npm registry,
  and that the data from this publish event includes both the name
  and url of the registry. (I see error-handling code in semantic-
  release/github in get-success-comment.js indicating this is not
  always the case.)

I tested this with the following code in a Node.js 18 repl:

```
> const _ = require('lodash')
> _.template(":tada: This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.gitTag}</br></br>The release is available on [${releaseInfos[0].name}](${releaseInfos[0].url}) :tada:</br></br>Your **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package::rocket:")({ issue: { pull_request: true }, nextRelease: { gitTag: "1.2.3-beta.4" }, releaseInfos: [{ name: "npm package (@latest dist-tag)", url: "https://google.com" }] })
':tada: This PR is included in version 1.2.3-beta.4</br></br>The release is available on [npm package (@latest dist-tag)](https://google.com) :tada:</br></br>Your **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package::rocket:'
```

[^1]: https://github.com/EricCrosson/numbers-ts/pull/14