### PR TITLE
Add `title` to components in openapi-generator

### DIFF
--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -174,7 +174,13 @@ export function convertRoutesToOpenAPI(
       if (openapiSchema === undefined) {
         return acc;
       } else {
-        return { ...acc, [name]: openapiSchema };
+        return {
+          ...acc,
+          [name]: {
+            title: name,
+            ...openapiSchema,
+          },
+        };
       }
     },
     {} as Record<string, OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject>,


### PR DESCRIPTION
In some renderers, this improves readability of referenced objects by giving them a more descriptive name than `object`