### PR TITLE
chore: avoid referencing an undefined variable in success comment

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
     [
       "@semantic-release/github",
       {
-        "successComment": ":tada: This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.gitTag}</br></br>The release is available on [${releaseInfos[0].name}](${releaseInfos[0].url}) :tada:</br></br>Your **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package::rocket:"
+        "successComment": ":tada: This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.gitTag}</br></br>The release is available on [${releases[0].name}](${releases[0].url}) :tada:</br></br>Your **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package::rocket:"
       }
     ]
   ]


### PR DESCRIPTION
I originally referenced `releaseInfos` after seeing the
@semantic-release/github plugin[^1], but it turns out this is
not passed to a user-provided success-comment template[^2].

Let's see if using `releases` (from which `releaseInfos` is derived[^3])
directly works.

[^1]: https://github.com/semantic-release/github/blob/c58b719134f25661a665327cbf127d8bdf4d326d/lib/get-success-comment.js#L12
[^2]: https://github.com/semantic-release/github/blob/c58b719134f25661a665327cbf127d8bdf4d326d/lib/success.js#L83-L84
[^3]: https://github.com/semantic-release/github/blob/c58b719134f25661a665327cbf127d8bdf4d326d/lib/success.js#L45