### PR TITLE
feat: support @title tag for parameters

### DIFF
--- a/packages/openapi-generator/src/optimize.ts
+++ b/packages/openapi-generator/src/optimize.ts
@@ -111,7 +111,15 @@ export function optimize(schema: Schema): Schema {
         required.push(key);
       }
     }
-    return { type: 'object', properties, required };
+
+    const schemaObject: Schema = { type: 'object', properties, required };
+
+    // only add comment field if there is a comment
+    if (schema.comment) {
+      return { ...schemaObject, comment: schema.comment };
+    }
+
+    return schemaObject;
   } else if (schema.type === 'intersection') {
     return foldIntersection(schema, optimize);
   } else if (schema.type === 'union') {

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -683,3 +683,139 @@ testCase('request body double ref', SCHEMA_DOUBLE_REF, {
     },
   },
 });
+
+const TITLE_TAG = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+export const oneOfRoute = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: t.union([
+    h.httpRequest({
+      /** @title this is a title for a oneOf option */
+      query: {
+        /** @title this is a title for a oneOf option's property */
+        foo: t.string
+      }
+    }),
+    h.httpRequest({
+      query: {
+        bar: t.string
+      }
+    }),
+  ]),
+  response: {
+    /** foo response */
+    200: t.string
+  },
+});
+
+export const route = h.httpRoute({
+  path: '/bar',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      /**
+       * bar param
+       * @title this is a bar parameter
+       * */
+      bar: t.string,
+    },
+  }),
+  response: {
+    /** bar response */
+    200: t.string
+  },
+});
+`;
+
+testCase('schema parameter with title tag', TITLE_TAG, {
+  openapi: '3.0.0',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/foo': {
+      get: {
+        parameters: [
+          {
+            in: 'query',
+            name: 'union',
+            required: true,
+            style: 'form',
+            explode: true,
+            schema: {
+              oneOf: [
+                {
+                  type: 'object',
+                  title: 'this is a title for a oneOf option',
+                  properties: {
+                    foo: {
+                      type: 'string',
+                      title: "this is a title for a oneOf option's property",
+                    },
+                  },
+                  required: ['foo'],
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    bar: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['bar'],
+                },
+              ],
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'foo response',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/bar': {
+      get: {
+        parameters: [
+          {
+            in: 'query',
+            name: 'bar',
+            description: 'bar param',
+            required: true,
+            schema: {
+              title: 'this is a bar parameter',
+              type: 'string',
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'bar response',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});

--- a/packages/openapi-generator/test/optimize.test.ts
+++ b/packages/openapi-generator/test/optimize.test.ts
@@ -112,3 +112,35 @@ test('enums are deduplicated', () => {
 
   assert.deepStrictEqual(optimize(input), expected);
 });
+
+test('comments are exposed in objects', () => {
+  const input: Schema = {
+    type: 'object',
+    properties: {
+      bar: { type: 'string' },
+    },
+    required: [],
+    comment: {
+      description: 'test description',
+      tags: [],
+      source: [],
+      problems: [],
+    },
+  };
+
+  const expected: Schema = {
+    type: 'object',
+    properties: {
+      bar: { type: 'string' },
+    },
+    required: [],
+    comment: {
+      description: 'test description',
+      tags: [],
+      source: [],
+      problems: [],
+    },
+  };
+
+  assert.deepStrictEqual(optimize(input), expected);
+});


### PR DESCRIPTION
Resolves DX-213 (hopefully 🤞)

This PR aims to add support for the `@title` tag, which will add a `title` field for generated openapi objects

- Wrapped `switch` block  from `schemaToOpenAPI` into a function (`createOpenAPIObject`).
- Use output from `createOpenAPIObject` to conditionally add `title` field if the tag exists.

Additional changes:
- Originally, the `optimize` function stripped the comment field from `object` types. This PR exposes the comment field for objects


This is my first time committing to this repo, so it wouldn't hurt to exercise a bit more caution when reviewing this PR!!