### PR TITLE
chore(dependabot): group @swc/core-* updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
     allow:
       - dependency-type: direct
     versioning-strategy: increase-if-necessary
+    groups:
+      dependencies:
+        patterns:
+          - '@swc/core-*'
     ignore:
       # Ignore all @types/nodes patch updates, since
       # this package updates so frequently


### PR DESCRIPTION
 We aim for @swc/core and associated manually-installed optional dependencies to remain pinned to the same version, but the current dependabot configuration opens two separate PRs: #513 #515
 
 This commit configures dependabot to group the @swc/core* updates into a single PR, to keep all @swc/core dependencies on the same version at all times.
