### PR TITLE
Use `allOf` for schemas that are refs

### DIFF
--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -173,6 +173,13 @@ export function convertRoutesToOpenAPI(
       const openapiSchema = schemaToOpenAPI(schema);
       if (openapiSchema === undefined) {
         return acc;
+      } else if ('$ref' in openapiSchema) {
+        return {
+          ...acc,
+          [name]: {
+            allOf: [{ title: name }, openapiSchema],
+          },
+        };
       } else {
         return {
           ...acc,


### PR DESCRIPTION
Fixes validation error that properties alongside a `$ref` aren't allowed