### PR TITLE
chore: add build and test scripts to the root directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
           npm ci
 
       - name: Compile TypeScript
-        run: npm run build --workspaces
+        run: npm run build
 
       - name: Test
-        run: npm test --workspaces --if-present
+        run: npm test
 
   # Only run CI for GitHub Pages on Node.js 16 because docusaurus doesn't support
   # earlier Node.js versions.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,12 @@ jobs:
         run: npm ci
 
       - name: Compile TypeScript
-        run: npm run build --workspaces
+        run: npm run build
 
       # Run tests before releasing to verify the code behaves as expected. We expect
       # this step to identify some (but not all) semantic merge conflicts
       - name: Test
-        run: npm test --workspaces --if-present
+        run: npm test
 
       # DISCUSS: Use `jq` or just a small node script to create/modify `.npmrc` in case
       # one gets added in the future

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   ],
   "packageManager": "npm@8.5.0",
   "scripts": {
+    "build": "npm run --workspaces build",
+    "test": "npm run --workspaces --if-present test",
     "distclean": "rm -rf node_modules packages/*/node_modules",
     "lint-staged": "lint-staged",
     "postinstall": "patch-package"


### PR DESCRIPTION
When I enter the repository directory, I habitually try to build and test
in that directory. Presently, that isn't supported in this repo.

This commit adds top-level build and test npm scripts so those actions
are supported.