### PR TITLE
chore(deps): upgrade supertest to v7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3123,15 +3123,14 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
+      "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
       "dev": true,
       "dependencies": {
         "dezalgo": "^1.0.4",
         "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
+        "once": "^1.4.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -11997,34 +11996,6 @@
         "semantic-release": ">=20.1.0"
       }
     },
-    "node_modules/semantic-release/node_modules/@semantic-release/npm": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-11.0.3.tgz",
-      "integrity": "sha512-KUsozQGhRBAnoVg4UMZj9ep436VEGwT536/jwSqB7vcEfA6oncCUU7UIYTRdLx7GvTtqn0kBjnkfLVkcnBa2YQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@semantic-release/error": "^4.0.0",
-        "aggregate-error": "^5.0.0",
-        "execa": "^8.0.0",
-        "fs-extra": "^11.0.0",
-        "lodash-es": "^4.17.21",
-        "nerf-dart": "^1.0.0",
-        "normalize-url": "^8.0.0",
-        "npm": "^10.5.0",
-        "rc": "^1.2.8",
-        "read-pkg": "^9.0.0",
-        "registry-auth-token": "^5.0.0",
-        "semver": "^7.1.2",
-        "tempy": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.17 || >=20"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=20.1.0"
-      }
-    },
     "node_modules/semantic-release/node_modules/aggregate-error": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
@@ -12265,22 +12236,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/semantic-release/node_modules/normalize-package-data": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
-      "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
     "node_modules/semantic-release/node_modules/p-filter": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
@@ -12323,44 +12278,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/semantic-release/node_modules/read-pkg": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.3",
-        "normalize-package-data": "^6.0.0",
-        "parse-json": "^8.0.0",
-        "type-fest": "^4.6.0",
-        "unicorn-magic": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/read-pkg/node_modules/parse-json": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
-      "integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "index-to-position": "^0.1.2",
-        "type-fest": "^4.7.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/semantic-release/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -12396,19 +12313,6 @@
       },
       "engines": {
         "node": ">=14.18"
-      }
-    },
-    "node_modules/semantic-release/node_modules/type-fest": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.16.0.tgz",
-      "integrity": "sha512-z7Rf5PXxIhbI6eJBTwdqe5bO02nUUmctq4WqviFSstBAWV0YNtEQRhEnZw73WJ8sZOqgFG6Jdl8gYZu7NBJZnA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semantic-release/node_modules/typescript": {
@@ -12914,9 +12818,9 @@
       }
     },
     "node_modules/superagent": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.1.tgz",
+      "integrity": "sha512-CcRSdb/P2oUVaEpQ87w9Obsl+E9FruRd6b2b7LdiBtJoyMr2DQt7a89anAfiX/EL59j9b2CbRFvf2S91DhuCww==",
       "dev": true,
       "dependencies": {
         "component-emitter": "^1.3.0",
@@ -12924,14 +12828,14 @@
         "debug": "^4.3.4",
         "fast-safe-stringify": "^2.1.1",
         "form-data": "^4.0.0",
-        "formidable": "^2.1.2",
+        "formidable": "^3.5.1",
         "methods": "^1.1.2",
         "mime": "2.6.0",
         "qs": "^6.11.0",
         "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=6.4.0 <13 || >=14"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/superagent/node_modules/mime": {
@@ -12947,16 +12851,16 @@
       }
     },
     "node_modules/supertest": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
-      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+      "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
       "dev": true,
       "dependencies": {
         "methods": "^1.1.2",
-        "superagent": "^8.1.2"
+        "superagent": "^9.0.1"
       },
       "engines": {
-        "node": ">=6.4.0"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {
@@ -13651,58 +13555,11 @@
         "express": "4.19.2",
         "io-ts-types": "0.5.19",
         "superagent": "9.0.1",
-        "supertest": "6.3.4",
+        "supertest": "7.0.0",
         "typescript": "4.7.4"
       },
       "peerDependencies": {
         "superagent": "*"
-      }
-    },
-    "packages/superagent-wrapper/node_modules/formidable": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
-      "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
-      "dev": true,
-      "dependencies": {
-        "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
-        "once": "^1.4.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
-    "packages/superagent-wrapper/node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "packages/superagent-wrapper/node_modules/superagent": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.1.tgz",
-      "integrity": "sha512-CcRSdb/P2oUVaEpQ87w9Obsl+E9FruRd6b2b7LdiBtJoyMr2DQt7a89anAfiX/EL59j9b2CbRFvf2S91DhuCww==",
-      "dev": true,
-      "dependencies": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.4",
-        "debug": "^4.3.4",
-        "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.0",
-        "formidable": "^3.5.1",
-        "methods": "^1.1.2",
-        "mime": "2.6.0",
-        "qs": "^6.11.0",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">=14.18.0"
       }
     },
     "packages/superagent-wrapper/node_modules/typescript": {

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -33,7 +33,7 @@
     "express": "4.19.2",
     "io-ts-types": "0.5.19",
     "superagent": "9.0.1",
-    "supertest": "6.3.4",
+    "supertest": "7.0.0",
     "typescript": "4.7.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
This removes our dependency on formidable@2

Closes https://github.com/BitGo/api-ts/security/dependabot/52