### PR TITLE
Use patch-package to unblock Typescript upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17848,20 +17848,20 @@
         "@swc-node/register": "1.6.8",
         "@types/express": "4.17.18",
         "c8": "8.0.1",
-        "typescript": "4.7.4"
+        "typescript": "5.2.2"
       }
     },
     "packages/express-wrapper/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "packages/io-ts-http": {
@@ -17877,20 +17877,20 @@
       "devDependencies": {
         "@swc-node/register": "1.6.8",
         "c8": "8.0.1",
-        "typescript": "4.7.4"
+        "typescript": "5.2.2"
       }
     },
     "packages/io-ts-http/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "packages/openapi-generator": {
@@ -17915,7 +17915,7 @@
         "@types/resolve": "1.20.3",
         "c8": "8.0.1",
         "memfs": "4.5.0",
-        "typescript": "4.7.4"
+        "typescript": "5.2.2"
       },
       "optionalDependencies": {
         "@swc/core-darwin-arm64": "1.3.91",
@@ -17923,16 +17923,16 @@
       }
     },
     "packages/openapi-generator/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "packages/response": {
@@ -17940,20 +17940,20 @@
       "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "devDependencies": {
-        "typescript": "4.7.4"
+        "typescript": "5.2.2"
       }
     },
     "packages/response/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "packages/superagent-wrapper": {
@@ -17978,23 +17978,23 @@
         "io-ts-types": "0.5.19",
         "superagent": "8.1.2",
         "supertest": "6.3.3",
-        "typescript": "4.7.4"
+        "typescript": "5.2.2"
       },
       "peerDependencies": {
         "superagent": "*"
       }
     },
     "packages/superagent-wrapper/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "packages/typed-express-router": {
@@ -18012,20 +18012,20 @@
         "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
         "@swc-node/register": "1.6.8",
         "c8": "8.0.1",
-        "typescript": "4.7.4"
+        "typescript": "5.2.2"
       }
     },
     "packages/typed-express-router/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     }
   }

--- a/packages/express-wrapper/package.json
+++ b/packages/express-wrapper/package.json
@@ -28,7 +28,7 @@
     "@swc-node/register": "1.6.8",
     "@types/express": "4.17.18",
     "c8": "8.0.1",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/express-wrapper/src/middleware.ts
+++ b/packages/express-wrapper/src/middleware.ts
@@ -80,7 +80,7 @@ export type MiddlewareChain =
     ];
 
 export type MiddlewareChainOutput<
-  Input,
+  Input extends {},
   Chain extends MiddlewareChain,
 > = Chain extends []
   ? Input

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@swc-node/register": "1.6.8",
     "c8": "8.0.1",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -34,7 +34,7 @@
     "@types/resolve": "1.20.3",
     "c8": "8.0.1",
     "memfs": "4.5.0",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "optionalDependencies": {
     "@swc/core-linux-x64-gnu": "1.3.91",

--- a/packages/response/package.json
+++ b/packages/response/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf -- dist"
   },
   "devDependencies": {
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -34,7 +34,7 @@
     "io-ts-types": "0.5.19",
     "superagent": "8.1.2",
     "supertest": "6.3.3",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "superagent": "*"

--- a/packages/typed-express-router/package.json
+++ b/packages/typed-express-router/package.json
@@ -27,7 +27,7 @@
     "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
     "@swc-node/register": "1.6.8",
     "c8": "8.0.1",
-    "typescript": "4.7.4"
+    "typescript": "5.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/patches/io-ts+2.1.3.patch
+++ b/patches/io-ts+2.1.3.patch
@@ -1,0 +1,19 @@
+This is a backport of this fix to version 2.1.3:
+https://github.com/gcanti/io-ts/pull/657
+
+It allows Typescript to be upgraded beyond version 4.7.4
+
+diff --git a/node_modules/io-ts/lib/index.d.ts b/node_modules/io-ts/lib/index.d.ts
+index 17c4ce8..1a7545c 100644
+--- a/node_modules/io-ts/lib/index.d.ts
++++ b/node_modules/io-ts/lib/index.d.ts
+@@ -996,6 +996,6 @@ export declare type Exact<T, X extends T> = T & {
+  * @since 1.1.0
+  * @deprecated
+  */
+-export declare function alias<A, O, P, I>(codec: PartialType<P, A, O, I>): <AA extends Exact<A, AA>, OO extends Exact<O, OO> = O, PP extends Exact<P, PP> = P, II extends I = I>() => PartialType<PP, AA, OO, II>;
+-export declare function alias<A, O, P, I>(codec: StrictType<P, A, O, I>): <AA extends Exact<A, AA>, OO extends Exact<O, OO> = O, PP extends Exact<P, PP> = P, II extends I = I>() => StrictType<PP, AA, OO, II>;
+-export declare function alias<A, O, P, I>(codec: InterfaceType<P, A, O, I>): <AA extends Exact<A, AA>, OO extends Exact<O, OO> = O, PP extends Exact<P, PP> = P, II extends I = I>() => InterfaceType<PP, AA, OO, II>;
++export declare function alias<A, O, P, I>(codec: PartialType<P, A, O, I>): <AA extends A, OO extends O = O, PP extends P = P, II extends I = I>() => PartialType<PP, AA, OO, II>;
++export declare function alias<A, O, P, I>(codec: StrictType<P, A, O, I>): <AA extends A, OO extends O = O, PP extends P = P, II extends I = I>() => StrictType<PP, AA, OO, II>;
++export declare function alias<A, O, P, I>(codec: InterfaceType<P, A, O, I>): <AA extends A, OO extends O = O, PP extends P = P, II extends I = I>() => InterfaceType<PP, AA, OO, II>;


### PR DESCRIPTION
This is an alternative to #581 using patch-package instead of a pseudo-`@types` package.