### PR TITLE
feat: add `exactOptionalized` combinator

### DIFF
--- a/packages/io-ts-http/docs/combinators.md
+++ b/packages/io-ts-http/docs/combinators.md
@@ -2,7 +2,7 @@
 
 `io-ts-http` currently exports a handful of combinators for `io-ts` codecs.
 
-## `optionalize`
+## `optionalized`
 
 Provides an easy way to define object types with some required and some optional
 properties. It accepts the same props that `type` and `partial` do in `io-ts`, and
@@ -10,7 +10,7 @@ behaves like a combination of the two. It works by figuring out which properties
 capable of being `undefined`, and marking them as optional. For example:
 
 ```typescript
-const Item = optionalize({
+const Item = optionalized({
   necessaryProperty: t.string,
   maybeDefined: t.union([t.string, t.undefined]),
 });
@@ -28,6 +28,21 @@ type Item = {
 This same type could be defined with a combination of `intersection`, `type`, and
 `partial`, however it is much easier to read, especially when combined with the next
 combinator.
+
+## `exactOptionalized`
+
+Behaves similarly to `optionalized`, but is more strict about how "explicitly undefined"
+values are handled. Any key that is defined with a value of `undefined` will be stripped
+on encoding and decoding, and `is` will return `false` for keys that are explicitly
+undefined:
+
+```typescript
+const Item = exactOptionalized({
+  foo: optional(t.string),
+});
+
+const foo = Item.is({ foo: undefined }); // returns `false`
+```
 
 ## `optional`
 

--- a/packages/io-ts-http/src/combinators.ts
+++ b/packages/io-ts-http/src/combinators.ts
@@ -80,6 +80,31 @@ export const optionalized = <P extends t.Props>(
     t.type(requiredProps, name ? `required_${name}` : undefined) as t.TypeC<
       RequiredProps<P>
     >,
+    t.partial(optionalProps, name ? `optional_${name}` : undefined) as t.PartialC<
+      OptionalProps<P>
+    >,
+  ]);
+};
+
+export const exactOptionalized = <P extends t.Props>(
+  props: P,
+  name?: string,
+): OptionalizedC<P> => {
+  const requiredProps: t.Props = {};
+  const optionalProps: t.Props = {};
+  for (const key of Object.keys(props)) {
+    const codec = props[key]!;
+    const isOptional = codec.is(void 0);
+    if (isOptional) {
+      optionalProps[key] = codec;
+    } else {
+      requiredProps[key] = codec;
+    }
+  }
+  return t.intersection([
+    t.type(requiredProps, name ? `required_${name}` : undefined) as t.TypeC<
+      RequiredProps<P>
+    >,
     partialWithoutUndefined(
       optionalProps,
       name ? `optional_${name}` : undefined,


### PR DESCRIPTION
Partially reverts the change in https://github.com/BitGo/api-ts/commit/06eddbb5adfdf8b1638a4f0265ae25ec03264ba1 and makes it opt-in with `exactOptionalized`. Typescript's `exactOptionalPropertyTypes` is off by default, and the current behavior can result in surprising runtime encoding errors due to a lot of code assuming treating "property is not defined" and "property is defined but set to `undefined`" as equivalent. And without `exactOptionalPropertyTypes` this is sound behavior according to the typechecker.

The original change noted:
> At the same time, `GenericHttpRequest` is defined using `Record` types whose codomains do not include `undefined`. With `exactOptionalPropertyTypes` enabled, this results in an error if, for example, an optional query parameter is defined on an `httpRequest` because of how `optionalized` forces all optional properties to be able to be explicitly `undefined`.

This is a type-level issue, whereas the surprising behavior happens at runtime.

BREAKING CHANGE: `optionalized` now accepts "defined undefined" properties