### PR TITLE
Loosen the `is` check for `optionalized`

### DIFF
--- a/packages/io-ts-http/src/combinators.ts
+++ b/packages/io-ts-http/src/combinators.ts
@@ -26,8 +26,7 @@ const partialWithoutUndefined = <P extends t.Props>(
   const partialCodec = t.partial(props, name);
   return new t.PartialType(
     partialCodec.name,
-    (i): i is DefinedValues<t.TypeOfPartialProps<P>> =>
-      partialCodec.is(i) && !Object.values(i).includes(void 0),
+    (i): i is DefinedValues<t.TypeOfPartialProps<P>> => partialCodec.is(i),
     (i, ctx) => {
       return pipe(
         partialCodec.validate(i, ctx),

--- a/packages/io-ts-http/test/combinators.test.ts
+++ b/packages/io-ts-http/test/combinators.test.ts
@@ -104,6 +104,14 @@ describe('optionalized', () => {
     assertDecodes(optionalCodec, { a: undefined, b: 'foo' }, expected);
   });
 
+  it('returns `true` for `is` when there actually is an explicit undefined', () => {
+    const optionalCodec = c.optionalized({
+      a: c.optional(t.number),
+      b: t.string,
+    });
+    assert(optionalCodec.is({ a: undefined, b: 'foo' }));
+  });
+
   it('strips explicit undefined properties when encoding', () => {
     const optionalCodec = c.optionalized({
       a: c.optional(t.number),
@@ -111,6 +119,18 @@ describe('optionalized', () => {
     });
     const expected = { b: 'foo' };
     assertEncodes(optionalCodec, { a: undefined, b: 'foo' }, expected);
+  });
+
+  it('successfully encodes when in a union and passed explicitly undefined properties', () => {
+    const unionCodec = t.union([
+      c.optionalized({
+        a: c.optional(t.number),
+        key: t.literal('foo'),
+      }),
+      t.undefined,
+    ]);
+    const expected = { key: 'foo' };
+    assertEncodes(unionCodec, { a: undefined, key: 'foo' }, expected);
   });
 
   it('returns undefined when encoding undefined', () => {


### PR DESCRIPTION
The breaking change at https://github.com/BitGo/api-ts/commit/06eddbb5adfdf8b1638a4f0265ae25ec03264ba1 introduced a codec that bahaves like `partial` but strips explicit `undefined` properties when decoding and encoding. This is only used by `optionalized`, and it turns out it is broken at runtime, particularly in codebases that don't set `exactOptionalPropertyTypes`. It defaults to off, and much code treats "key not present" and "key set to `undefined`" interchangeably. Some combinators in `io-ts` such as `union` rely on `is` to determine which codec to use when encoding, so when an `optionalized` codec is used in a union, and is passed an object with defined-undefined properties to encode, it results in an exception. This change fixes that by loosening up the runtime `is` check. 

BREAKING CHANGE: explicit undefined properties are now accepted by `optionalized.is`