### PR TITLE
fix(openapi-generator): process refs in a queue rather than recursively

### DIFF
--- a/packages/openapi-generator/src/state.ts
+++ b/packages/openapi-generator/src/state.ts
@@ -1,0 +1,22 @@
+import type { OpenAPIV3_1 } from 'openapi-types';
+import { Symbol } from 'ts-morph';
+
+export class State {
+  private knownRefs: Set<string> = new Set();
+  private refQueue: Symbol[] = [];
+
+  visitRef = (ref: Symbol): OpenAPIV3_1.ReferenceObject => {
+    const unaliasedName = ref.getFullyQualifiedName();
+    if (!this.knownRefs.has(unaliasedName)) {
+      this.knownRefs.add(unaliasedName);
+      this.refQueue.push(ref);
+    }
+    return {
+      $ref: `#/components/schemas/${ref.getName()}`,
+    };
+  };
+
+  dequeueRef = (): Symbol | undefined => {
+    return this.refQueue.shift();
+  };
+}


### PR DESCRIPTION
This fixes stack overflow errors in large schemas by implementing a queue for refs. While processing a type, when a ref is encountered, an openapi `ReferenceObject` is immediately emitted, and the expression and symbol are added to a queue for processing after the routes are done.

In addition, nearly all uses of `ReaderEither` are removed and explicit type annotations are added for most functions. This should help with maintainability and future refactoring.