### PR TITLE
fix(superagent-wrapper): add @types/superagent as a peerDependency

### DIFF
--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -37,6 +37,7 @@
     "typescript": "4.7.4"
   },
   "peerDependencies": {
+    "@types/superagent": "*",
     "superagent": "*"
   },
   "publishConfig": {


### PR DESCRIPTION
@api-ts/superagent-wrapper requires types to be supplied based on your version of superagent