### PR TITLE
Upgrade Prettier to 2.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "lint-staged": "13.1.0",
         "multi-semantic-release": "3.0.1",
         "pre-commit": "1.2.2",
-        "prettier": "2.8.1",
+        "prettier": "2.8.3",
         "turbo": "1.6.3",
         "typescript": "4.6.4"
       },
@@ -8043,9 +8043,9 @@
       "license": "ISC"
     },
     "node_modules/prettier": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -16036,9 +16036,9 @@
       }
     },
     "prettier": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
       "dev": true
     },
     "pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint-staged": "13.1.0",
     "multi-semantic-release": "3.0.1",
     "pre-commit": "1.2.2",
-    "prettier": "2.8.1",
+    "prettier": "2.8.3",
     "turbo": "1.6.3",
     "typescript": "4.6.4"
   },

--- a/packages/typed-express-router/src/index.ts
+++ b/packages/typed-express-router/src/index.ts
@@ -92,7 +92,7 @@ export function wrapRouter<Spec extends ApiSpec>(
         req.apiName = apiName;
         req.httpRoute = route;
         res.sendEncoded = (
-          status: keyof typeof route['response'],
+          status: keyof (typeof route)['response'],
           payload: unknown,
         ) => {
           try {


### PR DESCRIPTION
Some change in this patch version broke linting, so I pulled the branch down locally, ran `turbo run format:fix`, and committed the result.

Supersedes #374