### PR TITLE
fix: fix format of request bodies in openapi-generator

### DIFF
--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -82,6 +82,17 @@ function routeToOpenAPI(route: Route): [string, string, OpenAPIV3_1.OperationObj
   const tag = jsdoc.tags?.tag ?? '';
   const isInternal = jsdoc.tags?.private !== undefined;
 
+  const requestBody =
+    route.body === undefined
+      ? {}
+      : {
+          requestBody: {
+            content: {
+              'application/json': { schema: schemaToOpenAPI(route.body) },
+            },
+          },
+        };
+
   return [
     route.path,
     route.method.toLowerCase(),
@@ -106,9 +117,7 @@ function routeToOpenAPI(route: Route): [string, string, OpenAPIV3_1.OperationObj
           schema: schema as any, // TODO: Something to disallow arrays
         };
       }),
-      ...(route.body !== undefined
-        ? { requestBody: schemaToOpenAPI(route.body) as any }
-        : {}),
+      ...requestBody,
       responses: Object.entries(route.response).reduce((acc, [code, response]) => {
         const description = response.comment?.description ?? STATUS_CODES[code] ?? '';
 

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -185,6 +185,70 @@ testCase('simple route', SIMPLE, {
   },
 });
 
+const REQUEST_BODY = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({
+    body: {
+      foo: t.string,
+    },
+  }),
+  response: {
+    /** foo response */
+    200: t.string
+  },
+});
+`;
+
+testCase('request body route', REQUEST_BODY, {
+  openapi: '3.1.0',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/foo': {
+      get: {
+        parameters: [],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  foo: {
+                    type: 'string',
+                  },
+                },
+                required: ['foo'],
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: 'foo response',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});
+
 const UNION = `
 import * as t from 'io-ts';
 import * as h from '@api-ts/io-ts-http';


### PR DESCRIPTION
Caught this while trying to render a generated spec in SwaggerUI. This conflicts with #536 because of the `version` field, so depending on which one is merged first, the other will need to be fixed up.