### PR TITLE
chore: upgrade @semantic-release-extras/github-comment-specific to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "packages/**"
       ],
       "devDependencies": {
-        "@semantic-release-extras/github-comment-specific": "1.0.9",
+        "@semantic-release-extras/github-comment-specific": "2.0.1",
         "@semantic-release/npm": "11.0.1",
         "@types/node": "20.9.0",
         "lint-staged": "15.0.2",
@@ -818,15 +818,19 @@
       }
     },
     "node_modules/@semantic-release-extras/github-comment-specific": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@semantic-release-extras/github-comment-specific/-/github-comment-specific-1.0.9.tgz",
-      "integrity": "sha512-uO4upHJvewDewKD0rO0qEeCaqMKE7QY4j7VvOjd4CzD+eNatzdo2TGx7l68ey6qbFCHybpSdVA+EH29diATnoA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release-extras/github-comment-specific/-/github-comment-specific-2.0.1.tgz",
+      "integrity": "sha512-fCytRxRzzCqtvGuB4KiGL8OA6eenGfypEjBH+RhvL2hOZaZtu+RzvGuSmrdkzdVt/e6UwfE8nZvNtKPD2dusPg==",
       "dev": true,
       "dependencies": {
         "@octokit/plugin-throttling": "^8.0.0",
         "@octokit/rest": "^20.0.0",
         "@semantic-release/github": "^9.0.0",
-        "issue-parser": "6.0.0"
+        "issue-parser": "6.0.0",
+        "lodash-es": "^4.17.21"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/@semantic-release-extras/github-comment-specific/node_modules/@octokit/auth-token": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "pre-commit": "lint-staged",
   "devDependencies": {
-    "@semantic-release-extras/github-comment-specific": "1.0.9",
+    "@semantic-release-extras/github-comment-specific": "2.0.1",
     "@semantic-release/npm": "11.0.1",
     "@types/node": "20.9.0",
     "lint-staged": "15.0.2",


### PR DESCRIPTION
Which hopefully fixes this error[^1]

```
[2:00:21 PM] › 🎉  Started multirelease! Loading 6 packages...
[multi-semantic-release]: Error [ERR_REQUIRE_ESM]: require() of ES Module /home/runner/work/api-ts/api-ts/node_modules/@semantic-release-extras/github-comment-specific/node_modules/p-filter/index.js from /home/runner/work/api-ts/api-ts/node_modules/@semantic-release-extras/github-comment-specific/dist/index.js not supported.
Instead change the require of /home/runner/work/api-ts/api-ts/node_modules/@semantic-release-extras/github-comment-specific/node_modules/p-filter/index.js in /home/runner/work/api-ts/api-ts/node_modules/@semantic-release-extras/github-comment-specific/dist/index.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/home/runner/work/api-ts/api-ts/node_modules/@semantic-release-extras/github-comment-specific/dist/index.js:66:15)
    at loadPlugin (/home/runner/work/api-ts/api-ts/node_modules/multi-semantic-release/node_modules/semantic-release/lib/plugins/utils.js:51:36)
    at /home/runner/work/api-ts/api-ts/node_modules/multi-semantic-release/node_modules/semantic-release/lib/plugins/index.js:17:37
    at Array.reduce (<anonymous>)
    at module.exports (/home/runner/work/api-ts/api-ts/node_modules/multi-semantic-release/node_modules/semantic-release/lib/plugins/index.js:14:34)
    at module.exports (/home/runner/work/api-ts/api-ts/node_modules/multi-semantic-release/node_modules/semantic-release/lib/get-config.js:84:35)
    at async getConfigSemantic (/home/runner/work/api-ts/api-ts/node_modules/multi-semantic-release/lib/getConfigSemantic.js:21:10)
    at async getPackage (/home/runner/work/api-ts/api-ts/node_modules/multi-semantic-release/lib/multiSemanticRelease.js:157:31)
    at async Promise.all (index 0)
    at async multiSemanticRelease (/home/runner/work/api-ts/api-ts/node_modules/multi-semantic-release/lib/multiSemanticRelease.js:70:22) {
  code: 'ERR_REQUIRE_ESM'
}
```

[^1]: https://github.com/BitGo/api-ts/actions/runs/6799264165/job/18485202390#step:8:31