### PR TITLE
chore: ignore updates of whatwg-url >=13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,13 +24,13 @@ updates:
       - dependency-type: direct
     versioning-strategy: increase-if-necessary
     ignore:
-      - dependency-name: io-ts
-        versions: ['2.x']
-      - dependency-name: typescript
-        versions: ['>4.8']
-      - dependency-name: ts-morph
-        versions: ['>=16']
       # Ignore all @types/nodes patch updates, since
       # this package updates so frequently
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-patch']
+      - dependency-name: io-ts
+        versions: ['2.x']
+      - dependency-name: ts-morph
+        versions: ['>=16']
+      - dependency-name: typescript
+        versions: ['>4.8']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,5 @@ updates:
         versions: ['>=16']
       - dependency-name: typescript
         versions: ['>4.8']
+      - dependency-name: whatwg-url
+        versions: ['>=13']


### PR DESCRIPTION
whatwg-url@13's minimum-supported Node.js version (MSNV) is Node.js 16. api-ts still supports Node.js 14, so whatwg-url@13 is incompatible with api-ts right now.

This commit silences dependabot alerts to update whatwg-url to version 13 or higher. When api-ts' MSNV is 16, we will revert this diff (tracked by VL-497).

This PR supersedes #472.