### PR TITLE
chore: remove `drone.yaml` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .direnv/
-.drone.yml
 coverage/
 dist/
 node_modules/


### PR DESCRIPTION
Removes `drone.yaml` from `.gitignore`