### PR TITLE
feat(io-ts-http): Add PATCH http Method To Api-ts

### DIFF
--- a/packages/io-ts-http/README.md
+++ b/packages/io-ts-http/README.md
@@ -131,7 +131,7 @@ value; for example:
 import { apiSpec } from '@api-ts/io-ts-http';
 
 import { GetMessage, CreateMessage } from './routes/message';
-import { GetUser, CreateUser, UpdateUser, DeleteUser } from './routes/user';
+import { GetUser, CreateUser, PatchUser, UpdateUser, DeleteUser } from './routes/user';
 
 /**
  * message-user service
@@ -148,6 +148,7 @@ export const API = apiSpec({
     post: CreateUser,
     put: UpdateUser,
     delete: DeleteUser,
+    patch: PatchUser,
   },
 });
 ```

--- a/packages/io-ts-http/docs/apiSpec.md
+++ b/packages/io-ts-http/docs/apiSpec.md
@@ -13,7 +13,7 @@ not do anything aside from enforce the correct type of the parameter passed to i
 import { apiSpec } from '@api-ts/io-ts-http';
 
 import { GetMessage, CreateMessage } from './routes/message';
-import { GetUser, CreateUser, UpdateUser, DeleteUser } from './routes/user';
+import { GetUser, CreateUser, PatchUser, UpdateUser, DeleteUser } from './routes/user';
 
 /**
  * Example service
@@ -30,6 +30,7 @@ export const API = apiSpec({
     post: CreateUser,
     put: UpdateUser,
     delete: DeleteUser,
+    patch: PatchUser,
   },
 });
 ```

--- a/packages/io-ts-http/src/httpRoute.ts
+++ b/packages/io-ts-http/src/httpRoute.ts
@@ -8,6 +8,7 @@ export const Method = t.keyof({
   post: 1,
   put: 1,
   delete: 1,
+  patch: 1,
 });
 
 export type Method = t.TypeOf<typeof Method>;
@@ -39,7 +40,7 @@ type UnknownKeysToError<Spec extends ApiSpec> = {
   [ApiAction in keyof Spec]: {
     [M in keyof Spec[ApiAction]]: M extends Method
       ? Spec[ApiAction][M]
-      : `Unsupported HTTP Method. Use "get" | "post" | "put" | "delete"`;
+      : `Unsupported HTTP Method. Use "get" | "post" | "put" | "delete" | "patch"`;
   };
 };
 

--- a/packages/typed-express-router/src/index.ts
+++ b/packages/typed-express-router/src/index.ts
@@ -191,10 +191,12 @@ export function wrapRouter<Spec extends ApiSpec>(
       post: makeAddRoute('post'),
       put: makeAddRoute('put'),
       delete: makeAddRoute('delete'),
+      patch: makeAddRoute('patch'),
       getUnchecked: makeAddUncheckedRoute('get'),
       postUnchecked: makeAddUncheckedRoute('post'),
       putUnchecked: makeAddUncheckedRoute('put'),
       deleteUnchecked: makeAddUncheckedRoute('delete'),
+      patchUnchecked: makeAddUncheckedRoute('patch'),
       use: (middleware: UncheckedRequestHandler) => {
         routerMiddleware.push(middleware);
       },

--- a/packages/typed-express-router/src/types.ts
+++ b/packages/typed-express-router/src/types.ts
@@ -114,7 +114,7 @@ export type AddUncheckedRouteHandler<Spec extends ApiSpec, Method extends Method
  */
 export type WrappedRouter<Spec extends ApiSpec> = Omit<
   express.Router,
-  'get' | 'post' | 'put' | 'delete' | 'use'
+  'get' | 'post' | 'put' | 'delete' | 'use' | 'patch'
 > &
   express.RequestHandler & {
     use: (middleware: UncheckedRequestHandler<ApiSpec, string, HttpMethod>) => void;
@@ -122,8 +122,10 @@ export type WrappedRouter<Spec extends ApiSpec> = Omit<
     post: AddRouteHandler<Spec, 'post'>;
     put: AddRouteHandler<Spec, 'put'>;
     delete: AddRouteHandler<Spec, 'delete'>;
+    patch: AddRouteHandler<Spec, 'patch'>;
     getUnchecked: AddUncheckedRouteHandler<Spec, 'get'>;
     postUnchecked: AddUncheckedRouteHandler<Spec, 'post'>;
     putUnchecked: AddUncheckedRouteHandler<Spec, 'put'>;
     deleteUnchecked: AddUncheckedRouteHandler<Spec, 'delete'>;
+    patchUnchecked: AddUncheckedRouteHandler<Spec, 'patch'>;
   };


### PR DESCRIPTION
We currently use `api-ts` in one of our internal services, and we recently came across a limitation wherein we needed to use the `PATCH` http method, but, the `api-ts` service currently doesn't support it. As part of PR, we're introducing the `PATCH` http method within api-ts.

## Changes
- Modified: packages/io-ts-http/README.md
- Modified: packages/io-ts-http/docs/apiSpec.md
- Modified: packages/io-ts-http/src/httpRoute.ts
- Modified: packages/typed-express-router/src/index.ts
- Modified: packages/typed-express-router/src/types.ts

[COPS-151](https://bitgoinc.atlassian.net/browse/COPS-151)

[COPS-151]: https://bitgoinc.atlassian.net/browse/COPS-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ