### PR TITLE
chore(dependabot): remove tsmorph settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,8 +30,6 @@ updates:
         update-types: ['version-update:semver-patch']
       - dependency-name: io-ts
         versions: ['2.x']
-      - dependency-name: ts-morph
-        versions: ['>=16']
       - dependency-name: typescript
         versions: ['>4.8']
       - dependency-name: whatwg-url


### PR DESCRIPTION
tsmorph was removed in https://github.com/BitGo/api-ts/pull/508, so we
can remove the associated dependabot configuration.