### PR TITLE
chore: add noop test script for the response package

### DIFF
--- a/packages/response/package.json
+++ b/packages/response/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "tsc --build --incremental --verbose .",
+    "test": "echo 'No tests defined'",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "clean": "rm -rf -- dist"


### PR DESCRIPTION
Should fix this error in CI: https://github.com/BitGo/api-ts/actions/runs/6695330535/job/18197556505?pr=607#step:6:769