### PR TITLE
Allow custom known codecs to be defined in a config file

### DIFF
--- a/packages/openapi-generator/src/codec.ts
+++ b/packages/openapi-generator/src/codec.ts
@@ -9,7 +9,7 @@ import type { Project } from './project';
 import { findSymbolInitializer, resolveLiteralOrIdentifier } from './resolveInit';
 import type { SourceFile } from './sourceFile';
 
-import { KNOWN_IMPORTS, type KnownCodec } from './knownImports';
+import type { KnownCodec } from './knownImports';
 
 type ResolvedRef = { type: 'ref'; name: string; location: string };
 
@@ -32,7 +32,7 @@ function codecIdentifier(
     } else if (imp.type === 'star') {
       return E.left(`Tried to use star import as codec ${id.value}`);
     }
-    const knownImport = KNOWN_IMPORTS[imp.from]?.[imp.importedName];
+    const knownImport = project.knownImports[imp.from]?.[imp.importedName];
     if (knownImport !== undefined) {
       return E.right({ type: 'codec', schema: knownImport });
     }
@@ -67,7 +67,7 @@ function codecIdentifier(
     }
 
     const name = id.property.value;
-    const knownImport = KNOWN_IMPORTS[objectSym.from]?.[name];
+    const knownImport = project.knownImports[objectSym.from]?.[name];
     if (knownImport !== undefined) {
       return E.right({ type: 'codec', schema: knownImport });
     }

--- a/packages/openapi-generator/src/project.ts
+++ b/packages/openapi-generator/src/project.ts
@@ -4,15 +4,19 @@ import { promisify } from 'util';
 import * as E from 'fp-ts/Either';
 import resolve from 'resolve';
 
+import { KNOWN_IMPORTS, type KnownCodec } from './knownImports';
 import { parseSource, type SourceFile } from './sourceFile';
 
 const readFile = promisify(fs.readFile);
 
 export class Project {
+  readonly knownImports: Record<string, Record<string, KnownCodec>>;
+
   private files: Record<string, SourceFile>;
 
-  constructor(files: Record<string, SourceFile> = {}) {
+  constructor(files: Record<string, SourceFile> = {}, knownImports = KNOWN_IMPORTS) {
     this.files = files;
+    this.knownImports = knownImports;
   }
 
   add(path: string, sourceFile: SourceFile): void {


### PR DESCRIPTION
Some packages define custom codecs (as in they aren't built up from the `io-ts` combinators) or import them from external libraries. Currently, we define several of these in the `knownImports.ts` file, but it is impossible to include all of them, or ones that are from private packages. This change adds a `--codec-file` option that'll read a `js` file's default export and add it to the hardcoded set of known imports. To avoid issues with importing `fp-ts/Either` in this config file, the default export should actually be a function that accepts `E`, and returns the set of additional known codecs, like so:

```js
module.exports = (E) => {
  return {
    'my-custom-codecs': {
      foo: () => E.right({ type: 'object', properties: {}, required: [] })
    }
  }
}
```

I'm not in love with how this works, but haven't been able to think of a better way to support custom defined codecs without needing to bring in a full typechecker to read their output types.