### PR TITLE
Make error messages have the name of the symbol openapi-generator can't find

### DIFF
--- a/packages/openapi-generator/src/codec.ts
+++ b/packages/openapi-generator/src/codec.ts
@@ -352,7 +352,7 @@ export function parseCodecInitializer(
       } else {
         const refSource = project.get(schema.location);
         if (refSource === undefined) {
-          return E.left(`Unknown source ${schema.location}`);
+          return E.left(`Cannot find '${schema.name}' from '${schema.location}'`);
         }
         const initE = findSymbolInitializer(project, refSource, schema.name);
         if (E.isLeft(initE)) {

--- a/packages/openapi-generator/src/resolveInit.ts
+++ b/packages/openapi-generator/src/resolveInit.ts
@@ -19,7 +19,7 @@ function resolveImportPath(
   }
   const importSourceFile = project.get(importPathE.right);
   if (importSourceFile === undefined) {
-    return E.left(`Unknown import ${importPathE.right}`);
+    return E.left(importPathE.right);
   }
   return E.right(importSourceFile);
 }
@@ -37,7 +37,7 @@ function findExportedDeclaration(
   for (const starExport of sourceFile.symbols.exportStarFiles) {
     const starSourceFile = resolveImportPath(project, sourceFile, starExport);
     if (E.isLeft(starSourceFile)) {
-      return starSourceFile;
+      return E.left(`Cannot resolve * export from '${starExport}'`);
     }
     const starExportE = findExportedDeclaration(project, starSourceFile.right, name);
     if (E.isRight(starExportE)) {
@@ -77,7 +77,7 @@ export function findSymbolInitializer(
     if (imp.localName === name) {
       const impSourceFile = resolveImportPath(project, sourceFile, imp.from);
       if (E.isLeft(impSourceFile)) {
-        return impSourceFile;
+        return E.left(`Cannot resolve import '${imp.localName}' from '${imp.from}'`);
       }
       return findExportedDeclaration(project, impSourceFile.right, imp.importedName);
     }


### PR DESCRIPTION
When defining external codecs, it is helpful to know _what_ symbol can't be found. Currently, the error message prints something like:

> Unknown source @foo/bar

This error generally means that an external codec needs to be defined, but it is not clear which one. This PR changes it to:

> Cannot find 'myCustomCodec' from '@foo/bar'

So you don't need to go grepping through the codebase to find which symbol/codec it is complaining about.