### PR TITLE
Correctly handle `t.undefined` in openapi-generator

### DIFF
--- a/packages/openapi-generator/src/knownImports.ts
+++ b/packages/openapi-generator/src/knownImports.ts
@@ -30,6 +30,7 @@ export const KNOWN_IMPORTS: KnownImports = {
     number: () => E.right({ type: 'primitive', value: 'number' }),
     boolean: () => E.right({ type: 'primitive', value: 'boolean' }),
     null: () => E.right({ type: 'primitive', value: 'null' }),
+    undefined: () => E.right({ type: 'undefined' }),
     array: (_, innerSchema) => E.right({ type: 'array', items: innerSchema }),
     readonlyArray: (_, innerSchema) => E.right({ type: 'array', items: innerSchema }),
     type: (_, schema) => {

--- a/packages/openapi-generator/test/codec.test.ts
+++ b/packages/openapi-generator/test/codec.test.ts
@@ -322,6 +322,15 @@ testCase('null literal type is parsed', NULL_LITERAL, {
   FOO: { type: 'literal', kind: 'null', value: null },
 });
 
+const UNDEFINED_LITERAL = `
+import * as t from 'io-ts';
+export const FOO = t.undefined;
+`;
+
+testCase('undefined literal type is parsed', UNDEFINED_LITERAL, {
+  FOO: { type: 'undefined' },
+});
+
 const KEYOF = `
 import * as t from 'io-ts';
 export const FOO = t.keyof({ foo: null, bar: null });


### PR DESCRIPTION
Undefined values are represented in the IR and should get optimized down to optional or missing properties. What was overlooked is using `t.undefined` directly rather than going through `h.optional(...)`. This should address that.