### PR TITLE
fix: make `@swc/core` a non-dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1790,7 +1790,6 @@
       "version": "1.3.99",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.99.tgz",
       "integrity": "sha512-8O996RfuPC4ieb4zbYMfbyCU9k4gSOpyCNnr7qBQ+o7IEmh8JCV6B8wwu+fT/Om/6Lp34KJe1IpJ/24axKS6TQ==",
-      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.1",
@@ -1845,12 +1844,10 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1862,12 +1859,10 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1879,12 +1874,10 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1911,12 +1904,10 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1928,12 +1919,10 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1945,12 +1934,10 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1962,12 +1949,10 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1975,14 +1960,12 @@
     "node_modules/@swc/counter": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.1.tgz",
-      "integrity": "sha512-xVRaR4u9hcYjFvcSg71Lz5Bo4//CyjAAfMxa7UsaDSYxAshflUkVJWiyVWrfxC59z2kP1IzI4/1BEpnhI9o3Mw==",
-      "dev": true
+      "integrity": "sha512-xVRaR4u9hcYjFvcSg71Lz5Bo4//CyjAAfMxa7UsaDSYxAshflUkVJWiyVWrfxC59z2kP1IzI4/1BEpnhI9o3Mw=="
     },
     "node_modules/@swc/types": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
-      "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
-      "dev": true
+      "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -18260,6 +18243,7 @@
       "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "dependencies": {
+        "@swc/core": "1.3.99",
         "cmd-ts": "0.13.0",
         "comment-parser": "1.4.1",
         "fp-ts": "2.16.1",
@@ -18273,7 +18257,6 @@
       },
       "devDependencies": {
         "@swc-node/register": "1.6.8",
-        "@swc/core": "1.3.99",
         "@types/resolve": "1.20.6",
         "c8": "8.0.1",
         "memfs": "4.6.0",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -20,6 +20,7 @@
     "test": "c8 --all --src src node --require @swc-node/register --test test/*.test.ts"
   },
   "dependencies": {
+    "@swc/core": "1.3.99",
     "cmd-ts": "0.13.0",
     "comment-parser": "1.4.1",
     "fp-ts": "2.16.1",
@@ -30,7 +31,6 @@
   },
   "devDependencies": {
     "@swc-node/register": "1.6.8",
-    "@swc/core": "1.3.99",
     "@types/resolve": "1.20.6",
     "c8": "8.0.1",
     "memfs": "4.6.0",


### PR DESCRIPTION
`@swc/core` is used at runtime in `openapi-generator`, so is therefore not a dev dependency.