### PR TITLE
ci: use @semantic-release-extras/github-comment-specific

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,11 +3,6 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semrel-extra/npm",
-    [
-      "@semantic-release/github",
-      {
-        "successComment": ":tada: This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.gitTag}</br></br>The release is available on [${releases[0].name}](${releases[0].url}) :tada:</br></br>Your **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package::rocket:"
-      }
-    ]
+    "@semantic-release-extras/github-comment-specific"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/**"
       ],
       "devDependencies": {
+        "@semantic-release-extras/github-comment-specific": "1.0.3",
         "@semrel-extra/npm": "1.2.0",
         "@types/node": "18.11.7",
         "lint-staged": "13.1.0",
@@ -444,6 +445,22 @@
         "@octokit/core": ">=3"
       }
     },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-4.3.2.tgz",
+      "integrity": "sha512-ZaCK599h3tzcoy0Jtdab95jgmD7X9iAk59E2E7hYKCAmnURaI4WpzwL9vckImilybUGrjY1JOWJapDs2N2D3vw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^8.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^4.0.0"
+      }
+    },
     "node_modules/@octokit/request": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.2.tgz",
@@ -522,6 +539,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@semantic-release-extras/github-comment-specific": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release-extras/github-comment-specific/-/github-comment-specific-1.0.3.tgz",
+      "integrity": "sha512-+c1Z7LjdOpOm3KJ9hHMO5Jy9NqNeFXr/jIXEgrP+9gIg5rePfloPPUU5Hjy4S7CVqo0M20K85VeFepx+8tfUaA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/plugin-throttling": "4.3.2",
+        "@octokit/rest": "19.0.5",
+        "@semantic-release/github": "8.0.7",
+        "issue-parser": "6.0.0"
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
@@ -10971,6 +11000,16 @@
         "deprecation": "^2.3.1"
       }
     },
+    "@octokit/plugin-throttling": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-4.3.2.tgz",
+      "integrity": "sha512-ZaCK599h3tzcoy0Jtdab95jgmD7X9iAk59E2E7hYKCAmnURaI4WpzwL9vckImilybUGrjY1JOWJapDs2N2D3vw==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^8.0.0",
+        "bottleneck": "^2.15.3"
+      }
+    },
     "@octokit/request": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.2.tgz",
@@ -11034,6 +11073,18 @@
       "requires": {
         "@pnpm/network.ca-file": "^1.0.1",
         "config-chain": "^1.1.11"
+      }
+    },
+    "@semantic-release-extras/github-comment-specific": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release-extras/github-comment-specific/-/github-comment-specific-1.0.3.tgz",
+      "integrity": "sha512-+c1Z7LjdOpOm3KJ9hHMO5Jy9NqNeFXr/jIXEgrP+9gIg5rePfloPPUU5Hjy4S7CVqo0M20K85VeFepx+8tfUaA==",
+      "dev": true,
+      "requires": {
+        "@octokit/plugin-throttling": "4.3.2",
+        "@octokit/rest": "19.0.5",
+        "@semantic-release/github": "8.0.7",
+        "issue-parser": "6.0.0"
       }
     },
     "@semantic-release/commit-analyzer": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "pre-commit": "lint-staged",
   "devDependencies": {
+    "@semantic-release-extras/github-comment-specific": "1.0.3",
     "@semrel-extra/npm": "1.2.0",
     "@types/node": "18.11.7",
     "lint-staged": "13.1.0",


### PR DESCRIPTION
This is a drop-in replacement for the standard @semantic-release/
github plugin. It exists to add specificity to the GitHub issue and PR
comments, so instead of commenting that

```
This PR is included in version {version}
```

it comments

```
This PR is included in version {package}@{version}
```

Read more:
https://github.com/semantic-release-extras/github-comment-specific

This PR is based on #378 