### PR TITLE
ci(deps-dev): group swc core and native dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
     groups:
       dependencies:
         patterns:
-          - '@swc/core-*'
+          - '@swc/core*'
     ignore:
       # Ignore all @types/nodes patch updates, since
       # this package updates so frequently


### PR DESCRIPTION
Makes the change described in https://github.com/BitGo/api-ts/pull/520#discussion_r1304579036