### PR TITLE
fix: remove import of type from `superagent`

### DIFF
--- a/packages/superagent-wrapper/src/request.ts
+++ b/packages/superagent-wrapper/src/request.ts
@@ -51,12 +51,12 @@ type SuperagentLike<Req> = {
   [K in h.Method]: (url: string) => Req;
 };
 
-type Response = {
+export type Response = {
   body: unknown;
   status: number;
 };
 
-interface SuperagentRequest<Res extends Response> extends Promise<Res> {
+export interface SuperagentRequest<Res extends Response> extends Promise<Res> {
   ok(callback: (response: Res) => boolean): this;
   query(params: Record<string, string | string[]>): this;
   set(name: string, value: string): this;

--- a/packages/superagent-wrapper/src/routes.ts
+++ b/packages/superagent-wrapper/src/routes.ts
@@ -1,15 +1,21 @@
 import * as h from '@api-ts/io-ts-http';
-import type { SuperAgentRequest } from 'superagent';
+import type { SuperagentRequest, Response } from './request';
 
 import { requestForRoute, BoundRequestFactory, RequestFactory } from './request';
 
-export type ApiClient<Req extends SuperAgentRequest, Spec extends h.ApiSpec> = {
+export type ApiClient<
+  Req extends SuperagentRequest<Response>,
+  Spec extends h.ApiSpec,
+> = {
   [A in keyof Spec]: {
     [B in keyof Spec[A] & h.Method]: BoundRequestFactory<Req, NonNullable<Spec[A][B]>>;
   };
 };
 
-export const buildApiClient = <Req extends SuperAgentRequest, Spec extends h.ApiSpec>(
+export const buildApiClient = <
+  Req extends SuperagentRequest<Response>,
+  Spec extends h.ApiSpec,
+>(
   requestFactory: RequestFactory<Req>,
   spec: Spec,
 ): ApiClient<Req, Spec> => {


### PR DESCRIPTION
Opening as an alternative to #573