### PR TITLE
feat: export substitute path params

### DIFF
--- a/packages/superagent-wrapper/src/request.ts
+++ b/packages/superagent-wrapper/src/request.ts
@@ -63,7 +63,7 @@ export interface SuperagentRequest<Res extends Response> extends Promise<Res> {
   send(body: string): this;
 }
 
-const substitutePathParams = (path: string, params: Record<string, string>) => {
+export const substitutePathParams = (path: string, params: Record<string, string>) => {
   for (const key in params) {
     if (params.hasOwnProperty(key)) {
       path = path.replace(`{${key}}`, params[key]);


### PR DESCRIPTION
Adds substitutePathParams to superagent-wrapper exports.

Motivation: We are working on integrating with a new partner with which our contact specifies that we need to include the url path we are sending a request to in the data we sign (for a signature header). Currently we have all of our partners apis defined via api-ts specs so I'm looking to be able to pull this logic from superagent-wrapper for that use-case.