### PR TITLE
fix(express-wrapper): dont override status code in req

### DIFF
--- a/packages/express-wrapper/src/request.ts
+++ b/packages/express-wrapper/src/request.ts
@@ -131,7 +131,10 @@ export const handleRequest = (
         const response = await serviceFn(handlerParams);
         responseEncoder(httpRoute, response)(req, res, next);
       } catch (err) {
-        res.status(500).end();
+        if (!res.statusCode) {
+          res.status(500);
+        }
+        res.end();
         next();
         return;
       }


### PR DESCRIPTION
In the event of an error in handleRequest,
only set the status code on the request if it hasn't already been set.

Overriding the status code in the event of an error results in incorrect reporting of the error status code using plugins such as prom-bundle to generate metrics.