### PR TITLE
feat!: move to peerDependencies

### DIFF
--- a/packages/express-wrapper/package.json
+++ b/packages/express-wrapper/package.json
@@ -16,7 +16,7 @@
     "format:fix": "prettier --write .",
     "test": "c8 --all ava"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "express": "4.18.2",
     "fp-ts": "^2.0.0",

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -18,7 +18,7 @@
     "format:fix": "prettier --write .",
     "test": "c8 mocha test/**/*.test.ts --require ts-node/register --exit"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@api-ts/response": "0.0.0-semantically-released",
     "fp-ts": "^2.0.0",
     "io-ts": "2.1.3",

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -16,7 +16,7 @@
     "format:fix": "prettier --write .",
     "test": "c8 --all mocha test/**/*.test.ts --require ts-node/register --exit"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "fp-ts": "^2.0.0",
     "io-ts": "2.1.3",

--- a/packages/typed-express-router/package.json
+++ b/packages/typed-express-router/package.json
@@ -16,7 +16,7 @@
     "format:fix": "prettier --write .",
     "test": "c8 --all ava"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "@types/express": "4.17.17",
     "express": "4.18.2",


### PR DESCRIPTION
Moving to peerDependencies to reduce duplication of package dependency installations leading to type conflicts - io-ts and related packages are particularly suceptible to type conflicts when duplicate installations are in play.

BREAKING CHANGE: move to peerDependencies