### PR TITLE
chore(dependabot): disable typescript 5 upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
       - dependency-name: io-ts
         versions: ['2.x']
       - dependency-name: typescript
-        versions: ['^4.8']
+        versions: ['^>4.8']
       - dependency-name: ts-morph
         versions: ['>=16']
       # Ignore all @types/nodes patch updates, since


### PR DESCRIPTION
io-ts 2.1.3 is not compatible with typescript >4.8, so improve the
semver range disabling automated upgrade PRs to include typescript 5 and
higher (for now).

This is not where we want to keep api-ts long term, so regard this as
a medium-term solution.

Supersedes #424