### PR TITLE
Fix: Comment parsing was broken if the comment is not after a line break

### DIFF
--- a/packages/openapi-generator/src/comments.ts
+++ b/packages/openapi-generator/src/comments.ts
@@ -6,6 +6,11 @@ export function leadingComment(
   start: number,
   end: number,
 ): Block[] {
-  const commentString = src.slice(start - srcSpanStart, end - srcSpanStart);
+  let commentString = src.slice(start - srcSpanStart, end - srcSpanStart);
+
+  if (commentString.trim()[0] !== '/') {
+    commentString = '/' + commentString;
+  }
+
   return parseComment(commentString);
 }

--- a/packages/openapi-generator/test/codec.test.ts
+++ b/packages/openapi-generator/test/codec.test.ts
@@ -540,6 +540,85 @@ testCase('declaration comment is parsed', DECLARATION_COMMENT, {
   },
 });
 
+const DECLARATION_COMMENT_WITHOUT_LINE_BREAK = `
+import * as t from 'io-ts';
+/**
+ * Test codec
+ */
+export const FOO = t.number;
+`;
+
+testCase(
+  'declaration comment without line break is parsed',
+  DECLARATION_COMMENT_WITHOUT_LINE_BREAK,
+  {
+    FOO: {
+      type: 'number',
+      comment: {
+        description: 'Test codec',
+        tags: [],
+        source: [
+          {
+            number: 0,
+            source: '/**',
+            tokens: {
+              start: '',
+              delimiter: '/**',
+              postDelimiter: '',
+              tag: '',
+              postTag: '',
+              name: '',
+              postName: '',
+              type: '',
+              postType: '',
+              description: '',
+              end: '',
+              lineEnd: '',
+            },
+          },
+          {
+            number: 1,
+            source: ' * Test codec',
+            tokens: {
+              start: ' ',
+              delimiter: '*',
+              postDelimiter: ' ',
+              tag: '',
+              postTag: '',
+              name: '',
+              postName: '',
+              type: '',
+              postType: '',
+              description: 'Test codec',
+              end: '',
+              lineEnd: '',
+            },
+          },
+          {
+            number: 2,
+            source: ' */',
+            tokens: {
+              start: ' ',
+              delimiter: '',
+              postDelimiter: '',
+              tag: '',
+              postTag: '',
+              name: '',
+              postName: '',
+              type: '',
+              postType: '',
+              description: '',
+              end: '*/',
+              lineEnd: '',
+            },
+          },
+        ],
+        problems: [],
+      },
+    },
+  },
+);
+
 const FIRST_PROPERTY_COMMENT = `
 import * as t from 'io-ts';
 export const FOO = t.type({


### PR DESCRIPTION
DX-222

The openapi-generator cli would not recognize a comment block containing metadata if it's not written right after an empty line.

More info [in this PR](https://github.com/BitGo/entity-validation-types/pull/185)

The extracted comment block would sometimes not include the opening slash, which broke parsing. Fixed by manually adding the character if not present