### PR TITLE
Fix type declarations for io-ts 2.1.3 and upgrade Typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "pre-commit": "1.2.2",
         "prettier": "3.0.3",
         "turbo": "1.10.14",
-        "typescript": "4.6.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "npm": ">=7"
@@ -1646,6 +1646,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
+    },
+    "node_modules/@types/io-ts": {
+      "resolved": "packages/types-io-ts",
+      "link": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -17501,16 +17505,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {
@@ -17847,21 +17851,9 @@
         "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
         "@swc-node/register": "1.6.8",
         "@types/express": "4.17.18",
+        "@types/io-ts": "file:../types-io-ts",
         "c8": "8.0.1",
-        "typescript": "4.7.4"
-      }
-    },
-    "packages/express-wrapper/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "5.2.2"
       }
     },
     "packages/io-ts-http": {
@@ -17876,21 +17868,9 @@
       },
       "devDependencies": {
         "@swc-node/register": "1.6.8",
+        "@types/io-ts": "file:../types-io-ts",
         "c8": "8.0.1",
-        "typescript": "4.7.4"
-      }
-    },
-    "packages/io-ts-http/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "5.2.2"
       }
     },
     "packages/openapi-generator": {
@@ -17912,27 +17892,15 @@
       "devDependencies": {
         "@swc-node/register": "1.6.8",
         "@swc/core": "1.3.91",
+        "@types/io-ts": "file:../types-io-ts",
         "@types/resolve": "1.20.3",
         "c8": "8.0.1",
         "memfs": "4.5.0",
-        "typescript": "4.7.4"
+        "typescript": "5.2.2"
       },
       "optionalDependencies": {
         "@swc/core-darwin-arm64": "1.3.91",
         "@swc/core-linux-x64-gnu": "1.3.91"
-      }
-    },
-    "packages/openapi-generator/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "packages/response": {
@@ -17940,20 +17908,7 @@
       "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "devDependencies": {
-        "typescript": "4.7.4"
-      }
-    },
-    "packages/response/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "5.2.2"
       }
     },
     "packages/superagent-wrapper": {
@@ -17969,6 +17924,7 @@
       "devDependencies": {
         "@swc-node/register": "1.6.8",
         "@types/express": "4.17.18",
+        "@types/io-ts": "file:../types-io-ts",
         "@types/node": "20.8.0",
         "@types/superagent": "4.1.19",
         "@types/supertest": "2.0.14",
@@ -17978,23 +17934,10 @@
         "io-ts-types": "0.5.19",
         "superagent": "8.1.2",
         "supertest": "6.3.3",
-        "typescript": "4.7.4"
+        "typescript": "5.2.2"
       },
       "peerDependencies": {
         "superagent": "*"
-      }
-    },
-    "packages/superagent-wrapper/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "packages/typed-express-router": {
@@ -18011,22 +17954,15 @@
       "devDependencies": {
         "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
         "@swc-node/register": "1.6.8",
+        "@types/io-ts": "file:../types-io-ts",
         "c8": "8.0.1",
-        "typescript": "4.7.4"
+        "typescript": "5.2.2"
       }
     },
-    "packages/typed-express-router/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
+    "packages/types-io-ts": {
+      "name": "@types/io-ts",
+      "version": "2.1.3-fixed",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "pre-commit": "1.2.2",
     "prettier": "3.0.3",
     "turbo": "1.10.14",
-    "typescript": "4.6.4"
+    "typescript": "5.2.2"
   },
   "engines": {
     "npm": ">=7"

--- a/packages/express-wrapper/package.json
+++ b/packages/express-wrapper/package.json
@@ -27,8 +27,9 @@
     "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
     "@swc-node/register": "1.6.8",
     "@types/express": "4.17.18",
+    "@types/io-ts": "file:../types-io-ts",
     "c8": "8.0.1",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/express-wrapper/src/middleware.ts
+++ b/packages/express-wrapper/src/middleware.ts
@@ -80,7 +80,7 @@ export type MiddlewareChain =
     ];
 
 export type MiddlewareChainOutput<
-  Input,
+  Input extends {},
   Chain extends MiddlewareChain,
 > = Chain extends []
   ? Input

--- a/packages/express-wrapper/tsconfig.json
+++ b/packages/express-wrapper/tsconfig.json
@@ -2,7 +2,13 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*", "test/**/*"],
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "paths": {
+      "io-ts": ["../../node_modules/@types/io-ts/lib"],
+      "io-ts/lib/PathReporter": [
+        "../../node_modules/@types/io-ts/lib/PathReporter.d.ts"
+      ]
+    }
   },
   "references": [
     {

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -25,9 +25,10 @@
     "io-ts-types": "^0.5.15"
   },
   "devDependencies": {
+    "@types/io-ts": "file:../types-io-ts",
     "@swc-node/register": "1.6.8",
     "c8": "8.0.1",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/io-ts-http/tsconfig.json
+++ b/packages/io-ts-http/tsconfig.json
@@ -3,7 +3,10 @@
   "include": ["src/**/*", "test/**/*"],
   "compilerOptions": {
     "outDir": "dist",
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    "paths": {
+      "io-ts": ["../../node_modules/@types/io-ts/lib/index.d.ts"]
+    }
   },
   "references": [
     {

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -31,10 +31,11 @@
   "devDependencies": {
     "@swc-node/register": "1.6.8",
     "@swc/core": "1.3.91",
+    "@types/io-ts": "file:../types-io-ts",
     "@types/resolve": "1.20.3",
     "c8": "8.0.1",
     "memfs": "4.5.0",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "optionalDependencies": {
     "@swc/core-linux-x64-gnu": "1.3.91",

--- a/packages/openapi-generator/tsconfig.json
+++ b/packages/openapi-generator/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*.ts", "test/**/*.json", "test/**/*.ts"],
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "paths": {
+      "io-ts": ["../../node_modules/@types/io-ts/lib"]
+    }
   },
   "references": []
 }

--- a/packages/response/package.json
+++ b/packages/response/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf -- dist"
   },
   "devDependencies": {
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@swc-node/register": "1.6.8",
     "@types/express": "4.17.18",
+    "@types/io-ts": "file:../types-io-ts",
     "@types/node": "20.8.0",
     "@types/superagent": "4.1.19",
     "@types/supertest": "2.0.14",
@@ -34,7 +35,7 @@
     "io-ts-types": "0.5.19",
     "superagent": "8.1.2",
     "supertest": "6.3.3",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "superagent": "*"

--- a/packages/superagent-wrapper/tsconfig.json
+++ b/packages/superagent-wrapper/tsconfig.json
@@ -4,7 +4,13 @@
   "compilerOptions": {
     "lib": ["dom", "es2019"],
     "outDir": "dist",
-    "noUncheckedIndexedAccess": false
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "io-ts": ["../../node_modules/@types/io-ts/lib"],
+      "io-ts/lib/PathReporter": [
+        "../../node_modules/@types/io-ts/lib/PathReporter.d.ts"
+      ]
+    }
   },
   "references": [
     {

--- a/packages/typed-express-router/package.json
+++ b/packages/typed-express-router/package.json
@@ -26,8 +26,9 @@
   "devDependencies": {
     "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
     "@swc-node/register": "1.6.8",
+    "@types/io-ts": "file:../types-io-ts",
     "c8": "8.0.1",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/typed-express-router/tsconfig.json
+++ b/packages/typed-express-router/tsconfig.json
@@ -2,7 +2,13 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*", "test/**/*"],
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "paths": {
+      "io-ts": ["../../node_modules/@types/io-ts/lib"],
+      "io-ts/lib/PathReporter": [
+        "../../node_modules/@types/io-ts/lib/PathReporter.d.ts"
+      ]
+    }
   },
   "references": [
     {

--- a/packages/types-io-ts/lib/PathReporter.d.ts
+++ b/packages/types-io-ts/lib/PathReporter.d.ts
@@ -1,0 +1,17 @@
+/**
+ * @since 1.0.0
+ */
+import { Reporter } from './Reporter';
+import { ValidationError } from '.';
+/**
+ * @since 1.0.0
+ */
+export declare function failure(es: Array<ValidationError>): Array<string>;
+/**
+ * @since 1.0.0
+ */
+export declare function success(): Array<string>;
+/**
+ * @since 1.0.0
+ */
+export declare const PathReporter: Reporter<Array<string>>;

--- a/packages/types-io-ts/lib/Reporter.d.ts
+++ b/packages/types-io-ts/lib/Reporter.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @since 1.0.0
+ */
+import { Validation } from './index';
+/**
+ * @since 1.0.0
+ */
+export interface Reporter<A> {
+  report: (validation: Validation<any>) => A;
+}

--- a/packages/types-io-ts/lib/ThrowReporter.d.ts
+++ b/packages/types-io-ts/lib/ThrowReporter.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @deprecated
+ * @since 1.0.0
+ */
+import { Reporter } from './Reporter';
+/**
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare const ThrowReporter: Reporter<void>;

--- a/packages/types-io-ts/lib/index.d.ts
+++ b/packages/types-io-ts/lib/index.d.ts
@@ -1,0 +1,1393 @@
+/**
+ * @since 1.0.0
+ */
+import { Either } from 'fp-ts/lib/Either';
+import { Predicate, Refinement } from 'fp-ts/lib/function';
+/**
+ * @since 1.0.0
+ */
+export interface ContextEntry {
+  readonly key: string;
+  readonly type: Decoder<any, any>;
+  /** the input data */
+  readonly actual?: unknown;
+}
+/**
+ * @since 1.0.0
+ */
+export interface Context extends ReadonlyArray<ContextEntry> {}
+/**
+ * @since 1.0.0
+ */
+export interface ValidationError {
+  /** the offending (sub)value */
+  readonly value: unknown;
+  /** where the error originated */
+  readonly context: Context;
+  /** optional custom error message */
+  readonly message?: string;
+}
+/**
+ * @since 1.0.0
+ */
+export interface Errors extends Array<ValidationError> {}
+/**
+ * @since 1.0.0
+ */
+export type Validation<A> = Either<Errors, A>;
+/**
+ * @since 1.0.0
+ */
+export type Is<A> = (u: unknown) => u is A;
+/**
+ * @since 1.0.0
+ */
+export type Validate<I, A> = (i: I, context: Context) => Validation<A>;
+/**
+ * @since 1.0.0
+ */
+export type Decode<I, A> = (i: I) => Validation<A>;
+/**
+ * @since 1.0.0
+ */
+export type Encode<A, O> = (a: A) => O;
+/**
+ * @since 1.0.0
+ */
+export interface Any extends Type<any, any, any> {}
+/**
+ * @since 1.0.0
+ */
+export interface Mixed extends Type<any, any, unknown> {}
+/**
+ * @since 1.0.0
+ */
+export type TypeOf<C extends Any> = C['_A'];
+/**
+ * @since 1.0.0
+ */
+export type InputOf<C extends Any> = C['_I'];
+/**
+ * @since 1.0.0
+ */
+export type OutputOf<C extends Any> = C['_O'];
+/**
+ * @since 1.0.0
+ */
+export interface Decoder<I, A> {
+  readonly name: string;
+  readonly validate: Validate<I, A>;
+  readonly decode: Decode<I, A>;
+}
+/**
+ * @since 1.0.0
+ */
+export interface Encoder<A, O> {
+  readonly encode: Encode<A, O>;
+}
+/**
+ * @since 1.0.0
+ */
+export declare class Type<A, O = A, I = unknown>
+  implements Decoder<I, A>, Encoder<A, O>
+{
+  /** a unique name for this codec */
+  readonly name: string;
+  /** a custom type guard */
+  readonly is: Is<A>;
+  /** succeeds if a value of type I can be decoded to a value of type A */
+  readonly validate: Validate<I, A>;
+  /** converts a value of type A to a value of type O */
+  readonly encode: Encode<A, O>;
+  readonly _A: A;
+  readonly _O: O;
+  readonly _I: I;
+  constructor(
+    /** a unique name for this codec */
+    name: string,
+    /** a custom type guard */
+    is: Is<A>,
+    /** succeeds if a value of type I can be decoded to a value of type A */
+    validate: Validate<I, A>,
+    /** converts a value of type A to a value of type O */
+    encode: Encode<A, O>,
+  );
+  /**
+   * @since 1.0.0
+   */
+  pipe<B, IB, A extends IB, OB extends A>(
+    this: Type<A, O, I>,
+    ab: Type<B, OB, IB>,
+    name?: string,
+  ): Type<B, O, I>;
+  /**
+   * @since 1.0.0
+   */
+  asDecoder(): Decoder<I, A>;
+  /**
+   * @since 1.0.0
+   */
+  asEncoder(): Encoder<A, O>;
+  /**
+   * a version of `validate` with a default context
+   * @since 1.0.0
+   */
+  decode(i: I): Validation<A>;
+}
+/**
+ * @since 1.0.0
+ */
+export declare const identity: <A>(a: A) => A;
+/**
+ * @since 1.0.0
+ */
+export declare const getFunctionName: (f: Function) => string;
+/**
+ * @since 1.0.0
+ */
+export declare const getContextEntry: (
+  key: string,
+  decoder: Decoder<any, any>,
+) => ContextEntry;
+/**
+ * @since 1.0.0
+ */
+export declare const appendContext: (
+  c: Context,
+  key: string,
+  decoder: Decoder<any, any>,
+  actual?: unknown,
+) => Context;
+/**
+ * @since 1.0.0
+ */
+export declare const failures: <T>(errors: Errors) => Validation<T>;
+/**
+ * @since 1.0.0
+ */
+export declare const failure: <T>(
+  value: unknown,
+  context: Context,
+  message?: string,
+) => Validation<T>;
+/**
+ * @since 1.0.0
+ */
+export declare const success: <T>(value: T) => Validation<T>;
+/**
+ * @since 1.0.0
+ */
+export declare class NullType extends Type<null> {
+  readonly _tag: 'NullType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ */
+export interface NullC extends NullType {}
+/**
+ * @since 1.0.0
+ */
+export declare const nullType: NullC;
+/**
+ * @since 1.0.0
+ */
+export declare class UndefinedType extends Type<undefined> {
+  readonly _tag: 'UndefinedType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ */
+export interface UndefinedC extends UndefinedType {}
+declare const undefinedType: UndefinedC;
+/**
+ * @since 1.2.0
+ */
+export declare class VoidType extends Type<void> {
+  readonly _tag: 'VoidType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ */
+export interface VoidC extends VoidType {}
+/**
+ * @since 1.2.0
+ */
+export declare const voidType: VoidC;
+/**
+ * @since 1.5.0
+ */
+export declare class UnknownType extends Type<unknown> {
+  readonly _tag: 'UnknownType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ */
+export interface UnknownC extends UnknownType {}
+/**
+ * @since 1.5.0
+ */
+export declare const unknown: UnknownC;
+/**
+ * @since 1.0.0
+ */
+export declare class StringType extends Type<string> {
+  readonly _tag: 'StringType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ */
+export interface StringC extends StringType {}
+/**
+ * @since 1.0.0
+ */
+export declare const string: StringC;
+/**
+ * @since 1.0.0
+ */
+export declare class NumberType extends Type<number> {
+  readonly _tag: 'NumberType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ */
+export interface NumberC extends NumberType {}
+/**
+ * @since 1.0.0
+ */
+export declare const number: NumberC;
+/**
+ * @since 2.1.0
+ */
+export declare class BigIntType extends Type<bigint> {
+  readonly _tag: 'BigIntType';
+  constructor();
+}
+/**
+ * @since 2.1.0
+ */
+export interface BigIntC extends BigIntType {}
+/**
+ * @since 2.1.0
+ */
+export declare const bigint: BigIntC;
+/**
+ * @since 1.0.0
+ */
+export declare class BooleanType extends Type<boolean> {
+  readonly _tag: 'BooleanType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ */
+export interface BooleanC extends BooleanType {}
+/**
+ * @since 1.0.0
+ */
+export declare const boolean: BooleanC;
+/**
+ * @since 1.0.0
+ */
+export declare class AnyArrayType extends Type<Array<unknown>> {
+  readonly _tag: 'AnyArrayType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ */
+export interface UnknownArrayC extends AnyArrayType {}
+/**
+ * @since 1.7.1
+ */
+export declare const UnknownArray: UnknownArrayC;
+/**
+ * @since 1.0.0
+ */
+export declare class AnyDictionaryType extends Type<{
+  [key: string]: unknown;
+}> {
+  readonly _tag: 'AnyDictionaryType';
+  constructor();
+}
+/**
+ * @since 1.7.1
+ */
+export declare const UnknownRecord: UnknownRecordC;
+/**
+ * @since 1.5.3
+ */
+export interface UnknownRecordC extends AnyDictionaryType {}
+/**
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare class FunctionType extends Type<Function> {
+  readonly _tag: 'FunctionType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ * @deprecated
+ */
+export interface FunctionC extends FunctionType {}
+/**
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare const Function: FunctionC;
+/**
+ * @since 1.0.0
+ */
+export declare class RefinementType<
+  C extends Any,
+  A = any,
+  O = A,
+  I = unknown,
+> extends Type<A, O, I> {
+  readonly type: C;
+  readonly predicate: Predicate<A>;
+  readonly _tag: 'RefinementType';
+  constructor(
+    name: string,
+    is: RefinementType<C, A, O, I>['is'],
+    validate: RefinementType<C, A, O, I>['validate'],
+    encode: RefinementType<C, A, O, I>['encode'],
+    type: C,
+    predicate: Predicate<A>,
+  );
+}
+declare const _brand: unique symbol;
+/**
+ * @since 1.8.1
+ */
+export interface Brand<B> {
+  readonly [_brand]: B;
+}
+/**
+ * @since 1.8.1
+ */
+export type Branded<A, B> = A & Brand<B>;
+/**
+ * @since 1.8.1
+ */
+export interface BrandC<C extends Any, B>
+  extends RefinementType<C, Branded<TypeOf<C>, B>, OutputOf<C>, InputOf<C>> {}
+/**
+ * @since 1.8.1
+ */
+export declare const brand: <
+  C extends Any,
+  N extends string,
+  B extends { readonly [K in N]: symbol },
+>(
+  codec: C,
+  predicate: Refinement<TypeOf<C>, Branded<TypeOf<C>, B>>,
+  name: N,
+) => BrandC<C, B>;
+/**
+ * @since 1.8.1
+ */
+export interface IntBrand {
+  readonly Int: unique symbol;
+}
+/**
+ * A branded codec representing an integer
+ * @since 1.8.1
+ */
+export declare const Int: BrandC<NumberC, IntBrand>;
+/**
+ * @since 1.8.1
+ */
+export type Int = Branded<number, IntBrand>;
+type LiteralValue = string | number | boolean;
+/**
+ * @since 1.0.0
+ */
+export declare class LiteralType<V extends LiteralValue> extends Type<V> {
+  readonly value: V;
+  readonly _tag: 'LiteralType';
+  constructor(
+    name: string,
+    is: LiteralType<V>['is'],
+    validate: LiteralType<V>['validate'],
+    encode: LiteralType<V>['encode'],
+    value: V,
+  );
+}
+/**
+ * @since 1.5.3
+ */
+export interface LiteralC<V extends LiteralValue> extends LiteralType<V> {}
+/**
+ * @since 1.0.0
+ */
+export declare const literal: <V extends LiteralValue>(
+  value: V,
+  name?: string,
+) => LiteralC<V>;
+/**
+ * @since 1.0.0
+ */
+export declare class KeyofType<
+  D extends {
+    [key: string]: unknown;
+  },
+> extends Type<keyof D> {
+  readonly keys: D;
+  readonly _tag: 'KeyofType';
+  constructor(
+    name: string,
+    is: KeyofType<D>['is'],
+    validate: KeyofType<D>['validate'],
+    encode: KeyofType<D>['encode'],
+    keys: D,
+  );
+}
+/**
+ * @since 1.5.3
+ */
+export interface KeyofC<
+  D extends {
+    [key: string]: unknown;
+  },
+> extends KeyofType<D> {}
+/**
+ * @since 1.0.0
+ */
+export declare const keyof: <
+  D extends {
+    [key: string]: unknown;
+  },
+>(
+  keys: D,
+  name?: string,
+) => KeyofC<D>;
+/**
+ * @since 1.0.0
+ */
+export declare class RecursiveType<
+  C extends Any,
+  A = any,
+  O = A,
+  I = unknown,
+> extends Type<A, O, I> {
+  runDefinition: () => C;
+  readonly _tag: 'RecursiveType';
+  constructor(
+    name: string,
+    is: RecursiveType<C, A, O, I>['is'],
+    validate: RecursiveType<C, A, O, I>['validate'],
+    encode: RecursiveType<C, A, O, I>['encode'],
+    runDefinition: () => C,
+  );
+  readonly type: C;
+}
+/**
+ * @since 1.0.0
+ */
+export declare const recursion: <
+  A,
+  O = A,
+  I = unknown,
+  C extends Type<A, O, I> = Type<A, O, I>,
+>(
+  name: string,
+  definition: (self: C) => C,
+) => RecursiveType<C, A, O, I>;
+/**
+ * @since 1.0.0
+ */
+export declare class ArrayType<C extends Any, A = any, O = A, I = unknown> extends Type<
+  A,
+  O,
+  I
+> {
+  readonly type: C;
+  readonly _tag: 'ArrayType';
+  constructor(
+    name: string,
+    is: ArrayType<C, A, O, I>['is'],
+    validate: ArrayType<C, A, O, I>['validate'],
+    encode: ArrayType<C, A, O, I>['encode'],
+    type: C,
+  );
+}
+/**
+ * @since 1.5.3
+ */
+export interface ArrayC<C extends Mixed>
+  extends ArrayType<C, Array<TypeOf<C>>, Array<OutputOf<C>>, unknown> {}
+/**
+ * @since 1.0.0
+ */
+export declare const array: <C extends Mixed>(codec: C, name?: string) => ArrayC<C>;
+/**
+ * @since 1.0.0
+ */
+export declare class InterfaceType<P, A = any, O = A, I = unknown> extends Type<
+  A,
+  O,
+  I
+> {
+  readonly props: P;
+  readonly _tag: 'InterfaceType';
+  constructor(
+    name: string,
+    is: InterfaceType<P, A, O, I>['is'],
+    validate: InterfaceType<P, A, O, I>['validate'],
+    encode: InterfaceType<P, A, O, I>['encode'],
+    props: P,
+  );
+}
+/**
+ * @since 1.0.0
+ */
+export interface AnyProps {
+  [key: string]: Any;
+}
+/**
+ * @since 1.0.0
+ */
+export type TypeOfProps<P extends AnyProps> = {
+  [K in keyof P]: TypeOf<P[K]>;
+};
+/**
+ * @since 1.0.0
+ */
+export type OutputOfProps<P extends AnyProps> = {
+  [K in keyof P]: OutputOf<P[K]>;
+};
+/**
+ * @since 1.0.0
+ */
+export interface Props {
+  [key: string]: Mixed;
+}
+/**
+ * @since 1.5.3
+ */
+export interface TypeC<P extends Props>
+  extends InterfaceType<
+    P,
+    {
+      [K in keyof P]: TypeOf<P[K]>;
+    },
+    {
+      [K in keyof P]: OutputOf<P[K]>;
+    },
+    unknown
+  > {}
+/**
+ * @since 1.0.0
+ */
+export declare const type: <P extends Props>(props: P, name?: string) => TypeC<P>;
+/**
+ * @since 1.0.0
+ */
+export declare class PartialType<P, A = any, O = A, I = unknown> extends Type<A, O, I> {
+  readonly props: P;
+  readonly _tag: 'PartialType';
+  constructor(
+    name: string,
+    is: PartialType<P, A, O, I>['is'],
+    validate: PartialType<P, A, O, I>['validate'],
+    encode: PartialType<P, A, O, I>['encode'],
+    props: P,
+  );
+}
+/**
+ * @since 1.0.0
+ */
+export type TypeOfPartialProps<P extends AnyProps> = {
+  [K in keyof P]?: TypeOf<P[K]>;
+};
+/**
+ * @since 1.0.0
+ */
+export type OutputOfPartialProps<P extends AnyProps> = {
+  [K in keyof P]?: OutputOf<P[K]>;
+};
+/**
+ * @since 1.5.3
+ */
+export interface PartialC<P extends Props>
+  extends PartialType<
+    P,
+    {
+      [K in keyof P]?: TypeOf<P[K]>;
+    },
+    {
+      [K in keyof P]?: OutputOf<P[K]>;
+    },
+    unknown
+  > {}
+/**
+ * @since 1.0.0
+ */
+export declare const partial: <P extends Props>(props: P, name?: string) => PartialC<P>;
+/**
+ * @since 1.0.0
+ */
+export declare class DictionaryType<
+  D extends Any,
+  C extends Any,
+  A = any,
+  O = A,
+  I = unknown,
+> extends Type<A, O, I> {
+  readonly domain: D;
+  readonly codomain: C;
+  readonly _tag: 'DictionaryType';
+  constructor(
+    name: string,
+    is: DictionaryType<D, C, A, O, I>['is'],
+    validate: DictionaryType<D, C, A, O, I>['validate'],
+    encode: DictionaryType<D, C, A, O, I>['encode'],
+    domain: D,
+    codomain: C,
+  );
+}
+/**
+ * @since 1.0.0
+ */
+export type TypeOfDictionary<D extends Any, C extends Any> = {
+  [K in TypeOf<D>]: TypeOf<C>;
+};
+/**
+ * @since 1.0.0
+ */
+export type OutputOfDictionary<D extends Any, C extends Any> = {
+  [K in OutputOf<D>]: OutputOf<C>;
+};
+/**
+ * @since 1.5.3
+ */
+export interface RecordC<D extends Mixed, C extends Mixed>
+  extends DictionaryType<
+    D,
+    C,
+    {
+      [K in TypeOf<D>]: TypeOf<C>;
+    },
+    {
+      [K in OutputOf<D>]: OutputOf<C>;
+    },
+    unknown
+  > {}
+/**
+ * @since 1.7.1
+ */
+export declare function record<D extends Mixed, C extends Mixed>(
+  domain: D,
+  codomain: C,
+  name?: string,
+): RecordC<D, C>;
+/**
+ * @since 1.0.0
+ */
+export declare class UnionType<
+  CS extends Array<Any>,
+  A = any,
+  O = A,
+  I = unknown,
+> extends Type<A, O, I> {
+  readonly types: CS;
+  readonly _tag: 'UnionType';
+  constructor(
+    name: string,
+    is: UnionType<CS, A, O, I>['is'],
+    validate: UnionType<CS, A, O, I>['validate'],
+    encode: UnionType<CS, A, O, I>['encode'],
+    types: CS,
+  );
+}
+/**
+ * @since 1.5.3
+ */
+export interface UnionC<CS extends [Mixed, Mixed, ...Array<Mixed>]>
+  extends UnionType<CS, TypeOf<CS[number]>, OutputOf<CS[number]>, unknown> {}
+/**
+ * @since 1.0.0
+ */
+export declare const union: <CS extends [Mixed, Mixed, ...Mixed[]]>(
+  codecs: CS,
+  name?: string,
+) => UnionC<CS>;
+/**
+ * @since 1.0.0
+ */
+export declare class IntersectionType<
+  CS extends Array<Any>,
+  A = any,
+  O = A,
+  I = unknown,
+> extends Type<A, O, I> {
+  readonly types: CS;
+  readonly _tag: 'IntersectionType';
+  constructor(
+    name: string,
+    is: IntersectionType<CS, A, O, I>['is'],
+    validate: IntersectionType<CS, A, O, I>['validate'],
+    encode: IntersectionType<CS, A, O, I>['encode'],
+    types: CS,
+  );
+}
+/**
+ * @since 1.5.3
+ */
+export interface IntersectionC<CS extends [Mixed, Mixed, ...Array<Mixed>]>
+  extends IntersectionType<
+    CS,
+    CS extends {
+      length: 2;
+    }
+      ? TypeOf<CS[0]> & TypeOf<CS[1]>
+      : CS extends {
+          length: 3;
+        }
+      ? TypeOf<CS[0]> & TypeOf<CS[1]> & TypeOf<CS[2]>
+      : CS extends {
+          length: 4;
+        }
+      ? TypeOf<CS[0]> & TypeOf<CS[1]> & TypeOf<CS[2]> & TypeOf<CS[3]>
+      : CS extends {
+          length: 5;
+        }
+      ? TypeOf<CS[0]> & TypeOf<CS[1]> & TypeOf<CS[2]> & TypeOf<CS[3]> & TypeOf<CS[4]>
+      : unknown,
+    CS extends {
+      length: 2;
+    }
+      ? OutputOf<CS[0]> & OutputOf<CS[1]>
+      : CS extends {
+          length: 3;
+        }
+      ? OutputOf<CS[0]> & OutputOf<CS[1]> & OutputOf<CS[2]>
+      : CS extends {
+          length: 4;
+        }
+      ? OutputOf<CS[0]> & OutputOf<CS[1]> & OutputOf<CS[2]> & OutputOf<CS[3]>
+      : CS extends {
+          length: 5;
+        }
+      ? OutputOf<CS[0]> &
+          OutputOf<CS[1]> &
+          OutputOf<CS[2]> &
+          OutputOf<CS[3]> &
+          OutputOf<CS[4]>
+      : unknown,
+    unknown
+  > {}
+/**
+ * @since 1.0.0
+ */
+export declare function intersection<
+  A extends Mixed,
+  B extends Mixed,
+  C extends Mixed,
+  D extends Mixed,
+  E extends Mixed,
+>(codecs: [A, B, C, D, E], name?: string): IntersectionC<[A, B, C, D, E]>;
+export declare function intersection<
+  A extends Mixed,
+  B extends Mixed,
+  C extends Mixed,
+  D extends Mixed,
+>(codecs: [A, B, C, D], name?: string): IntersectionC<[A, B, C, D]>;
+export declare function intersection<A extends Mixed, B extends Mixed, C extends Mixed>(
+  codecs: [A, B, C],
+  name?: string,
+): IntersectionC<[A, B, C]>;
+export declare function intersection<A extends Mixed, B extends Mixed>(
+  codecs: [A, B],
+  name?: string,
+): IntersectionC<[A, B]>;
+/**
+ * @since 1.0.0
+ */
+export declare class TupleType<
+  CS extends Array<Any>,
+  A = any,
+  O = A,
+  I = unknown,
+> extends Type<A, O, I> {
+  readonly types: CS;
+  readonly _tag: 'TupleType';
+  constructor(
+    name: string,
+    is: TupleType<CS, A, O, I>['is'],
+    validate: TupleType<CS, A, O, I>['validate'],
+    encode: TupleType<CS, A, O, I>['encode'],
+    types: CS,
+  );
+}
+/**
+ * @since 1.5.3
+ */
+export interface TupleC<CS extends [Mixed, ...Array<Mixed>]>
+  extends TupleType<
+    CS,
+    CS extends {
+      length: 1;
+    }
+      ? [TypeOf<CS[0]>]
+      : CS extends {
+          length: 2;
+        }
+      ? [TypeOf<CS[0]>, TypeOf<CS[1]>]
+      : CS extends {
+          length: 3;
+        }
+      ? [TypeOf<CS[0]>, TypeOf<CS[1]>, TypeOf<CS[2]>]
+      : CS extends {
+          length: 4;
+        }
+      ? [TypeOf<CS[0]>, TypeOf<CS[1]>, TypeOf<CS[2]>, TypeOf<CS[3]>]
+      : CS extends {
+          length: 5;
+        }
+      ? [TypeOf<CS[0]>, TypeOf<CS[1]>, TypeOf<CS[2]>, TypeOf<CS[3]>, TypeOf<CS[4]>]
+      : unknown,
+    CS extends {
+      length: 1;
+    }
+      ? [OutputOf<CS[0]>]
+      : CS extends {
+          length: 2;
+        }
+      ? [OutputOf<CS[0]>, OutputOf<CS[1]>]
+      : CS extends {
+          length: 3;
+        }
+      ? [OutputOf<CS[0]>, OutputOf<CS[1]>, OutputOf<CS[2]>]
+      : CS extends {
+          length: 4;
+        }
+      ? [OutputOf<CS[0]>, OutputOf<CS[1]>, OutputOf<CS[2]>, OutputOf<CS[3]>]
+      : CS extends {
+          length: 5;
+        }
+      ? [
+          OutputOf<CS[0]>,
+          OutputOf<CS[1]>,
+          OutputOf<CS[2]>,
+          OutputOf<CS[3]>,
+          OutputOf<CS[4]>,
+        ]
+      : unknown,
+    unknown
+  > {}
+/**
+ * @since 1.0.0
+ */
+export declare function tuple<
+  A extends Mixed,
+  B extends Mixed,
+  C extends Mixed,
+  D extends Mixed,
+  E extends Mixed,
+>(codecs: [A, B, C, D, E], name?: string): TupleC<[A, B, C, D, E]>;
+export declare function tuple<
+  A extends Mixed,
+  B extends Mixed,
+  C extends Mixed,
+  D extends Mixed,
+>(codecs: [A, B, C, D], name?: string): TupleC<[A, B, C, D]>;
+export declare function tuple<A extends Mixed, B extends Mixed, C extends Mixed>(
+  codecs: [A, B, C],
+  name?: string,
+): TupleC<[A, B, C]>;
+export declare function tuple<A extends Mixed, B extends Mixed>(
+  codecs: [A, B],
+  name?: string,
+): TupleC<[A, B]>;
+export declare function tuple<A extends Mixed>(codecs: [A], name?: string): TupleC<[A]>;
+/**
+ * @since 1.0.0
+ */
+export declare class ReadonlyType<
+  C extends Any,
+  A = any,
+  O = A,
+  I = unknown,
+> extends Type<A, O, I> {
+  readonly type: C;
+  readonly _tag: 'ReadonlyType';
+  constructor(
+    name: string,
+    is: ReadonlyType<C, A, O, I>['is'],
+    validate: ReadonlyType<C, A, O, I>['validate'],
+    encode: ReadonlyType<C, A, O, I>['encode'],
+    type: C,
+  );
+}
+/**
+ * @since 1.5.3
+ */
+export interface ReadonlyC<C extends Mixed>
+  extends ReadonlyType<
+    C,
+    {
+      readonly [K in keyof TypeOf<C>]: TypeOf<C>[K];
+    },
+    {
+      readonly [K in keyof OutputOf<C>]: OutputOf<C>[K];
+    },
+    unknown
+  > {}
+/**
+ * @since 1.0.0
+ */
+export declare const readonly: <C extends Mixed>(
+  codec: C,
+  name?: string,
+) => ReadonlyC<C>;
+/**
+ * @since 1.0.0
+ */
+export declare class ReadonlyArrayType<
+  C extends Any,
+  A = any,
+  O = A,
+  I = unknown,
+> extends Type<A, O, I> {
+  readonly type: C;
+  readonly _tag: 'ReadonlyArrayType';
+  constructor(
+    name: string,
+    is: ReadonlyArrayType<C, A, O, I>['is'],
+    validate: ReadonlyArrayType<C, A, O, I>['validate'],
+    encode: ReadonlyArrayType<C, A, O, I>['encode'],
+    type: C,
+  );
+}
+/**
+ * @since 1.5.3
+ */
+export interface ReadonlyArrayC<C extends Mixed>
+  extends ReadonlyArrayType<
+    C,
+    ReadonlyArray<TypeOf<C>>,
+    ReadonlyArray<OutputOf<C>>,
+    unknown
+  > {}
+/**
+ * @since 1.0.0
+ */
+export declare const readonlyArray: <C extends Mixed>(
+  codec: C,
+  name?: string,
+) => ReadonlyArrayC<C>;
+/**
+ * Strips additional properties
+ * @since 1.0.0
+ */
+export declare const strict: <P extends Props>(
+  props: P,
+  name?: string,
+) => ExactC<TypeC<P>>;
+/**
+ * @since 1.3.0
+ * @deprecated
+ */
+export declare class TaggedUnionType<
+  Tag extends string,
+  CS extends Array<Mixed>,
+  A = any,
+  O = A,
+  I = unknown,
+> extends UnionType<CS, A, O, I> {
+  readonly tag: Tag;
+  constructor(
+    name: string,
+    is: TaggedUnionType<Tag, CS, A, O, I>['is'],
+    validate: TaggedUnionType<Tag, CS, A, O, I>['validate'],
+    encode: TaggedUnionType<Tag, CS, A, O, I>['encode'],
+    codecs: CS,
+    tag: Tag,
+  );
+}
+/**
+ * @since 1.5.3
+ * @deprecated
+ */
+export interface TaggedUnionC<
+    Tag extends string,
+    CS extends [Mixed, Mixed, ...Array<Mixed>],
+  > // tslint:disable-next-line: deprecation
+  extends TaggedUnionType<Tag, CS, TypeOf<CS[number]>, OutputOf<CS[number]>, unknown> {}
+/**
+ * Use `union` instead
+ *
+ * @since 1.3.0
+ * @deprecated
+ */
+export declare const taggedUnion: <
+  Tag extends string,
+  CS extends [Mixed, Mixed, ...Mixed[]],
+>(
+  tag: Tag,
+  codecs: CS,
+  name?: string,
+) => TaggedUnionC<Tag, CS>;
+/**
+ * @since 1.1.0
+ */
+export declare class ExactType<C extends Any, A = any, O = A, I = unknown> extends Type<
+  A,
+  O,
+  I
+> {
+  readonly type: C;
+  readonly _tag: 'ExactType';
+  constructor(
+    name: string,
+    is: ExactType<C, A, O, I>['is'],
+    validate: ExactType<C, A, O, I>['validate'],
+    encode: ExactType<C, A, O, I>['encode'],
+    type: C,
+  );
+}
+/**
+ * @since 1.1.0
+ */
+export interface HasPropsRefinement extends RefinementType<HasProps, any, any, any> {}
+/**
+ * @since 1.1.0
+ */
+export interface HasPropsReadonly extends ReadonlyType<HasProps, any, any, any> {}
+/**
+ * @since 1.1.0
+ */
+export interface HasPropsIntersection
+  extends IntersectionType<Array<HasProps>, any, any, any> {}
+/**
+ * @since 1.1.0
+ */
+export type HasProps =
+  | HasPropsRefinement
+  | HasPropsReadonly
+  | HasPropsIntersection
+  | InterfaceType<any, any, any, any>
+  | StrictType<any, any, any, any>
+  | PartialType<any, any, any, any>;
+/**
+ * @since 1.5.3
+ */
+export interface ExactC<C extends HasProps>
+  extends ExactType<C, TypeOf<C>, OutputOf<C>, InputOf<C>> {}
+/**
+ * Strips additional properties
+ * @since 1.1.0
+ */
+export declare const exact: <C extends HasProps>(codec: C, name?: string) => ExactC<C>;
+export {
+  /**
+   * @since 1.0.0
+   */
+  nullType as null,
+};
+export {
+  /**
+   * @since 1.0.0
+   */
+  undefinedType as undefined,
+};
+export {
+  /**
+   * Use `UnknownArray` instead
+   * @deprecated
+   * @since 1.0.0
+   */
+  UnknownArray as Array,
+};
+export {
+  /**
+   * Use `type` instead
+   * @deprecated
+   * @since 1.0.0
+   */
+  type as interface,
+};
+export {
+  /**
+   * @since 1.0.0
+   */
+  voidType as void,
+};
+/**
+ * Use `unknown` instead
+ * @since 1.0.0
+ * @deprecated
+ */
+export type mixed = unknown;
+/**
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare const getValidationError: (
+  value: unknown,
+  context: Context,
+) => ValidationError;
+/**
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare const getDefaultContext: (decoder: Decoder<any, any>) => Context;
+/**
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare class NeverType extends Type<never> {
+  readonly _tag: 'NeverType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ * @deprecated
+ */
+export interface NeverC extends NeverType {}
+/**
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare const never: NeverC;
+/**
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare class AnyType extends Type<any> {
+  readonly _tag: 'AnyType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ * @deprecated
+ */
+export interface AnyC extends AnyType {}
+/**
+ * Use `unknown` instead
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare const any: AnyC;
+/**
+ * Use `UnknownRecord` instead
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare const Dictionary: UnknownRecordC;
+/**
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare class ObjectType extends Type<object> {
+  readonly _tag: 'ObjectType';
+  constructor();
+}
+/**
+ * @since 1.5.3
+ * @deprecated
+ */
+export interface ObjectC extends ObjectType {}
+/**
+ * Use `UnknownRecord` instead
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare const object: ObjectC;
+/**
+ * Use `BrandC` instead
+ * @since 1.5.3
+ * @deprecated
+ */
+export interface RefinementC<C extends Any>
+  extends RefinementType<C, TypeOf<C>, OutputOf<C>, InputOf<C>> {}
+/**
+ * Use `brand` instead
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare function refinement<C extends Any>(
+  codec: C,
+  predicate: Predicate<TypeOf<C>>,
+  name?: string,
+): RefinementC<C>;
+/**
+ * Use `Int` instead
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare const Integer: RefinementC<NumberC>;
+/**
+ * Use `record` instead
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare const dictionary: typeof record;
+/**
+ * used in `intersection` as a workaround for #234
+ * @since 1.4.2
+ * @deprecated
+ */
+export type Compact<A> = {
+  [K in keyof A]: A[K];
+};
+/**
+ * @since 1.0.0
+ * @deprecated
+ */
+export declare class StrictType<P, A = any, O = A, I = unknown> extends Type<A, O, I> {
+  readonly props: P;
+  readonly _tag: 'StrictType';
+  constructor(
+    name: string,
+    is: StrictType<P, A, O, I>['is'],
+    validate: StrictType<P, A, O, I>['validate'],
+    encode: StrictType<P, A, O, I>['encode'],
+    props: P,
+  );
+}
+/**
+ * @since 1.5.3
+ * @deprecated
+ */
+export interface StrictC<P extends Props> // tslint:disable-next-line: deprecation
+  extends StrictType<
+    P,
+    {
+      [K in keyof P]: TypeOf<P[K]>;
+    },
+    {
+      [K in keyof P]: OutputOf<P[K]>;
+    },
+    unknown
+  > {}
+/**
+ * @since 1.3.0
+ * @deprecated
+ */
+export type TaggedProps<Tag extends string> = {
+  [K in Tag]: LiteralType<any>;
+};
+/**
+ * @since 1.3.0
+ * @deprecated
+ */
+export interface TaggedRefinement<Tag extends string, A, O = A>
+  extends RefinementType<Tagged<Tag>, A, O> {}
+/**
+ * @since 1.3.0
+ * @deprecated
+ */
+export interface TaggedUnion<Tag extends string, A, O = A>
+  extends UnionType<Array<Tagged<Tag>>, A, O> {}
+/**
+ * @since 1.3.0
+ * @deprecated
+ */
+export type TaggedIntersectionArgument<Tag extends string> =
+  | [Tagged<Tag>]
+  | [Tagged<Tag>, Mixed]
+  | [Mixed, Tagged<Tag>]
+  | [Tagged<Tag>, Mixed, Mixed]
+  | [Mixed, Tagged<Tag>, Mixed]
+  | [Mixed, Mixed, Tagged<Tag>]
+  | [Tagged<Tag>, Mixed, Mixed, Mixed]
+  | [Mixed, Tagged<Tag>, Mixed, Mixed]
+  | [Mixed, Mixed, Tagged<Tag>, Mixed]
+  | [Mixed, Mixed, Mixed, Tagged<Tag>]
+  | [Tagged<Tag>, Mixed, Mixed, Mixed, Mixed]
+  | [Mixed, Tagged<Tag>, Mixed, Mixed, Mixed]
+  | [Mixed, Mixed, Tagged<Tag>, Mixed, Mixed]
+  | [Mixed, Mixed, Mixed, Tagged<Tag>, Mixed]
+  | [Mixed, Mixed, Mixed, Mixed, Tagged<Tag>];
+/**
+ * @since 1.3.0
+ * @deprecated
+ */
+export interface TaggedIntersection<Tag extends string, A, O = A> // tslint:disable-next-line: deprecation
+  extends IntersectionType<TaggedIntersectionArgument<Tag>, A, O> {}
+/**
+ * @since 1.3.0
+ * @deprecated
+ */
+export interface TaggedExact<Tag extends string, A, O = A>
+  extends ExactType<Tagged<Tag>, A, O> {}
+/**
+ * @since 1.3.0
+ * @deprecated
+ */
+export type Tagged<Tag extends string, A = any, O = A> =
+  | InterfaceType<TaggedProps<Tag>, A, O>
+  | StrictType<TaggedProps<Tag>, A, O>
+  | TaggedRefinement<Tag, A, O>
+  | TaggedUnion<Tag, A, O>
+  | TaggedIntersection<Tag, A, O>
+  | TaggedExact<Tag, A, O>
+  | RecursiveType<any, A, O>;
+/**
+ * Drops the codec "kind"
+ * @since 1.1.0
+ * @deprecated
+ */
+export declare function clean<A, O = A, I = unknown>(
+  codec: Type<A, O, I>,
+): Type<A, O, I>;
+/**
+ * @since 1.0.0
+ * @deprecated
+ */
+export type PropsOf<
+  T extends {
+    props: any;
+  },
+> = T['props'];
+/**
+ * @since 1.1.0
+ * @deprecated
+ */
+export type Exact<T, X extends T> = T & {
+  [K in ({
+    [K in keyof X]: K;
+  } & {
+    [K in keyof T]: never;
+  } & {
+    [key: string]: never;
+  })[keyof X]]?: never;
+};
+/**
+ * Keeps the codec "kind"
+ * @since 1.1.0
+ * @deprecated
+ */
+export declare function alias<A, O, P, I>(
+  codec: PartialType<P, A, O, I>,
+): <
+  AA extends A,
+  OO extends O = O,
+  PP extends P = P,
+  II extends I = I,
+>() => PartialType<PP, AA, OO, II>;
+export declare function alias<A, O, P, I>(
+  codec: StrictType<P, A, O, I>,
+): <AA extends A, OO extends O = O, PP extends P = P, II extends I = I>() => StrictType<
+  PP,
+  AA,
+  OO,
+  II
+>;
+export declare function alias<A, O, P, I>(
+  codec: InterfaceType<P, A, O, I>,
+): <
+  AA extends A,
+  OO extends O = O,
+  PP extends P = P,
+  II extends I = I,
+>() => InterfaceType<PP, AA, OO, II>;

--- a/packages/types-io-ts/package.json
+++ b/packages/types-io-ts/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@types/io-ts",
+  "version": "2.1.3-fixed",
+  "description": "",
+  "main": "",
+  "typings": "lib/index.d.ts",
+  "scripts": {},
+  "author": "",
+  "license": "Apache-2.0"
+}

--- a/website/docs/tutorial-basics/create-an-api-spec.md
+++ b/website/docs/tutorial-basics/create-an-api-spec.md
@@ -54,7 +54,7 @@ In your new directory, create a `package.json` file:
     "io-ts": "2.1.3"
   },
   "devDependencies": {
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   }
 }
 ```

--- a/website/docs/tutorial-basics/create-an-http-client.md
+++ b/website/docs/tutorial-basics/create-an-http-client.md
@@ -32,7 +32,7 @@ As before, first edit your `package.json` file to add our new dependencies
     "@types/express": "4.17.13",
     "@types/node": "18.6.1",
     "@types/superagent": "4.1.15",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   }
 }
 ```

--- a/website/docs/tutorial-basics/create-an-http-server.md
+++ b/website/docs/tutorial-basics/create-an-http-server.md
@@ -34,7 +34,7 @@ First, edit your `package.json` file to add a few new dependencies (highlighted)
   "devDependencies": {
     "@types/express": "4.17.13",
     "@types/node": "18.6.1",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   }
 }
 ```

--- a/website/docs/tutorial-basics/render-an-open-api-spec.md
+++ b/website/docs/tutorial-basics/render-an-open-api-spec.md
@@ -36,7 +36,7 @@ As before, first edit your `package.json` file to add our new dependencies
     "@types/express": "4.17.13",
     "@types/node": "18.6.1",
     "@types/superagent": "4.1.15",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   }
 }
 ```


### PR DESCRIPTION
Allows Typescript to be ugraded to the latest version by fixing an issue with the types in `io-ts` 2.1.3. This is mostly a backport of the fix done in https://github.com/gcanti/io-ts/pull/657.

Rather than maintaining a fork of `io-ts`, I opted to instead export the fixed declarations into a vendored `@types/io-ts` package, then added `paths` entries in `tsconfig.json` to force `tsc` to favor these declarations over the ones bundled with upstream `io-ts`. This technique should be possible to replicate in other packages that want to upgrade TS without moving off of `io-ts` 2.1.3