### PR TITLE
Make undefined behavior of optionalized work like partial

### DIFF
--- a/packages/io-ts-http/src/combinators.ts
+++ b/packages/io-ts-http/src/combinators.ts
@@ -43,6 +43,10 @@ const partialWithoutUndefined = <P extends t.Props>(
     },
     (a) => {
       const result = partialCodec.encode(a);
+      if (result === undefined) {
+        // `t.partial` will return this when passed `undefined` even though it is not in the type
+        return result;
+      }
       for (const key of Object.keys(result)) {
         if (result[key] === void 0) {
           delete result[key];

--- a/packages/io-ts-http/test/combinators.test.ts
+++ b/packages/io-ts-http/test/combinators.test.ts
@@ -113,6 +113,12 @@ describe('optionalized', () => {
     assertEncodes(optionalCodec, { a: undefined, b: 'foo' }, expected);
   });
 
+  it('returns undefined when encoding undefined', () => {
+    const optionalCodec = c.optionalized({});
+    const expected = undefined;
+    assertEncodes(optionalCodec, undefined, expected);
+  });
+
   it('decodes explicit null properties', () => {
     const nullCodec = c.optionalized({
       a: t.null,


### PR DESCRIPTION
Makes `optionalized.encode` behave like `t.partial.encode` in the event that it is passed `undefined`. This is technically undefined behavior, but having it work this way appears to fix issues in places that treat objects missing keys and ones with accessors or keys set to `undefined` in a loose manner.