### PR TITLE
feat: output OpenAPI v3 instead of v3.1

### DIFF
--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -107,7 +107,7 @@ export const internalRoute = h.httpRoute({
 `;
 
 testCase('simple route', SIMPLE, {
-  openapi: '3.1.0',
+  openapi: '3.0.0',
   info: {
     title: 'Test',
     version: '1.0.0',
@@ -205,7 +205,7 @@ export const route = h.httpRoute({
 `;
 
 testCase('request body route', REQUEST_BODY, {
-  openapi: '3.1.0',
+  openapi: '3.0.0',
   info: {
     title: 'Test',
     version: '1.0.0',
@@ -276,7 +276,7 @@ export const route = h.httpRoute({
 `;
 
 testCase('request union route', UNION, {
-  openapi: '3.1.0',
+  openapi: '3.0.0',
   info: {
     title: 'Test',
     version: '1.0.0',


### PR DESCRIPTION
It appears that a lot of tooling does not support OpenAPI v3.1, so this changes `openapi-generator` to output OpenAPI v3 for broader compatibility. The largest change is with explicit `null`-typed properties, since OpenAPI does not have a `null` primitive type. As a workaround, I have it emit a `nullable` type with an empty `enum`, which should mean the only possible value for that type is `null`, but I'm guessing a lot of tooling conflates "nullable" with "optional" and we might need to handle this in the future.