### PR TITLE
Correctly parse comments in source files with leading comments

### DIFF
--- a/packages/openapi-generator/src/cli.ts
+++ b/packages/openapi-generator/src/cli.ts
@@ -110,7 +110,7 @@ const app = command({
       process.exit(1);
     }
 
-    let apiSpec: Route[] | undefined;
+    let apiSpec: Route[] = [];
     for (const symbol of Object.values(entryPoint.symbols.declarations)) {
       if (symbol.init === undefined) {
         continue;
@@ -130,10 +130,9 @@ const app = command({
         continue;
       }
 
-      apiSpec = result.right;
-      break;
+      apiSpec.push(...result.right);
     }
-    if (apiSpec === undefined) {
+    if (apiSpec.length === 0) {
       console.error(`Could not find API spec in ${filePath}`);
       process.exit(1);
     }

--- a/packages/openapi-generator/src/comments.ts
+++ b/packages/openapi-generator/src/comments.ts
@@ -6,6 +6,6 @@ export function leadingComment(
   start: number,
   end: number,
 ): Block[] {
-  const commentString = src.slice(start - srcSpanStart + 1, end - srcSpanStart);
+  const commentString = src.slice(start - srcSpanStart, end - srcSpanStart);
   return parseComment(commentString);
 }

--- a/packages/openapi-generator/src/sourceFile.ts
+++ b/packages/openapi-generator/src/sourceFile.ts
@@ -9,13 +9,25 @@ export type SourceFile = {
   span: swc.Span;
 };
 
+// `module.span.start` is the offset of the first non-comment statement in a source file, so in order to get a better
+// offset for the first symbol, we need to keep track of end of the previously parsed file. `swc` appears to use a global
+// increasing counter for this, so we also need to track it globally here
+let lastSpanEnd = -1;
+
 export async function parseSource(path: string, src: string): Promise<SourceFile> {
   try {
     const module = await swc.parse(src, {
       syntax: 'typescript',
       target: 'esnext',
     });
-    const symbols = parseTopLevelSymbols(src, module.span.start, module.body);
+    if (lastSpanEnd === -1) {
+      // Since the starting offset is seemingly arbitrary, simulate it by subtracting the length of the source file
+      // from the end of the first module. This probably doesn't matter since the first source file parsed will be
+      // the apiSpec file.
+      lastSpanEnd = module.span.end - src.length;
+    }
+    const symbols = parseTopLevelSymbols(src, lastSpanEnd, module.body);
+    lastSpanEnd = module.span.end;
     return {
       path,
       src,

--- a/packages/openapi-generator/test/codec.test.ts
+++ b/packages/openapi-generator/test/codec.test.ts
@@ -481,7 +481,7 @@ testCase('declaration comment is parsed', DECLARATION_COMMENT, {
       tags: [],
       source: [
         {
-          number: 2,
+          number: 0,
           source: '/**',
           tokens: {
             start: '',
@@ -499,7 +499,7 @@ testCase('declaration comment is parsed', DECLARATION_COMMENT, {
           },
         },
         {
-          number: 3,
+          number: 1,
           source: ' * Test codec',
           tokens: {
             start: ' ',
@@ -517,7 +517,7 @@ testCase('declaration comment is parsed', DECLARATION_COMMENT, {
           },
         },
         {
-          number: 4,
+          number: 2,
           source: ' */',
           tokens: {
             start: ' ',

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -399,3 +399,72 @@ testCase('nullable property route', NULLABLE_PROPERTY, {
     schemas: {},
   },
 });
+
+const HEADER_COMMENT = `
+/*
+ * This is a comment
+ */
+
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * A simple route
+ *
+ * ## How to call the route
+ *
+ * \`\`\`
+ * curl -X GET http://localhost:3000/foo?foo=bar
+ * \`\`\`
+ *
+ * @operationId api.v1.test
+ * @tag Test Routes
+ */
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({}),
+  response: {
+    200: t.string
+  },
+});
+`;
+
+testCase('source file with a header comment', HEADER_COMMENT, {
+  openapi: '3.0.0',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/foo': {
+      get: {
+        summary: 'A simple route',
+        description:
+          '## How to call the route\n' +
+          '\n' +
+          '```\n' +
+          'curl -X GET http://localhost:3000/foo?foo=bar\n' +
+          '```',
+        operationId: 'api.v1.test',
+        tags: ['Test Routes'],
+        parameters: [],
+        responses: {
+          200: {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});

--- a/packages/openapi-generator/test/route.test.ts
+++ b/packages/openapi-generator/test/route.test.ts
@@ -577,7 +577,7 @@ testCase('route with operationId', WITH_OPERATION_ID, {
           problems: [],
           source: [
             {
-              number: 5,
+              number: 3,
               source: ' * @operationId foo',
               tokens: {
                 start: ' ',
@@ -595,7 +595,7 @@ testCase('route with operationId', WITH_OPERATION_ID, {
               },
             },
             {
-              number: 6,
+              number: 4,
               source: ' */',
               tokens: {
                 start: ' ',
@@ -617,7 +617,7 @@ testCase('route with operationId', WITH_OPERATION_ID, {
       ],
       source: [
         {
-          number: 2,
+          number: 0,
           source: '/**',
           tokens: {
             start: '',
@@ -635,7 +635,7 @@ testCase('route with operationId', WITH_OPERATION_ID, {
           },
         },
         {
-          number: 3,
+          number: 1,
           source: ' * A route',
           tokens: {
             start: ' ',
@@ -653,7 +653,7 @@ testCase('route with operationId', WITH_OPERATION_ID, {
           },
         },
         {
-          number: 4,
+          number: 2,
           source: ' *',
           tokens: {
             start: ' ',
@@ -671,7 +671,7 @@ testCase('route with operationId', WITH_OPERATION_ID, {
           },
         },
         {
-          number: 5,
+          number: 3,
           source: ' * @operationId foo',
           tokens: {
             start: ' ',
@@ -689,7 +689,7 @@ testCase('route with operationId', WITH_OPERATION_ID, {
           },
         },
         {
-          number: 6,
+          number: 4,
           source: ' */',
           tokens: {
             start: ' ',


### PR DESCRIPTION
The result from `swc.parse` includes a `span` which is used to slice source files to pass to the comment parser. This number starts at an arbitrary value and continuously increments as source files are parsed. Unfortunately, `module.span.start` is the offset of the first parsed statement in a source file, ignoring any comments at the top of a file (so the first declaration's `span.start` == `module.span.start`). For the purposes of using these spans to slice the source for comments, we want to offset from the beginning of the actual file, not the first statement. Fortunately, this appears to be doable by tracking the previous span end.