### PR TITLE
feat: support reading codecs directly ref-d from objects

### DIFF
--- a/packages/openapi-generator/src/resolveInit.ts
+++ b/packages/openapi-generator/src/resolveInit.ts
@@ -63,7 +63,7 @@ export function findSymbolInitializer(
         return findExportedDeclaration(project, impSourceFile.right, name[1]);
       }
     }
-    return E.left(`Unknown identifier ${name[0]}.${name[1]}`);
+    name = name[0];
   }
   for (const declaration of sourceFile.symbols.declarations) {
     if (declaration.name === name) {

--- a/packages/openapi-generator/test/codec.test.ts
+++ b/packages/openapi-generator/test/codec.test.ts
@@ -719,3 +719,34 @@ testCase('httpRequest combinator is parsed', HTTP_REQUEST_COMBINATOR, {
     required: ['params', 'query'],
   },
 });
+
+const OBJECT_PROPERTY = `
+import * as t from 'io-ts';
+
+const props = {
+  foo: t.number,
+  bar: t.string,
+};
+
+export const FOO = t.type({
+  baz: props.foo,
+});
+`;
+
+testCase('object property is parsed', OBJECT_PROPERTY, {
+  FOO: {
+    type: 'object',
+    properties: {
+      baz: { type: 'primitive', value: 'number' },
+    },
+    required: ['baz'],
+  },
+  props: {
+    type: 'object',
+    properties: {
+      foo: { type: 'primitive', value: 'number' },
+      bar: { type: 'primitive', value: 'string' },
+    },
+    required: ['foo', 'bar'],
+  },
+});

--- a/packages/openapi-generator/test/resolve.test.ts
+++ b/packages/openapi-generator/test/resolve.test.ts
@@ -515,3 +515,35 @@ testCase('cross-file star multi export is parsed', STAR_MULTI_EXPORT, '/index.ts
     required: ['baz'],
   },
 });
+
+const IMPORT_MEMBER_EXPRESSION = {
+  '/foo.ts': `
+    import * as t from 'io-ts';
+    export const Foos = {
+      foo: t.number,
+    }
+  `,
+  '/index.ts': `
+    import * as t from 'io-ts';
+    import { Foos } from './foo';
+    export const FOO = t.type({ foo: Foos.foo });
+  `,
+};
+
+testCase(
+  'cross-file import member expression is parsed',
+  IMPORT_MEMBER_EXPRESSION,
+  '/index.ts',
+  {
+    FOO: {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'primitive',
+          value: 'number',
+        },
+      },
+      required: ['foo'],
+    },
+  },
+);


### PR DESCRIPTION
Adds support for directly referencing a codec inside another local or imported object literal:

```typescript
const GroupOfCodecs = {
  one: t.string,
  two: t.number,
}

export const MyObject = t.type({
  foo: GroupOfCodecs.one,
  bar: GroupOfCodecs.two,
});
```