### PR TITLE
perf: remove unneeded nullish check

### DIFF
--- a/packages/openapi-generator/src/jsdoc.ts
+++ b/packages/openapi-generator/src/jsdoc.ts
@@ -27,9 +27,7 @@ export function parseCommentBlock(comment: Block): JSDoc {
     }
   }
 
-  if (description !== undefined) {
-    description = description.trim();
-  }
+  description = description.trim();
 
   return {
     ...(summary.length > 0 ? { summary } : {}),


### PR DESCRIPTION
In the current implementation, `description` is always a string, so there
is no point checking if it is not undefined.

This closes
https://github.com/BitGo/api-ts/security/code-scanning/4