### PR TITLE
Simplify primitive IR type

### DIFF
--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -48,13 +48,12 @@ create a JS file with the following format:
 module.exports = (E) => {
   return {
     'io-ts-bigint': {
-      BigIntFromString: () => E.right({ type: 'primitive', value: 'string' }),
-      NonZeroBigInt: () => E.right({ type: 'primitive', value: 'number' }),
-      NonZeroBigIntFromString: () => E.right({ type: 'primitive', value: 'string' }),
-      NegativeBigIntFromString: () => E.right({ type: 'primitive', value: 'string' }),
-      NonNegativeBigIntFromString: () =>
-        E.right({ type: 'primitive', value: 'string' }),
-      PositiveBigIntFromString: () => E.right({ type: 'primitive', value: 'string' }),
+      BigIntFromString: () => E.right({ type: 'string' }),
+      NonZeroBigInt: () => E.right({ type: 'number' }),
+      NonZeroBigIntFromString: () => E.right({ type: 'string' }),
+      NegativeBigIntFromString: () => E.right({ type: 'string' }),
+      NonNegativeBigIntFromString: () => E.right({ type: 'string' }),
+      PositiveBigIntFromString: () => E.right({ type: 'string' }),
     },
     // ... and so on for other packages
   };

--- a/packages/openapi-generator/src/codec.ts
+++ b/packages/openapi-generator/src/codec.ts
@@ -291,13 +291,13 @@ export function parsePlainInitializer(
   } else if (init.type === 'ArrayExpression') {
     return parseArrayExpression(project, source, init);
   } else if (init.type === 'StringLiteral') {
-    return E.right({ type: 'primitive', value: 'string', enum: [init.value] });
+    return E.right({ type: 'string', enum: [init.value] });
   } else if (init.type === 'NumericLiteral') {
-    return E.right({ type: 'primitive', value: 'number', enum: [init.value] });
+    return E.right({ type: 'number', enum: [init.value] });
   } else if (init.type === 'BooleanLiteral') {
-    return E.right({ type: 'primitive', value: 'boolean', enum: [init.value] });
+    return E.right({ type: 'boolean', enum: [init.value] });
   } else if (init.type === 'NullLiteral') {
-    return E.right({ type: 'primitive', value: 'null', enum: [null] });
+    return E.right({ type: 'null', enum: [null] });
   } else if (init.type === 'Identifier' && init.value === 'undefined') {
     return E.right({ type: 'undefined' });
   } else if (init.type === 'TsConstAssertion' || init.type === 'TsAsExpression') {

--- a/packages/openapi-generator/src/ir.ts
+++ b/packages/openapi-generator/src/ir.ts
@@ -10,10 +10,19 @@ export type UndefinedValue = {
 };
 
 export type Primitive = {
-  type: 'primitive';
-  value: 'string' | 'number' | 'integer' | 'boolean' | 'null';
+  type: 'string' | 'number' | 'integer' | 'boolean' | 'null';
   enum?: (string | number | boolean | null | PseudoBigInt)[];
 };
+
+export function isPrimitive(schema: Schema): schema is Primitive {
+  return (
+    schema.type === 'string' ||
+    schema.type === 'number' ||
+    schema.type === 'integer' ||
+    schema.type === 'boolean' ||
+    schema.type === 'null'
+  );
+}
 
 export type Array = {
   type: 'array';

--- a/packages/openapi-generator/src/knownImports.ts
+++ b/packages/openapi-generator/src/knownImports.ts
@@ -1,6 +1,6 @@
 import * as E from 'fp-ts/Either';
 
-import type { Schema } from './ir';
+import { isPrimitive, type Schema } from './ir';
 
 export type DerefFn = (ref: Schema) => E.Either<string, Schema>;
 export type KnownCodec = (
@@ -26,10 +26,10 @@ function isOptional(schema: Schema): boolean {
 
 export const KNOWN_IMPORTS: KnownImports = {
   'io-ts': {
-    string: () => E.right({ type: 'primitive', value: 'string' }),
-    number: () => E.right({ type: 'primitive', value: 'number' }),
-    boolean: () => E.right({ type: 'primitive', value: 'boolean' }),
-    null: () => E.right({ type: 'primitive', value: 'null' }),
+    string: () => E.right({ type: 'string' }),
+    number: () => E.right({ type: 'number' }),
+    boolean: () => E.right({ type: 'boolean' }),
+    null: () => E.right({ type: 'null' }),
     undefined: () => E.right({ type: 'undefined' }),
     array: (_, innerSchema) => E.right({ type: 'array', items: innerSchema }),
     readonlyArray: (_, innerSchema) => E.right({ type: 'array', items: innerSchema }),
@@ -89,7 +89,7 @@ export const KNOWN_IMPORTS: KnownImports = {
       return E.right({ type: 'intersection', schemas: schema.schemas });
     },
     literal: (_, arg) => {
-      if (arg.type !== 'primitive' || arg.enum === undefined) {
+      if (!isPrimitive(arg) || arg.enum === undefined) {
         return E.left(`Unimplemented literal type ${arg.type}`);
       } else {
         return E.right(arg);
@@ -100,8 +100,7 @@ export const KNOWN_IMPORTS: KnownImports = {
         return E.left(`Unimplemented keyof type ${arg.type}`);
       }
       const schemas: Schema[] = Object.keys(arg.properties).map((prop) => ({
-        type: 'primitive',
-        value: 'string',
+        type: 'string',
         enum: [prop],
       }));
       return E.right({
@@ -112,20 +111,20 @@ export const KNOWN_IMPORTS: KnownImports = {
     brand: (_, arg) => E.right(arg),
   },
   'io-ts-types': {
-    BigIntFromString: () => E.right({ type: 'primitive', value: 'string' }),
-    BooleanFromNumber: () => E.right({ type: 'primitive', value: 'number' }),
-    BooleanFromString: () => E.right({ type: 'primitive', value: 'string' }),
-    DateFromISOString: () => E.right({ type: 'primitive', value: 'string' }),
-    DateFromNumber: () => E.right({ type: 'primitive', value: 'number' }),
-    DateFromUnixTime: () => E.right({ type: 'primitive', value: 'number' }),
-    IntFromString: () => E.right({ type: 'primitive', value: 'string' }),
-    JsonFromString: () => E.right({ type: 'primitive', value: 'string' }),
+    BigIntFromString: () => E.right({ type: 'string' }),
+    BooleanFromNumber: () => E.right({ type: 'number' }),
+    BooleanFromString: () => E.right({ type: 'string' }),
+    DateFromISOString: () => E.right({ type: 'string' }),
+    DateFromNumber: () => E.right({ type: 'number' }),
+    DateFromUnixTime: () => E.right({ type: 'number' }),
+    IntFromString: () => E.right({ type: 'string' }),
+    JsonFromString: () => E.right({ type: 'string' }),
     nonEmptyArray: (_, innerSchema) => E.right({ type: 'array', items: innerSchema }),
-    NonEmptyString: () => E.right({ type: 'primitive', value: 'string' }),
-    NumberFromString: () => E.right({ type: 'primitive', value: 'string' }),
+    NonEmptyString: () => E.right({ type: 'string' }),
+    NumberFromString: () => E.right({ type: 'string' }),
     readonlyNonEmptyArray: (_, innerSchema) =>
       E.right({ type: 'array', items: innerSchema }),
-    UUID: () => E.right({ type: 'primitive', value: 'string' }),
+    UUID: () => E.right({ type: 'string' }),
   },
   '@api-ts/io-ts-http': {
     optional: (_, innerSchema) =>

--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -12,16 +12,16 @@ function schemaToOpenAPI(
   schema = optimize(schema);
 
   switch (schema.type) {
-    case 'primitive':
-      if (schema.value === 'integer') {
-        return { type: 'number', ...(schema.enum ? { enum: schema.enum } : {}) };
-      } else if (schema.value === 'null') {
-        // TODO: OpenAPI v3 does not have an explicit null type, is there a better way to represent this?
-        // Or should we just conflate explicit null and undefined properties?
-        return { nullable: true, enum: [] };
-      } else {
-        return { type: schema.value, ...(schema.enum ? { enum: schema.enum } : {}) };
-      }
+    case 'boolean':
+    case 'string':
+    case 'number':
+      return { type: schema.type, ...(schema.enum ? { enum: schema.enum } : {}) };
+    case 'integer':
+      return { type: 'number', ...(schema.enum ? { enum: schema.enum } : {}) };
+    case 'null':
+      // TODO: OpenAPI v3 does not have an explicit null type, is there a better way to represent this?
+      // Or should we just conflate explicit null and undefined properties?
+      return { nullable: true, enum: [] };
     case 'ref':
       return { $ref: `#/components/schemas/${schema.name}` };
     case 'array':
@@ -60,7 +60,7 @@ function schemaToOpenAPI(
       let nullable = false;
       let oneOf: (OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject)[] = [];
       for (const s of schema.schemas) {
-        if (s.type === 'primitive' && s.value === 'null') {
+        if (s.type === 'null') {
           nullable = true;
           continue;
         }

--- a/packages/openapi-generator/src/route.ts
+++ b/packages/openapi-generator/src/route.ts
@@ -210,8 +210,7 @@ export function parseRoute(project: Project, schema: Schema): E.Either<string, R
   if (schema.properties['path'] === undefined) {
     return E.left('Route must have a path');
   } else if (
-    schema.properties['path'].type !== 'primitive' ||
-    schema.properties['path'].value !== 'string' ||
+    schema.properties['path'].type !== 'string' ||
     schema.properties['path'].enum?.length !== 1
   ) {
     return E.left('Route path must be a string literal');
@@ -220,8 +219,7 @@ export function parseRoute(project: Project, schema: Schema): E.Either<string, R
   if (schema.properties['method'] === undefined) {
     return E.left('Route must have a method');
   } else if (
-    schema.properties['method'].type !== 'primitive' ||
-    schema.properties['method'].value !== 'string' ||
+    schema.properties['method'].type !== 'string' ||
     schema.properties['method'].enum?.length !== 1
   ) {
     return E.left('Route method must be a string literal');

--- a/packages/openapi-generator/test/apiSpec.test.ts
+++ b/packages/openapi-generator/test/apiSpec.test.ts
@@ -79,7 +79,7 @@ testCase('simple api spec', SIMPLE, '/index.ts', {
       path: '/test',
       method: 'GET',
       parameters: [],
-      response: { 200: { type: 'primitive', value: 'string' } },
+      response: { 200: { type: 'string' } },
     },
   ],
 });
@@ -111,7 +111,7 @@ testCase('const route reference', ROUTE_REF, '/index.ts', {
       path: '/test',
       method: 'GET',
       parameters: [],
-      response: { 200: { type: 'primitive', value: 'string' } },
+      response: { 200: { type: 'string' } },
     },
   ],
 });
@@ -143,7 +143,7 @@ testCase('const action reference', ACTION_REF, '/index.ts', {
       path: '/test',
       method: 'GET',
       parameters: [],
-      response: { 200: { type: 'primitive', value: 'string' } },
+      response: { 200: { type: 'string' } },
     },
   ],
 });
@@ -181,7 +181,7 @@ testCase('spread api spec', SPREAD, '/index.ts', {
       path: '/test',
       method: 'GET',
       parameters: [],
-      response: { 200: { type: 'primitive', value: 'string' } },
+      response: { 200: { type: 'string' } },
     },
   ],
 });
@@ -215,7 +215,7 @@ testCase('computed property api spec', COMPUTED_PROPERTY, '/index.ts', {
       path: '/test',
       method: 'GET',
       parameters: [],
-      response: { 200: { type: 'primitive', value: 'string' } },
+      response: { 200: { type: 'string' } },
     },
   ],
 });

--- a/packages/openapi-generator/test/codec.test.ts
+++ b/packages/openapi-generator/test/codec.test.ts
@@ -46,7 +46,7 @@ export const FOO = t.number;
 `;
 
 testCase('simple codec is parsed', SIMPLE, {
-  FOO: { type: 'primitive', value: 'number' },
+  FOO: { type: 'number' },
 });
 
 const DIRECT = `
@@ -55,7 +55,7 @@ export const FOO = number;
 `;
 
 testCase('direct import is parsed', DIRECT, {
-  FOO: { type: 'primitive', value: 'number' },
+  FOO: { type: 'number' },
 });
 
 const TYPE = `
@@ -66,7 +66,7 @@ export const FOO = t.type({ foo: t.number });
 testCase('type is parsed', TYPE, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
 });
@@ -79,7 +79,7 @@ export const FOO = t.partial({ foo: t.number });
 testCase('partial type is parsed', PARTIAL, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: [],
   },
 });
@@ -91,10 +91,10 @@ export const FOO = t.type({ bar });
 `;
 
 testCase('shorthand property is parsed', SHORTHAND_PROPERTY, {
-  bar: { type: 'primitive', value: 'number' },
+  bar: { type: 'number' },
   FOO: {
     type: 'object',
-    properties: { bar: { type: 'primitive', value: 'number' } },
+    properties: { bar: { type: 'number' } },
     required: ['bar'],
   },
 });
@@ -110,14 +110,14 @@ export const TEST = t.type({ ...foo, bar: t.string });
 testCase('spread property is parsed', SPREAD_PROPERTY, {
   foo: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
   TEST: {
     type: 'object',
     properties: {
-      foo: { type: 'primitive', value: 'number' },
-      bar: { type: 'primitive', value: 'string' },
+      foo: { type: 'number' },
+      bar: { type: 'string' },
     },
     required: ['foo', 'bar'],
   },
@@ -132,12 +132,12 @@ export const FOO = t.type(props);
 testCase('const assertion is parsed', CONST_ASSERTION, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
   props: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
 });
@@ -153,12 +153,12 @@ export const FOO = t.type({
 testCase('spread const assertion is parsed', SPREAD_CONST_ASSERTION, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
   props: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
 });
@@ -172,12 +172,12 @@ export const FOO = t.type(props);
 testCase('as assertion is parsed', AS_ASSERTION, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
   props: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
 });
@@ -193,12 +193,12 @@ export const FOO = t.type({
 testCase('spread const assertion is parsed', SPREAD_AS_ASSERTION, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
   props: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
 });
@@ -209,7 +209,7 @@ export const FOO = t.array(t.number);
 `;
 
 testCase('array type is parsed', ARRAY, {
-  FOO: { type: 'array', items: { type: 'primitive', value: 'number' } },
+  FOO: { type: 'array', items: { type: 'number' } },
 });
 
 const UNION = `
@@ -220,10 +220,7 @@ export const FOO = t.union([t.string, t.number]);
 testCase('union type is parsed', UNION, {
   FOO: {
     type: 'union',
-    schemas: [
-      { type: 'primitive', value: 'string' },
-      { type: 'primitive', value: 'number' },
-    ],
+    schemas: [{ type: 'string' }, { type: 'number' }],
   },
 });
 
@@ -238,14 +235,11 @@ export const FOO = t.union([...common, t.number]);
 testCase('union type with spread is parsed', UNION_SPREAD, {
   FOO: {
     type: 'union',
-    schemas: [
-      { type: 'primitive', value: 'string' },
-      { type: 'primitive', value: 'number' },
-    ],
+    schemas: [{ type: 'string' }, { type: 'number' }],
   },
   common: {
     type: 'tuple',
-    schemas: [{ type: 'primitive', value: 'string' }],
+    schemas: [{ type: 'string' }],
   },
 });
 
@@ -258,10 +252,7 @@ export const FOO = t.union([...[t.string], t.number]);
 testCase('union type with inline spread is parsed', UNION_INLINE_SPREAD, {
   FOO: {
     type: 'union',
-    schemas: [
-      { type: 'primitive', value: 'string' },
-      { type: 'primitive', value: 'number' },
-    ],
+    schemas: [{ type: 'string' }, { type: 'number' }],
   },
 });
 
@@ -276,12 +267,12 @@ testCase('intersection type is parsed', INTERSECTION, {
     schemas: [
       {
         type: 'object',
-        properties: { foo: { type: 'primitive', value: 'number' } },
+        properties: { foo: { type: 'number' } },
         required: ['foo'],
       },
       {
         type: 'object',
-        properties: { bar: { type: 'primitive', value: 'string' } },
+        properties: { bar: { type: 'string' } },
         required: [],
       },
     ],
@@ -294,7 +285,7 @@ export const FOO = t.record(t.string, t.number);
 `;
 
 testCase('record type is parsed', RECORD, {
-  FOO: { type: 'record', codomain: { type: 'primitive', value: 'number' } },
+  FOO: { type: 'record', codomain: { type: 'number' } },
 });
 
 const ENUM = `
@@ -310,16 +301,16 @@ testCase('enum type is parsed', ENUM, {
   Foo: {
     type: 'object',
     properties: {
-      Foo: { type: 'primitive', value: 'string', enum: ['foo'] },
-      Bar: { type: 'primitive', value: 'string', enum: ['bar'] },
+      Foo: { type: 'string', enum: ['foo'] },
+      Bar: { type: 'string', enum: ['bar'] },
     },
     required: ['Foo', 'Bar'],
   },
   TEST: {
     type: 'union',
     schemas: [
-      { type: 'primitive', value: 'string', enum: ['Foo'] },
-      { type: 'primitive', value: 'string', enum: ['Bar'] },
+      { type: 'string', enum: ['Foo'] },
+      { type: 'string', enum: ['Bar'] },
     ],
   },
 });
@@ -330,7 +321,7 @@ export const FOO = t.literal('foo');
 `;
 
 testCase('string literal type is parsed', STRING_LITERAL, {
-  FOO: { type: 'primitive', value: 'string', enum: ['foo'] },
+  FOO: { type: 'string', enum: ['foo'] },
 });
 
 const NUMBER_LITERAL = `
@@ -339,7 +330,7 @@ export const FOO = t.literal(42);
 `;
 
 testCase('number literal type is parsed', NUMBER_LITERAL, {
-  FOO: { type: 'primitive', value: 'number', enum: [42] },
+  FOO: { type: 'number', enum: [42] },
 });
 
 const BOOLEAN_LITERAL = `
@@ -348,7 +339,7 @@ export const FOO = t.literal(true);
 `;
 
 testCase('boolean literal type is parsed', BOOLEAN_LITERAL, {
-  FOO: { type: 'primitive', value: 'boolean', enum: [true] },
+  FOO: { type: 'boolean', enum: [true] },
 });
 
 const NULL_LITERAL = `
@@ -357,7 +348,7 @@ export const FOO = t.literal(null);
 `;
 
 testCase('null literal type is parsed', NULL_LITERAL, {
-  FOO: { type: 'primitive', value: 'null', enum: [null] },
+  FOO: { type: 'null', enum: [null] },
 });
 
 const UNDEFINED_LITERAL = `
@@ -378,8 +369,8 @@ testCase('keyof type is parsed', KEYOF, {
   FOO: {
     type: 'union',
     schemas: [
-      { type: 'primitive', value: 'string', enum: ['foo'] },
-      { type: 'primitive', value: 'string', enum: ['bar'] },
+      { type: 'string', enum: ['foo'] },
+      { type: 'string', enum: ['bar'] },
     ],
   },
 });
@@ -390,7 +381,7 @@ export const FOO = test;
 `;
 
 testCase('aliased import is parsed', ALIAS, {
-  FOO: { type: 'primitive', value: 'string' },
+  FOO: { type: 'string' },
 });
 
 const BRAND = `
@@ -403,10 +394,7 @@ export const FOO = t.brand(t.string, (s): s is FooBranded => s === 'foo', 'Foo')
 `;
 
 testCase('brand type is parsed', BRAND, {
-  FOO: {
-    type: 'primitive',
-    value: 'string',
-  },
+  FOO: { type: 'string' },
 });
 
 const LOCAL_REF = `
@@ -418,7 +406,7 @@ export const BAR = t.type({ bar: FOO });
 testCase('local ref is parsed', LOCAL_REF, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
   BAR: {
@@ -437,7 +425,7 @@ export const BAR = t.type({ bar: FOO });
 testCase('local exported ref is parsed', LOCAL_EXPORTED_REF, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'primitive', value: 'number' } },
+    properties: { foo: { type: 'number' } },
     required: ['foo'],
   },
   BAR: {
@@ -487,8 +475,7 @@ export const FOO = t.number;
 
 testCase('declaration comment is parsed', DECLARATION_COMMENT, {
   FOO: {
-    type: 'primitive',
-    value: 'number',
+    type: 'number',
     comment: {
       description: 'Test codec',
       tags: [],
@@ -566,8 +553,7 @@ testCase('first property comment is parsed', FIRST_PROPERTY_COMMENT, {
     type: 'object',
     properties: {
       foo: {
-        type: 'primitive',
-        value: 'number',
+        type: 'number',
         comment: {
           description: 'this is a comment',
           problems: [],
@@ -612,10 +598,9 @@ testCase('second property comment is parsed', SECOND_PROPERTY_COMMENT, {
   FOO: {
     type: 'object',
     properties: {
-      foo: { type: 'primitive', value: 'number' },
+      foo: { type: 'number' },
       bar: {
-        type: 'primitive',
-        value: 'string',
+        type: 'string',
         comment: {
           description: 'this is a comment',
           problems: [],
@@ -656,7 +641,7 @@ export const FOO = h.optional(t.string);
 testCase('optional combinator is parsed', OPTIONAL_COMBINATOR, {
   FOO: {
     type: 'union',
-    schemas: [{ type: 'primitive', value: 'string' }, { type: 'undefined' }],
+    schemas: [{ type: 'string' }, { type: 'undefined' }],
   },
 });
 
@@ -673,10 +658,10 @@ testCase('optionalized combinator is parsed', OPTIONALIZED_COMBINATOR, {
   FOO: {
     type: 'object',
     properties: {
-      foo: { type: 'primitive', value: 'string' },
+      foo: { type: 'string' },
       bar: {
         type: 'union',
-        schemas: [{ type: 'primitive', value: 'number' }, { type: 'undefined' }],
+        schemas: [{ type: 'number' }, { type: 'undefined' }],
       },
     },
     required: ['foo'],
@@ -702,7 +687,7 @@ testCase('httpRequest combinator is parsed', HTTP_REQUEST_COMBINATOR, {
     properties: {
       params: {
         type: 'object',
-        properties: { foo: { type: 'primitive', value: 'string' } },
+        properties: { foo: { type: 'string' } },
         required: ['foo'],
       },
       query: {
@@ -710,7 +695,7 @@ testCase('httpRequest combinator is parsed', HTTP_REQUEST_COMBINATOR, {
         properties: {
           bar: {
             type: 'union',
-            schemas: [{ type: 'primitive', value: 'number' }, { type: 'undefined' }],
+            schemas: [{ type: 'number' }, { type: 'undefined' }],
           },
         },
         required: [],
@@ -737,15 +722,15 @@ testCase('object property is parsed', OBJECT_PROPERTY, {
   FOO: {
     type: 'object',
     properties: {
-      baz: { type: 'primitive', value: 'number' },
+      baz: { type: 'number' },
     },
     required: ['baz'],
   },
   props: {
     type: 'object',
     properties: {
-      foo: { type: 'primitive', value: 'number' },
-      bar: { type: 'primitive', value: 'string' },
+      foo: { type: 'number' },
+      bar: { type: 'string' },
     },
     required: ['foo', 'bar'],
   },

--- a/packages/openapi-generator/test/optimize.test.ts
+++ b/packages/openapi-generator/test/optimize.test.ts
@@ -10,14 +10,14 @@ test('intersections are simplified', () => {
       {
         type: 'object',
         properties: {
-          foo: { type: 'primitive', value: 'string' },
+          foo: { type: 'string' },
         },
         required: ['foo'],
       },
       {
         type: 'object',
         properties: {
-          bar: { type: 'primitive', value: 'string' },
+          bar: { type: 'string' },
         },
         required: [],
       },
@@ -27,8 +27,8 @@ test('intersections are simplified', () => {
   const expected: Schema = {
     type: 'object',
     properties: {
-      foo: { type: 'primitive', value: 'string' },
-      bar: { type: 'primitive', value: 'string' },
+      foo: { type: 'string' },
+      bar: { type: 'string' },
     },
     required: ['foo'],
   };
@@ -40,24 +40,12 @@ test('unions are combined', () => {
   const input: Schema = {
     type: 'union',
     schemas: [
-      {
-        type: 'primitive',
-        value: 'string',
-        enum: ['foo'],
-      },
-      {
-        type: 'primitive',
-        value: 'string',
-        enum: ['bar'],
-      },
+      { type: 'string', enum: ['foo'] },
+      { type: 'string', enum: ['bar'] },
     ],
   };
 
-  const expected: Schema = {
-    type: 'primitive',
-    value: 'string',
-    enum: ['foo', 'bar'],
-  };
+  const expected: Schema = { type: 'string', enum: ['foo', 'bar'] };
 
   assert.deepStrictEqual(optimize(input), expected);
 });
@@ -67,7 +55,7 @@ test('undefined properties are simplified', () => {
     type: 'object',
     properties: {
       foo: { type: 'undefined' },
-      bar: { type: 'primitive', value: 'string' },
+      bar: { type: 'string' },
     },
     required: ['foo'],
   };
@@ -75,7 +63,7 @@ test('undefined properties are simplified', () => {
   const expected: Schema = {
     type: 'object',
     properties: {
-      bar: { type: 'primitive', value: 'string' },
+      bar: { type: 'string' },
     },
     required: [],
   };
@@ -89,9 +77,9 @@ test('undefined property unions are simplified', () => {
     properties: {
       foo: {
         type: 'union',
-        schemas: [{ type: 'undefined' }, { type: 'primitive', value: 'string' }],
+        schemas: [{ type: 'undefined' }, { type: 'string' }],
       },
-      bar: { type: 'primitive', value: 'string' },
+      bar: { type: 'string' },
     },
     required: ['foo', 'bar'],
   };
@@ -99,8 +87,8 @@ test('undefined property unions are simplified', () => {
   const expected: Schema = {
     type: 'object',
     properties: {
-      foo: { type: 'primitive', value: 'string' },
-      bar: { type: 'primitive', value: 'string' },
+      foo: { type: 'string' },
+      bar: { type: 'string' },
     },
     required: ['bar'],
   };

--- a/packages/openapi-generator/test/project.test.ts
+++ b/packages/openapi-generator/test/project.test.ts
@@ -47,7 +47,7 @@ async function testCase(
 
 const EXTERNAL_CUSTOM_CODEC: KnownImports = {
   foo: {
-    bar: () => E.right({ type: 'primitive', value: 'string' }),
+    bar: () => E.right({ type: 'string' }),
   },
 };
 
@@ -62,13 +62,13 @@ testCase(
   EXTERNAL_CUSTOM_CODEC_SRC,
   EXTERNAL_CUSTOM_CODEC,
   {
-    FOO: { type: 'primitive', value: 'string' },
+    FOO: { type: 'string' },
   },
 );
 
 const INTERNAL_CODEC_OVERRIDE: KnownImports = {
   '.': {
-    bar: () => E.right({ type: 'primitive', value: 'string' }),
+    bar: () => E.right({ type: 'string' }),
   },
 };
 
@@ -87,7 +87,7 @@ testCase(
     FOO: {
       type: 'object',
       properties: {
-        bar: { type: 'primitive', value: 'string' },
+        bar: { type: 'string' },
       },
       required: ['bar'],
     },

--- a/packages/openapi-generator/test/resolve.test.ts
+++ b/packages/openapi-generator/test/resolve.test.ts
@@ -60,7 +60,7 @@ testCase(
   {
     FOO: {
       type: 'object',
-      properties: { foo: { type: 'primitive', value: 'string' } },
+      properties: { foo: { type: 'string' } },
       required: ['foo'],
     },
   },
@@ -80,10 +80,7 @@ testCase(
   {
     FOO: {
       type: 'union',
-      schemas: [
-        { type: 'primitive', value: 'string' },
-        { type: 'primitive', value: 'number' },
-      ],
+      schemas: [{ type: 'string' }, { type: 'number' }],
     },
   },
   ['Unimplemented initializer type ArrayExpression'],
@@ -106,8 +103,8 @@ testCase(
     FOO: {
       type: 'union',
       schemas: [
-        { type: 'primitive', value: 'string', enum: ['foo'] },
-        { type: 'primitive', value: 'string', enum: ['bar'] },
+        { type: 'string', enum: ['foo'] },
+        { type: 'string', enum: ['bar'] },
       ],
     },
   },
@@ -125,7 +122,7 @@ testCase(
   { '/index.ts': LITERAL_CONST },
   '/index.ts',
   {
-    FOO: { type: 'primitive', value: 'number', enum: [42] },
+    FOO: { type: 'number', enum: [42] },
   },
   ['Unimplemented initializer type NumericLiteral'],
 );
@@ -538,10 +535,7 @@ testCase(
     FOO: {
       type: 'object',
       properties: {
-        foo: {
-          type: 'primitive',
-          value: 'number',
-        },
+        foo: { type: 'number' },
       },
       required: ['foo'],
     },

--- a/packages/openapi-generator/test/route.test.ts
+++ b/packages/openapi-generator/test/route.test.ts
@@ -84,15 +84,13 @@ testCase('simple route', SIMPLE, {
         name: 'foo',
         required: true,
         schema: {
-          type: 'primitive',
-          value: 'string',
+          type: 'string',
         },
       },
     ],
     response: {
       200: {
-        type: 'primitive',
-        value: 'string',
+        type: 'string',
       },
     },
   },
@@ -125,8 +123,7 @@ testCase('path params route', PATH_PARAMS, {
         name: 'bar',
         required: true,
         schema: {
-          type: 'primitive',
-          value: 'string',
+          type: 'string',
         },
       },
     ],
@@ -168,14 +165,13 @@ testCase('optional query param route', OPTIONAL_QUERY_PARAM, {
         required: false,
         schema: {
           type: 'union',
-          schemas: [{ type: 'primitive', value: 'string' }, { type: 'undefined' }],
+          schemas: [{ type: 'string' }, { type: 'undefined' }],
         },
       },
     ],
     response: {
       200: {
-        type: 'primitive',
-        value: 'string',
+        type: 'string',
       },
     },
   },
@@ -204,8 +200,7 @@ testCase('const request route', REQUEST_REF, {
     parameters: [],
     response: {
       200: {
-        type: 'primitive',
-        value: 'string',
+        type: 'string',
       },
     },
   },
@@ -233,10 +228,7 @@ testCase('const response route', RESPONSE_REF, {
     method: 'GET',
     parameters: [],
     response: {
-      200: {
-        type: 'primitive',
-        value: 'string',
-      },
+      200: { type: 'string' },
     },
   },
 });
@@ -281,20 +273,14 @@ testCase('query param union route', QUERY_PARAM_UNION, {
             {
               type: 'object',
               properties: {
-                foo: {
-                  type: 'primitive',
-                  value: 'string',
-                },
+                foo: { type: 'string' },
               },
               required: ['foo'],
             },
             {
               type: 'object',
               properties: {
-                bar: {
-                  type: 'primitive',
-                  value: 'string',
-                },
+                bar: { type: 'string' },
               },
               required: ['bar'],
             },
@@ -303,10 +289,7 @@ testCase('query param union route', QUERY_PARAM_UNION, {
       },
     ],
     response: {
-      200: {
-        type: 'primitive',
-        value: 'string',
-      },
+      200: { type: 'string' },
     },
   },
 });
@@ -357,20 +340,14 @@ testCase('path param union route', PATH_PARAM_UNION, {
             {
               type: 'object',
               properties: {
-                foo: {
-                  type: 'primitive',
-                  value: 'string',
-                },
+                foo: { type: 'string' },
               },
               required: ['foo'],
             },
             {
               type: 'object',
               properties: {
-                bar: {
-                  type: 'primitive',
-                  value: 'string',
-                },
+                bar: { type: 'string' },
               },
               required: ['bar'],
             },
@@ -381,17 +358,11 @@ testCase('path param union route', PATH_PARAM_UNION, {
         type: 'path',
         name: 'id',
         required: true,
-        schema: {
-          type: 'primitive',
-          value: 'string',
-        },
+        schema: { type: 'string' },
       },
     ],
     response: {
-      200: {
-        type: 'primitive',
-        value: 'string',
-      },
+      200: { type: 'string' },
     },
   },
 });
@@ -431,30 +402,21 @@ testCase('body union route', BODY_UNION, {
         {
           type: 'object',
           properties: {
-            foo: {
-              type: 'primitive',
-              value: 'string',
-            },
+            foo: { type: 'string' },
           },
           required: ['foo'],
         },
         {
           type: 'object',
           properties: {
-            bar: {
-              type: 'primitive',
-              value: 'string',
-            },
+            bar: { type: 'string' },
           },
           required: ['bar'],
         },
       ],
     },
     response: {
-      200: {
-        type: 'primitive',
-        value: 'string',
-      },
+      200: { type: 'string' },
     },
   },
 });
@@ -492,26 +454,17 @@ testCase('request intersection route', REQUEST_INTERSECTION, {
         type: 'query',
         name: 'foo',
         required: true,
-        schema: {
-          type: 'primitive',
-          value: 'string',
-        },
+        schema: { type: 'string' },
       },
       {
         type: 'query',
         name: 'bar',
         required: true,
-        schema: {
-          type: 'primitive',
-          value: 'string',
-        },
+        schema: { type: 'string' },
       },
     ],
     response: {
-      200: {
-        type: 'primitive',
-        value: 'string',
-      },
+      200: { type: 'string' },
     },
   },
 });
@@ -551,30 +504,21 @@ testCase('request body intersection route', BODY_INTERSECTION, {
         {
           type: 'object',
           properties: {
-            foo: {
-              type: 'primitive',
-              value: 'string',
-            },
+            foo: { type: 'string' },
           },
           required: ['foo'],
         },
         {
           type: 'object',
           properties: {
-            bar: {
-              type: 'primitive',
-              value: 'string',
-            },
+            bar: { type: 'string' },
           },
           required: ['bar'],
         },
       ],
     },
     response: {
-      200: {
-        type: 'primitive',
-        value: 'string',
-      },
+      200: { type: 'string' },
     },
   },
 });
@@ -612,15 +556,13 @@ testCase('route with operationId', WITH_OPERATION_ID, {
         name: 'foo',
         required: true,
         schema: {
-          type: 'primitive',
-          value: 'string',
+          type: 'string',
         },
       },
     ],
     response: {
       200: {
-        type: 'primitive',
-        value: 'string',
+        type: 'string',
       },
     },
     comment: {


### PR DESCRIPTION
For primitive types, the `value` field is confusingly named, and it can just be folded into the `type` field anyway. This should make the IR format more readable.

BREAKING CHANGE: non backwards-compatible change to the IR format, since it is [publicly exposed when defining custom external codecs](https://github.com/BitGo/api-ts/blob/master/packages/openapi-generator/README.md#custom-codec-file)