### PR TITLE
feat: handle apiSpec spread elements in openapi-generator

### DIFF
--- a/packages/openapi-generator/test/apiSpec.test.ts
+++ b/packages/openapi-generator/test/apiSpec.test.ts
@@ -1,17 +1,26 @@
 import * as E from 'fp-ts/lib/Either';
 import assert from 'node:assert';
 import test from 'node:test';
+import type { NestedDirectoryJSON } from 'memfs';
 
-import { parseSource, parseApiSpec, Project, type Route } from '../src';
+import { TestProject } from './testProject';
+import { parseApiSpec, type Route } from '../src';
 
 async function testCase(
   description: string,
-  src: string,
+  files: NestedDirectoryJSON,
+  entryPoint: string,
   expected: Record<string, Route[]>,
   expectedErrors: string[] = [],
 ) {
   test(description, async () => {
-    const sourceFile = await parseSource('./index.ts', src);
+    const project = new TestProject(files);
+
+    await project.parseEntryPoint(entryPoint);
+    const sourceFile = project.get(entryPoint);
+    if (sourceFile === undefined) {
+      throw new Error(`could not find source file ${entryPoint}`);
+    }
 
     const actual: Record<string, Route[]> = {};
     const errors: string[] = [];
@@ -32,7 +41,7 @@ async function testCase(
         if (arg.expression.type !== 'ObjectExpression') {
           continue;
         }
-        const result = parseApiSpec(new Project(), sourceFile, arg.expression);
+        const result = parseApiSpec(project, sourceFile, arg.expression);
         if (E.isLeft(result)) {
           errors.push(result.left);
         } else {
@@ -46,86 +55,161 @@ async function testCase(
   });
 }
 
-const SIMPLE = `
-import * as t from 'io-ts';
-import * as h from '@api-ts/io-ts-http';
-export const test = h.apiSpec({
-  'api.test': {
-    get: h.httpRoute({
+const SIMPLE = {
+  '/index.ts': `
+    import * as t from 'io-ts';
+    import * as h from '@api-ts/io-ts-http';
+    export const test = h.apiSpec({
+      'api.test': {
+        get: h.httpRoute({
+          path: '/test',
+          method: 'GET',
+          request: h.httpRequest({}),
+          response: {
+            200: t.string,
+          },
+        })
+      }
+    });`,
+};
+
+testCase('simple api spec', SIMPLE, '/index.ts', {
+  test: [
+    {
+      path: '/test',
+      method: 'GET',
+      parameters: [],
+      response: { 200: { type: 'primitive', value: 'string' } },
+    },
+  ],
+});
+
+const ROUTE_REF = {
+  '/index.ts': `
+    import * as t from 'io-ts';
+    import * as h from '@api-ts/io-ts-http';
+
+    const testRoute = h.httpRoute({
       path: '/test',
       method: 'GET',
       request: h.httpRequest({}),
       response: {
         200: t.string,
       },
-    })
-  }
-});
-`;
+    });
 
-testCase('simple api spec', SIMPLE, {
-  test: [
-    {
-      path: '/test',
-      method: 'GET',
-      parameters: [],
-      response: { 200: { type: 'primitive', value: 'string' } },
-    },
-  ],
-});
-
-const ROUTE_REF = `
-import * as t from 'io-ts';
-import * as h from '@api-ts/io-ts-http';
-
-const testRoute = h.httpRoute({
-  path: '/test',
-  method: 'GET',
-  request: h.httpRequest({}),
-  response: {
-    200: t.string,
-  },
-});
-
-export const test = h.apiSpec({
-  'api.test': {
-    get: testRoute,
-  }
-});
-`;
-
-testCase('const route reference', ROUTE_REF, {
-  test: [
-    {
-      path: '/test',
-      method: 'GET',
-      parameters: [],
-      response: { 200: { type: 'primitive', value: 'string' } },
-    },
-  ],
-});
-
-const ACTION_REF = `
-import * as t from 'io-ts';
-import * as h from '@api-ts/io-ts-http';
-
-const testAction = {
-  get: h.httpRoute({
-    path: '/test',
-    method: 'GET',
-    request: h.httpRequest({}),
-    response: {
-      200: t.string,
-    },
-  }),
+    export const test = h.apiSpec({
+      'api.test': {
+        get: testRoute,
+      }
+    });`,
 };
 
-export const test = h.apiSpec({
-  'api.test': testAction,
+testCase('const route reference', ROUTE_REF, '/index.ts', {
+  test: [
+    {
+      path: '/test',
+      method: 'GET',
+      parameters: [],
+      response: { 200: { type: 'primitive', value: 'string' } },
+    },
+  ],
 });
-`;
 
-testCase('const action reference', ACTION_REF, {
+const ACTION_REF = {
+  '/index.ts': `
+    import * as t from 'io-ts';
+    import * as h from '@api-ts/io-ts-http';
+
+    const testAction = {
+      get: h.httpRoute({
+        path: '/test',
+        method: 'GET',
+        request: h.httpRequest({}),
+        response: {
+          200: t.string,
+        },
+      }),
+    };
+
+    export const test = h.apiSpec({
+      'api.test': testAction,
+    });`,
+};
+
+testCase('const action reference', ACTION_REF, '/index.ts', {
+  test: [
+    {
+      path: '/test',
+      method: 'GET',
+      parameters: [],
+      response: { 200: { type: 'primitive', value: 'string' } },
+    },
+  ],
+});
+
+const SPREAD = {
+  '/index.ts': `
+    import * as h from '@api-ts/io-ts-http';
+
+    import { Ref } from './ref';
+
+    export const test = h.apiSpec({
+      ...Ref,
+    });`,
+  '/ref.ts': `
+    import * as t from 'io-ts';
+    import * as h from '@api-ts/io-ts-http';
+    export const Ref = {
+      'api.test': {
+        get: h.httpRoute({
+          path: '/test',
+          method: 'GET',
+          request: h.httpRequest({}),
+          response: {
+            200: t.string,
+          },
+        })
+      }
+    };
+  `,
+};
+
+testCase('spread api spec', SPREAD, '/index.ts', {
+  test: [
+    {
+      path: '/test',
+      method: 'GET',
+      parameters: [],
+      response: { 200: { type: 'primitive', value: 'string' } },
+    },
+  ],
+});
+
+const COMPUTED_PROPERTY = {
+  '/index.ts': `
+    import * as t from 'io-ts';
+    import * as h from '@api-ts/io-ts-http';
+
+    function test(): 'api.test' {
+      return 'api.test';
+    }
+
+    export const test = h.apiSpec({
+      [test()]: {
+        get: h.httpRoute({
+          path: '/test',
+          method: 'GET',
+          request: h.httpRequest({}),
+          response: {
+            200: t.string,
+          },
+        })
+      }
+    });`,
+};
+
+testCase('computed property api spec', COMPUTED_PROPERTY, '/index.ts', {
   test: [
     {
       path: '/test',

--- a/packages/openapi-generator/test/resolve.test.ts
+++ b/packages/openapi-generator/test/resolve.test.ts
@@ -1,70 +1,10 @@
 import * as E from 'fp-ts/lib/Either';
-import { Volume, type NestedDirectoryJSON } from 'memfs';
-import resolve from 'resolve';
+import { type NestedDirectoryJSON } from 'memfs';
 import assert from 'node:assert';
 import test from 'node:test';
-import { promisify } from 'util';
 
+import { TestProject } from './testProject';
 import { parseCodecInitializer, Project, type Schema } from '../src';
-
-class TestProject extends Project {
-  private volume: ReturnType<(typeof Volume)['fromJSON']>;
-
-  constructor(files: NestedDirectoryJSON) {
-    super();
-    this.volume = Volume.fromNestedJSON(files, '/');
-  }
-
-  override async readFile(filename: string): Promise<string> {
-    const file: any = await promisify(this.volume.readFile.bind(this.volume))(filename);
-    return file.toString('utf-8');
-  }
-
-  override resolve(basedir: string, path: string): E.Either<string, string> {
-    try {
-      const result = resolve.sync(path, {
-        basedir,
-        extensions: ['.ts', '.js'],
-        readFileSync: this.volume.readFileSync.bind(this.volume),
-        isFile: (file) => {
-          try {
-            var stat = this.volume.statSync(file);
-          } catch (e: any) {
-            if (e && (e.code === 'ENOENT' || e.code === 'ENOTDIR')) return false;
-            throw e;
-          }
-          return stat.isFile() || stat.isFIFO();
-        },
-        isDirectory: (dir) => {
-          try {
-            var stat = this.volume.statSync(dir);
-          } catch (e: any) {
-            if (e && (e.code === 'ENOENT' || e.code === 'ENOTDIR')) return false;
-            throw e;
-          }
-          return stat.isDirectory();
-        },
-        realpathSync: (file) => {
-          try {
-            return this.volume.realpathSync(file) as string;
-          } catch (realPathErr: any) {
-            if (realPathErr.code !== 'ENOENT') {
-              throw realPathErr;
-            }
-          }
-          return file;
-        },
-      });
-      return E.right(result);
-    } catch (e: any) {
-      if (typeof e === 'object' && e.hasOwnProperty('message')) {
-        return E.left(e.message);
-      } else {
-        return E.left(JSON.stringify(e));
-      }
-    }
-  }
-}
 
 async function testCase(
   description: string,

--- a/packages/openapi-generator/test/testProject.ts
+++ b/packages/openapi-generator/test/testProject.ts
@@ -1,0 +1,65 @@
+import * as E from 'fp-ts/lib/Either';
+import { Volume, type NestedDirectoryJSON } from 'memfs';
+import resolve from 'resolve';
+import { promisify } from 'util';
+
+import { Project } from '../src';
+
+export class TestProject extends Project {
+  private volume: ReturnType<(typeof Volume)['fromJSON']>;
+
+  constructor(files: NestedDirectoryJSON) {
+    super();
+    this.volume = Volume.fromNestedJSON(files, '/');
+  }
+
+  override async readFile(filename: string): Promise<string> {
+    const file: any = await promisify(this.volume.readFile.bind(this.volume))(filename);
+    return file.toString('utf-8');
+  }
+
+  override resolve(basedir: string, path: string): E.Either<string, string> {
+    try {
+      const result = resolve.sync(path, {
+        basedir,
+        extensions: ['.ts', '.js'],
+        readFileSync: this.volume.readFileSync.bind(this.volume),
+        isFile: (file) => {
+          try {
+            var stat = this.volume.statSync(file);
+          } catch (e: any) {
+            if (e && (e.code === 'ENOENT' || e.code === 'ENOTDIR')) return false;
+            throw e;
+          }
+          return stat.isFile() || stat.isFIFO();
+        },
+        isDirectory: (dir) => {
+          try {
+            var stat = this.volume.statSync(dir);
+          } catch (e: any) {
+            if (e && (e.code === 'ENOENT' || e.code === 'ENOTDIR')) return false;
+            throw e;
+          }
+          return stat.isDirectory();
+        },
+        realpathSync: (file) => {
+          try {
+            return this.volume.realpathSync(file) as string;
+          } catch (realPathErr: any) {
+            if (realPathErr.code !== 'ENOENT') {
+              throw realPathErr;
+            }
+          }
+          return file;
+        },
+      });
+      return E.right(result);
+    } catch (e: any) {
+      if (typeof e === 'object' && e.hasOwnProperty('message')) {
+        return E.left(e.message);
+      } else {
+        return E.left(JSON.stringify(e));
+      }
+    }
+  }
+}


### PR DESCRIPTION
Handles the case where multiple `h.apiSpec`s are composed together by splatting properties.