### PR TITLE
api-ts openapi-generator updates

### DIFF
--- a/packages/openapi-generator/src/expression.ts
+++ b/packages/openapi-generator/src/expression.ts
@@ -174,6 +174,21 @@ const SPECIAL_CASES: SpecialCaseMap = {
         })),
       ),
   },
+  'query-param-types/dist/src/index': {
+    nonEmptyArrayFromQueryParam: (location) =>
+      pipe(
+        getFirstArgument(location),
+        RE.chain(toOpenAPISchema),
+        RE.map(({ schema }) => ({
+          schema: {
+            title: 'NonEmptyArrayFromQueryParam',
+            type: 'array',
+            items: schema,
+          },
+          required: true,
+        })),
+      ),
+  },
   'io-ts-types/lib/DateFromISOString': {
     DateFromISOString: () =>
       RE.right({
@@ -190,7 +205,7 @@ const SPECIAL_CASES: SpecialCaseMap = {
         getFirstArgument(location),
         RE.chain(toOpenAPISchema),
         RE.map(({ schema }) => ({
-          schema: { type: 'array', items: schema },
+          schema,
           required: false,
         })),
       ),

--- a/packages/openapi-generator/src/project.ts
+++ b/packages/openapi-generator/src/project.ts
@@ -89,6 +89,8 @@ const routesForSymbol =
               body,
               responses,
               summary,
+              operationId,
+              tags,
               description,
               isPrivate,
             },
@@ -101,6 +103,8 @@ const routesForSymbol =
                     ...paths[path],
                     [method]: {
                       summary,
+                      operationId,
+                      tags,
                       ...(description !== undefined ? { description } : {}),
                       ...(isPrivate ? { 'x-internal': true } : {}),
                       parameters: [
@@ -165,6 +169,11 @@ export function componentsForProject(
         title: config.name,
         version: version,
       },
+      servers: [
+        {
+          url: '',
+        },
+      ],
       paths,
       components: {
         schemas: memo,


### PR DESCRIPTION
[feat(generator): parse route operationId, platform tags, summary](https://github.com/BitGo/api-ts/commit/e06fe9476a123492306825bc97faac65783fdc34)
- Ability to parse `@operationId` jsDoc tag on `httpRoute` definitions. This populates the URL in the `dev-portal`.
- Ability to parse `@summary` jsDoc tag on `httpRoute` definitions. Previously the summary in the openAPI spec would be the name given to the `httpRoute`. This update lets you set a summary. The summary populates the LHS navigation for the route in the `dev-portal`.
- Ability to parse `@tags` jsDoc tag on `httpRoute` definitions. These are the tags that go into `platform.yaml` in the `api-docs` package and under your kit name in `dev-portal`. This allows for proper grouping/classification of your routes on the developer portal.

[feat: parse nonEmptyArrayFromQueryParam, schema for optional](https://github.com/BitGo/api-ts/commit/d95a4d738b0f5ca365b51be17e94066a059b458a)
- Ability to parse `nonEmptyArrayFromQueryParam` codec in request bodies. 
- Fixed the schema for the `optional` codec. Previously `optional` would translate to an array type which is wrong. 