### PR TITLE
chore(superagent-wrapper): move fp-ts to a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10476,7 +10476,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@api-ts/io-ts-http": "0.0.0-semantically-released",
-        "fp-ts": "^2.0.0",
         "io-ts": "2.1.3",
         "whatwg-url": "12.0.0"
       },
@@ -10497,6 +10496,9 @@
         "supertest": "6.3.3",
         "ts-node": "10.9.1",
         "typescript": "4.7.4"
+      },
+      "peerDependencies": {
+        "fp-ts": "^2.0.0"
       }
     },
     "packages/superagent-wrapper/node_modules/tr46": {
@@ -10692,7 +10694,6 @@
         "c8": "7.12.0",
         "chai": "4.3.7",
         "express": "4.18.2",
-        "fp-ts": "^2.0.0",
         "io-ts": "2.1.3",
         "io-ts-types": "0.5.19",
         "mocha": "10.2.0",

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
-    "fp-ts": "^2.0.0",
     "io-ts": "2.1.3",
     "whatwg-url": "12.0.0"
   },
@@ -39,6 +38,9 @@
     "supertest": "6.3.3",
     "ts-node": "10.9.1",
     "typescript": "4.7.4"
+  },
+  "peerDependencies": {
+    "fp-ts": "^2.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Packages using superagent-wrapper also typically use fp-ts. Moving fp-ts to a peer dependency of superagent-wrapper to avoid collisions of fp-ts versions between superagent-wrapper and packages that use superagent-wrapper

Ticket: BG-66089