### PR TITLE
Add support for specifying base URL

### DIFF
--- a/packages/openapi-generator/src/apiSpec.ts
+++ b/packages/openapi-generator/src/apiSpec.ts
@@ -1,11 +1,13 @@
 import * as swc from '@swc/core';
 import * as E from 'fp-ts/Either';
+import type { Block } from 'comment-parser';
 
 import { parsePlainInitializer } from './codec';
 import type { Project } from './project';
 import { resolveLiteralOrIdentifier } from './resolveInit';
 import { parseRoute, type Route } from './route';
 import { SourceFile } from './sourceFile';
+import { OpenAPIV3 } from 'openapi-types';
 
 export function parseApiSpec(
   project: Project,
@@ -82,4 +84,15 @@ export function parseApiSpec(
   }
 
   return E.right(result);
+}
+
+export function parseApiSpecComment(
+  comment: Block | undefined,
+): OpenAPIV3.ServerObject | undefined {
+  if (comment === undefined) {
+    return undefined;
+  }
+  const description = comment.description;
+  const url = comment.tags.find((tag) => tag.tag === 'url')?.name;
+  return url !== undefined ? { url, description } : undefined;
 }

--- a/packages/openapi-generator/src/cli.ts
+++ b/packages/openapi-generator/src/cli.ts
@@ -5,8 +5,9 @@ import * as E from 'fp-ts/Either';
 import * as fs from 'fs';
 import * as p from 'path';
 import type { Expression } from '@swc/core';
+import type { OpenAPIV3 } from 'openapi-types';
 
-import { parseApiSpec } from './apiSpec';
+import { parseApiSpec, parseApiSpecComment } from './apiSpec';
 import { getRefs } from './ref';
 import { convertRoutesToOpenAPI } from './openapi';
 import type { Route } from './route';
@@ -106,6 +107,7 @@ const app = command({
     }
 
     let apiSpec: Route[] = [];
+    let servers: OpenAPIV3.ServerObject[] = [];
     for (const symbol of Object.values(entryPoint.symbols.declarations)) {
       if (symbol.init === undefined) {
         continue;
@@ -136,6 +138,10 @@ const app = command({
         process.exit(1);
       }
 
+      const server = parseApiSpecComment(symbol.comment);
+      if (server !== undefined) {
+        servers.push(server);
+      }
       apiSpec.push(...result.right);
     }
     if (apiSpec.length === 0) {
@@ -189,6 +195,7 @@ const app = command({
         version,
         description,
       },
+      servers,
       apiSpec,
       components,
     );

--- a/packages/openapi-generator/src/index.ts
+++ b/packages/openapi-generator/src/index.ts
@@ -1,4 +1,4 @@
-export { parseApiSpec } from './apiSpec';
+export { parseApiSpec, parseApiSpecComment } from './apiSpec';
 export { parseCodecInitializer, parsePlainInitializer } from './codec';
 export { parseCommentBlock, type JSDoc } from './jsdoc';
 export { convertRoutesToOpenAPI } from './openapi';

--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -174,6 +174,7 @@ function routeToOpenAPI(route: Route): [string, string, OpenAPIV3.OperationObjec
 
 export function convertRoutesToOpenAPI(
   info: OpenAPIV3.InfoObject,
+  servers: OpenAPIV3.ServerObject[],
   routes: Route[],
   schemas: Record<string, Schema>,
 ): OpenAPIV3.Document {
@@ -215,6 +216,7 @@ export function convertRoutesToOpenAPI(
   return {
     openapi: '3.0.3',
     info,
+    ...(servers.length > 0 ? { servers } : {}),
     paths,
     components: {
       schemas: openapiSchemas,

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -47,6 +47,7 @@ async function testCase(
 
     const actual = convertRoutesToOpenAPI(
       { title: 'Test', version: '1.0.0' },
+      [],
       routes,
       schemas,
     );


### PR DESCRIPTION
Adds support for emitting the `servers` section of an OpenAPI spec by annotating `h.apiSpec` objects with the appropriate JSDoc tags. For example:

```javascript
    /** An API spec
     *
     * @url /api/v1
     **/
    export const test = h.apiSpec({
      'api.test': {
        get: h.httpRoute({
          path: '/test',
          method: 'GET',
          request: h.httpRequest({}),
          response: {
            200: t.string,
          },
        })
      }
    });
```

Will result in something like this in the emitted OpenAPI:

```yaml
servers:
- description: An API spec
  url: /api/v1
```