### PR TITLE
fix: refactor ref recursion

### DIFF
--- a/packages/openapi-generator/src/index.ts
+++ b/packages/openapi-generator/src/index.ts
@@ -3,6 +3,7 @@ export { parseCodecInitializer, parsePlainInitializer } from './codec';
 export { parseCommentBlock, type JSDoc } from './jsdoc';
 export { convertRoutesToOpenAPI } from './openapi';
 export { Project } from './project';
+export { getRefs } from './ref';
 export { parseRoute, type Route } from './route';
 export { parseSource } from './sourceFile';
 export { parseTopLevelSymbols } from './symbol';

--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -2,7 +2,6 @@ import { OpenAPIV3 } from 'openapi-types';
 
 import { STATUS_CODES } from 'http';
 import { parseCommentBlock } from './jsdoc';
-import type { Components } from './ref';
 import type { Route } from './route';
 import type { Schema } from './ir';
 
@@ -150,7 +149,7 @@ function routeToOpenAPI(route: Route): [string, string, OpenAPIV3.OperationObjec
 export function convertRoutesToOpenAPI(
   info: OpenAPIV3.InfoObject,
   routes: Route[],
-  schemas: Components,
+  schemas: Record<string, Schema>,
 ): OpenAPIV3.Document {
   const paths = routes.reduce(
     (acc, route) => {

--- a/packages/openapi-generator/src/ref.ts
+++ b/packages/openapi-generator/src/ref.ts
@@ -1,42 +1,25 @@
-import * as E from 'fp-ts/Either';
+import type { Schema, Reference } from './ir';
 
-import { parseCodecInitializer } from './codec';
-import type { Project } from './project';
-import type { Schema } from './ir';
-import { findSymbolInitializer } from './resolveInit';
-
-export type Components = Record<string, Schema>;
-
-export function parseRefs(project: Project, schema: Schema): Record<string, Schema> {
+export function getRefs(schema: Schema): Reference[] {
   if (schema.type === 'ref') {
-    const sourceFile = project.get(schema.location);
-    if (sourceFile === undefined) {
-      return {};
-    }
-    const initE = findSymbolInitializer(project, sourceFile, schema.name);
-    if (E.isLeft(initE)) {
-      return {};
-    }
-    const [newSourceFile, init] = initE.right;
-    const codecE = parseCodecInitializer(project, newSourceFile, init);
-    if (E.isLeft(codecE)) {
-      return {};
-    }
-    const codec = codecE.right;
-    return { [schema.name]: codec };
+    return [schema];
   } else if (schema.type === 'array') {
-    return parseRefs(project, schema.items);
-  } else if (schema.type === 'intersection' || schema.type === 'union') {
-    return schema.schemas.reduce((acc, member) => {
-      return { ...acc, ...parseRefs(project, member) };
-    }, {});
+    return getRefs(schema.items);
+  } else if (
+    schema.type === 'intersection' ||
+    schema.type === 'union' ||
+    schema.type === 'tuple'
+  ) {
+    return schema.schemas.reduce<Reference[]>((acc, member) => {
+      return [...acc, ...getRefs(member)];
+    }, []);
   } else if (schema.type === 'object') {
-    return Object.values(schema.properties).reduce((acc, member) => {
-      return { ...acc, ...parseRefs(project, member) };
-    }, {});
+    return Object.values(schema.properties).reduce<Reference[]>((acc, member) => {
+      return [...acc, ...getRefs(member)];
+    }, []);
   } else if (schema.type === 'record') {
-    return parseRefs(project, schema.codomain);
+    return getRefs(schema.codomain);
   } else {
-    return {};
+    return [];
   }
 }

--- a/packages/openapi-generator/test/ref.test.ts
+++ b/packages/openapi-generator/test/ref.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+import { getRefs, type Schema } from '../src';
+
+test('simple ref is returned', () => {
+  const schema: Schema = {
+    type: 'ref',
+    name: 'Foo',
+    location: '/foo.ts',
+  };
+
+  assert.deepStrictEqual(getRefs(schema), [schema]);
+});
+
+test('array ref is returned', () => {
+  const schema: Schema = {
+    type: 'array',
+    items: {
+      type: 'ref',
+      name: 'Foo',
+      location: '/foo.ts',
+    },
+  };
+
+  assert.deepStrictEqual(getRefs(schema), [
+    {
+      type: 'ref',
+      name: 'Foo',
+      location: '/foo.ts',
+    },
+  ]);
+});
+
+test('intersection ref is returned', () => {
+  const schema: Schema = {
+    type: 'intersection',
+    schemas: [
+      {
+        type: 'ref',
+        name: 'Foo',
+        location: '/foo.ts',
+      },
+      {
+        type: 'ref',
+        name: 'Bar',
+        location: '/bar.ts',
+      },
+    ],
+  };
+
+  assert.deepStrictEqual(getRefs(schema), [
+    {
+      type: 'ref',
+      name: 'Foo',
+      location: '/foo.ts',
+    },
+    {
+      type: 'ref',
+      name: 'Bar',
+      location: '/bar.ts',
+    },
+  ]);
+});
+
+test('union ref is returned', () => {
+  const schema: Schema = {
+    type: 'union',
+    schemas: [
+      {
+        type: 'ref',
+        name: 'Foo',
+        location: '/foo.ts',
+      },
+      {
+        type: 'ref',
+        name: 'Bar',
+        location: '/bar.ts',
+      },
+    ],
+  };
+
+  assert.deepStrictEqual(getRefs(schema), [
+    {
+      type: 'ref',
+      name: 'Foo',
+      location: '/foo.ts',
+    },
+    {
+      type: 'ref',
+      name: 'Bar',
+      location: '/bar.ts',
+    },
+  ]);
+});
+
+test('tuple ref is returned', () => {
+  const schema: Schema = {
+    type: 'tuple',
+    schemas: [
+      {
+        type: 'ref',
+        name: 'Foo',
+        location: '/foo.ts',
+      },
+      {
+        type: 'ref',
+        name: 'Bar',
+        location: '/bar.ts',
+      },
+    ],
+  };
+
+  assert.deepStrictEqual(getRefs(schema), [
+    {
+      type: 'ref',
+      name: 'Foo',
+      location: '/foo.ts',
+    },
+    {
+      type: 'ref',
+      name: 'Bar',
+      location: '/bar.ts',
+    },
+  ]);
+});
+
+test('object ref is returned', () => {
+  const schema: Schema = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'ref',
+        name: 'Foo',
+        location: '/foo.ts',
+      },
+      bar: {
+        type: 'ref',
+        name: 'Bar',
+        location: '/bar.ts',
+      },
+    },
+    required: ['foo', 'bar'],
+  };
+
+  assert.deepStrictEqual(getRefs(schema), [
+    {
+      type: 'ref',
+      name: 'Foo',
+      location: '/foo.ts',
+    },
+    {
+      type: 'ref',
+      name: 'Bar',
+      location: '/bar.ts',
+    },
+  ]);
+});
+
+test('record ref is returned', () => {
+  const schema: Schema = {
+    type: 'record',
+    codomain: {
+      type: 'ref',
+      name: 'Foo',
+      location: '/foo.ts',
+    },
+  };
+
+  assert.deepStrictEqual(getRefs(schema), [
+    {
+      type: 'ref',
+      name: 'Foo',
+      location: '/foo.ts',
+    },
+  ]);
+});


### PR DESCRIPTION
- Decouples the traversal to find refs from the parsing step
- Adds tests (thanks Copilot) for ref traversal
- Fixes issue where some schemas would be silently dropped if there was a parsing error, now they result in an error message