### PR TITLE
chore(dependabot): fix typo in semver range

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
       - dependency-name: io-ts
         versions: ['2.x']
       - dependency-name: typescript
-        versions: ['^>4.8']
+        versions: ['>4.8']
       - dependency-name: ts-morph
         versions: ['>=16']
       # Ignore all @types/nodes patch updates, since


### PR DESCRIPTION
This range was intended to ignore all versions greater than 4.8, but
there is a typo that renders the range invalid.