### PR TITLE
feat(openapi-generator): ability to output yaml specs if needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10426,7 +10426,8 @@
         "io-ts-types": "0.5.19",
         "openapi-types": "12.1.0",
         "ts-morph": "14.0.0",
-        "typescript": "4.7.4"
+        "typescript": "4.7.4",
+        "yaml": "^2.2.1"
       },
       "bin": {
         "openapi-generator": "dist/src/cli.js"
@@ -10449,6 +10450,14 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "packages/openapi-generator/node_modules/yaml": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "packages/response": {
@@ -10656,13 +10665,19 @@
         "parser-ts": "0.6.16",
         "ts-morph": "14.0.0",
         "ts-node": "10.9.1",
-        "typescript": "4.7.4"
+        "typescript": "4.7.4",
+        "yaml": "*"
       },
       "dependencies": {
         "typescript": {
           "version": "4.7.4",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
           "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+        },
+        "yaml": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+          "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw=="
         }
       }
     },

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -28,7 +28,8 @@
     "io-ts-types": "0.5.19",
     "openapi-types": "12.1.0",
     "ts-morph": "14.0.0",
-    "typescript": "4.7.4"
+    "typescript": "4.7.4",
+    "yaml": "^2.2.1"
   },
   "devDependencies": {
     "@ava/typescript": "3.0.1",

--- a/packages/openapi-generator/src/cli.ts
+++ b/packages/openapi-generator/src/cli.ts
@@ -6,6 +6,7 @@ import * as E from 'fp-ts/Either';
 import * as fs from 'fs';
 import * as p from 'path';
 import { promisify } from 'util';
+import * as yaml from 'yaml';
 
 import { componentsForProject } from './project';
 
@@ -75,7 +76,9 @@ const app = command({
         (api) => api,
       ),
     );
-    const formattedApi = JSON.stringify(api, null, 2) + '\n';
+    const formattedApi = output.includes('.yaml')
+      ? yaml.stringify(api, null, 2) + '\n'
+      : JSON.stringify(api, null, 2) + '\n';
     await writeFile(output, formattedApi);
   },
 });


### PR DESCRIPTION
Ticket: BG-66640. 

Changes: 
- Added the ability to output a yaml version of the OpenAPI spec if the output file (specified using the --output option on the cli) has a .yaml extension.