### PR TITLE
Handle `Object.assign` in openapi-generator

### DIFF
--- a/packages/openapi-generator/src/knownImports.ts
+++ b/packages/openapi-generator/src/knownImports.ts
@@ -25,6 +25,26 @@ function isOptional(schema: Schema): boolean {
 // TODO: Read this from a JSON (or YAML?) file
 
 export const KNOWN_IMPORTS: KnownImports = {
+  global: {
+    'Object.assign': (_, ...schemas) => {
+      if (schemas.length < 2) {
+        return E.left('assign must have at least 2 arguments');
+      }
+      const [target, ...sources] = schemas;
+      if (target === undefined) {
+        return E.left('assign target must be object');
+      } else if (target.type !== 'object') {
+        return E.left('assign target must be object');
+      }
+      const properties = sources.reduce((acc, source) => {
+        if (source.type !== 'object') {
+          return acc;
+        }
+        return { ...acc, ...source.properties };
+      }, target.properties);
+      return E.right({ type: 'object', properties, required: Object.keys(properties) });
+    },
+  },
   'io-ts': {
     string: () => E.right({ type: 'string' }),
     number: () => E.right({ type: 'number' }),

--- a/packages/openapi-generator/test/codec.test.ts
+++ b/packages/openapi-generator/test/codec.test.ts
@@ -735,3 +735,33 @@ testCase('object property is parsed', OBJECT_PROPERTY, {
     required: ['foo', 'bar'],
   },
 });
+
+const OBJECT_ASSIGN = `
+import * as t from 'io-ts';
+
+const props = Object.assign({}, {
+  foo: t.number,
+  bar: t.string,
+});
+
+export const FOO = t.type(props);
+`;
+
+testCase('object assign is parsed', OBJECT_ASSIGN, {
+  FOO: {
+    type: 'object',
+    properties: {
+      foo: { type: 'number' },
+      bar: { type: 'string' },
+    },
+    required: ['foo', 'bar'],
+  },
+  props: {
+    type: 'object',
+    properties: {
+      foo: { type: 'number' },
+      bar: { type: 'string' },
+    },
+    required: ['foo', 'bar'],
+  },
+});


### PR DESCRIPTION
This is a slightly hacky way to do it, and will break if `Object.assign` is aliased, but that seems like a sufficiently rare edge case that it can be addressed if and when it comes up.