### PR TITLE
Locate and read metadata from `package.json`

### DIFF
--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -16,9 +16,13 @@ of the Typescript file passed as an input parameter. The OpenAPI specification w
 written to stdout.
 
 ```
+ARGUMENTS:
+  <file> - API route definition file
+
 OPTIONS:
-  --name, -n <str>     - API name [optional]
-  --version, -v <str>  - API version [optional]
+  --name, -n <str>       - API name [optional]
+  --version, -v <str>    - API version [optional]
+  --codec-file, -c <str> - Custom codec definition file [optional]
 
 FLAGS:
   --internal, -i - include routes marked private
@@ -30,3 +34,34 @@ For example:
 ```shell
 npx openapi-generator src/index.ts
 ```
+
+## Custom codec file
+
+`openapi-generator` only reads files in the specified package, and stops at the module
+boundary. This allows it to work even without `node_modules` installed. It has built-in
+support for `io-ts`, `io-ts-types`, and `@api-ts/io-ts-http` imports. If your package
+imports codecs from another external library, then you will have to define them in a
+custom configuration file so that `openapi-generator` will understand them. To do so,
+create a JS file with the following format:
+
+```typescript
+module.exports = (E) => {
+  return {
+    'io-ts-bigint': {
+      BigIntFromString: () => E.right({ type: 'primitive', value: 'string' }),
+      NonZeroBigInt: () => E.right({ type: 'primitive', value: 'number' }),
+      NonZeroBigIntFromString: () => E.right({ type: 'primitive', value: 'string' }),
+      NegativeBigIntFromString: () => E.right({ type: 'primitive', value: 'string' }),
+      NonNegativeBigIntFromString: () =>
+        E.right({ type: 'primitive', value: 'string' }),
+      PositiveBigIntFromString: () => E.right({ type: 'primitive', value: 'string' }),
+    },
+    // ... and so on for other packages
+  };
+};
+```
+
+The input parameter `E` is the namespace import of `fp-ts/Either` (so that trying to
+`require` it from the config file isn't an issue), and the return type is a `Record`
+containing AST definitions for external libraries.
+[Refer to KNOWN_IMPORTS here for info on the structure](./src/knownImports.ts)

--- a/packages/openapi-generator/src/packageInfo.ts
+++ b/packages/openapi-generator/src/packageInfo.ts
@@ -1,0 +1,30 @@
+import * as fs from 'fs/promises';
+import * as p from 'path';
+
+export async function getPackageJsonPath(
+  entryPoint: string,
+): Promise<string | undefined> {
+  let dir = p.dirname(entryPoint);
+  while (dir !== '/') {
+    const pkgJsonPath = p.join(dir, 'package.json');
+    try {
+      const pkgJson = await fs.stat(pkgJsonPath);
+      if (pkgJson !== undefined) {
+        return pkgJsonPath;
+      }
+    } catch (e: any) {
+      if (e.code === 'ENOENT') {
+        const parentDir = p.dirname(dir);
+        if (parentDir === dir) {
+          // This is the root directory
+          break;
+        }
+        dir = parentDir;
+        continue;
+      } else {
+        throw e;
+      }
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
Adds support for reading `package.json` and getting configuration and metadata out of it. Command-line flags take priority if specified. Then enables bundling custom codec definitions along with the project.