### PR TITLE
fix(superagent-wrapper): support non-`/` api base paths

### DIFF
--- a/packages/superagent-wrapper/src/request.ts
+++ b/packages/superagent-wrapper/src/request.ts
@@ -1,9 +1,10 @@
 import * as h from '@api-ts/io-ts-http';
 import * as E from 'fp-ts/Either';
+import { pipe } from 'fp-ts/pipeable';
 import * as t from 'io-ts';
 import * as PathReporter from 'io-ts/lib/PathReporter';
+import { posix } from 'path';
 import { URL } from 'whatwg-url';
-import { pipe } from 'fp-ts/pipeable';
 
 type SuccessfulResponses<Route extends h.HttpRoute> = {
   [R in keyof Route['response']]: {
@@ -85,7 +86,8 @@ export const superagentRequestFactory =
       throw Error(`Unsupported http method "${route.method}"`);
     }
     const url = new URL(base);
-    url.pathname = substitutePathParams(route.path, params);
+    const substitutedPath = substitutePathParams(route.path, params);
+    url.pathname = posix.join(url.pathname, substitutedPath);
     return superagent[method](url.toString());
   };
 


### PR DESCRIPTION
This should fix #337. I initially tried to use an alternate URL constructor like:
```
const url = new URL(substitutedPath, basePath);
```
and was surprised to learn that this actually has the exact same behavior of stripping the base path. It seems like it should be possible to make the substituted path a relative one, but that [has issues as well](https://github.com/whatwg/url/issues/531).

Ultimately I pulled in `posix.join` from `path`. This works, but may potentially introduce issues with some web bundlers if they don't provide an implementation of Node's `path` module.