### PR TITLE
chore(deps): remove unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/**"
       ],
       "devDependencies": {
-        "@semantic-release/npm": "9.0.2",
         "@semrel-extra/npm": "1.2.0",
         "@types/node": "18.11.7",
         "lint-staged": "13.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "pre-commit": "lint-staged",
   "devDependencies": {
-    "@semantic-release/npm": "9.0.2",
     "@semrel-extra/npm": "1.2.0",
     "@types/node": "18.11.7",
     "lint-staged": "13.1.0",


### PR DESCRIPTION
@semantic-release/npm is included in semantic-release
(which itself is a transitive dependency of multi-semantic-release).
Additionally, we aren't using @semantic-release/npm, we're using
@semrel-extra/npm which wraps @semantic-release/npm with a slight
patch which prevents npm from failing release workflows with an
error due to rate-limiting in a monorepo-release configuration.