### PR TITLE
feat(openapi-generator): propagate nullable status through unions

### DIFF
--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -334,3 +334,68 @@ testCase('request union route', UNION, {
     schemas: {},
   },
 });
+
+const NULLABLE_PROPERTY = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({
+    body: {
+      foo: t.union([t.string, t.null]),
+    },
+  }),
+  response: {
+    /** foo response */
+    200: t.string
+  },
+});
+`;
+
+testCase('nullable property route', NULLABLE_PROPERTY, {
+  openapi: '3.0.0',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/foo': {
+      get: {
+        parameters: [],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  foo: {
+                    type: 'string',
+                    nullable: true,
+                  },
+                },
+                required: ['foo'],
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: 'foo response',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});


### PR DESCRIPTION
`nullable` is a property of other types in OpenAPI, whereas it is a distinct IR node in this project. This implements simplifying IR unions of a type and null into a single nullable type.