### PR TITLE
feat(openapi-generator): take and parse @example tags on JSDoc

### DIFF
--- a/packages/openapi-generator/src/jsdoc.ts
+++ b/packages/openapi-generator/src/jsdoc.ts
@@ -3,26 +3,49 @@ import type { Block } from 'comment-parser';
 export type JSDoc = {
   summary?: string;
   description?: string;
-  tags?: Record<string, string>;
+  tags?: Record<string, string> & { example?: unknown };
 };
 
 export function parseCommentBlock(comment: Block): JSDoc {
   let summary: string = '';
   let description: string = '';
-  let tags: Record<string, string> = {};
+  let tags: Record<string, string> & { example?: any } = {};
+  let writingExample = false;
 
   for (const line of comment.source) {
-    if (summary.length === 0) {
-      if (line.tokens.description === '') {
-        continue;
+    if (writingExample) {
+      tags['example'] = `${tags['example']}\n${line.source.split('*')[1]?.trim()}`;
+      try {
+        tags['example'] = JSON.parse(tags['example']);
+        writingExample = false;
+      } catch (e) {
+        if (line.source.endsWith('*/'))
+          throw new Error('@example contains invalid JSON');
+        else continue;
       }
-      summary = line.tokens.description;
     } else {
-      if (line.tokens.tag !== undefined && line.tokens.tag.length > 0) {
-        tags[line.tokens.tag.slice(1)] =
-          `${line.tokens.name} ${line.tokens.description}`.trim();
+      if (summary.length === 0) {
+        if (line.tokens.description === '') {
+          continue;
+        }
+        summary = line.tokens.description;
       } else {
-        description = `${description ?? ''}\n${line.tokens.description}`;
+        if (line.tokens.tag !== undefined && line.tokens.tag.length > 0) {
+          if (line.tokens.tag === '@example') {
+            tags['example'] = line.source.split('@example')[1]?.trim();
+            if (tags['example'].startsWith('{') || tags['example'].startsWith('[')) {
+              try {
+                tags['example'] = JSON.parse(tags['example']);
+              } catch (e) {
+                writingExample = true;
+              }
+            }
+          } else
+            tags[line.tokens.tag.slice(1)] =
+              `${line.tokens.name} ${line.tokens.description}`.trim();
+        } else {
+          description = `${description ?? ''}\n${line.tokens.description}`;
+        }
       }
     }
   }

--- a/packages/openapi-generator/src/jsdoc.ts
+++ b/packages/openapi-generator/src/jsdoc.ts
@@ -1,15 +1,17 @@
 import type { Block } from 'comment-parser';
 
+type Tags = Record<Exclude<string, 'example'>, string> & { example?: any };
+
 export type JSDoc = {
   summary?: string;
   description?: string;
-  tags?: Record<string, string> & { example?: unknown };
+  tags?: Tags;
 };
 
 export function parseCommentBlock(comment: Block): JSDoc {
   let summary: string = '';
   let description: string = '';
-  let tags: Record<string, string> & { example?: any } = {};
+  let tags: Tags = {};
   let writingExample = false;
 
   for (const line of comment.source) {

--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -117,6 +117,7 @@ function routeToOpenAPI(route: Route): [string, string, OpenAPIV3.OperationObjec
   const tag = jsdoc.tags?.tag ?? '';
   const isInternal = jsdoc.tags?.private !== undefined;
   const isUnstable = jsdoc.tags?.unstable !== undefined;
+  const example = jsdoc.tags?.example;
 
   const requestBody =
     route.body === undefined
@@ -163,7 +164,10 @@ function routeToOpenAPI(route: Route): [string, string, OpenAPIV3.OperationObjec
           [Number(code)]: {
             description,
             content: {
-              'application/json': { schema: schemaToOpenAPI(response) },
+              'application/json': {
+                schema: schemaToOpenAPI(response),
+                ...(example !== undefined ? { example } : undefined),
+              },
             },
           },
         };

--- a/packages/openapi-generator/test/jsdoc.test.ts
+++ b/packages/openapi-generator/test/jsdoc.test.ts
@@ -152,3 +152,127 @@ test('comment with a summary, description, and a tag in the middle of the descri
 
   assert.deepEqual(parseJSDoc(comment), expected);
 });
+
+test('parameter with a comment and an example string', () => {
+  const comment = `
+    /**
+     * A variable with example
+     * 
+     * @example foo
+     */
+  `;
+
+  const expected: JSDoc = {
+    summary: 'A variable with example',
+    tags: {
+      example: 'foo',
+    },
+  };
+
+  assert.deepEqual(parseJSDoc(comment), expected);
+});
+
+test('parameter with a comment and an example object', () => {
+  const comment = `
+    /**
+     * A variable with example
+     * 
+     * @example { "test": "foo" }
+     */
+  `;
+
+  const expected: JSDoc = {
+    summary: 'A variable with example',
+    // @ts-expect-error parser doesn't properly infer type
+    tags: {
+      example: { test: 'foo' },
+    },
+  };
+
+  assert.deepEqual(parseJSDoc(comment), expected);
+});
+
+test('parameter with a comment and an example object (multi-line)', () => {
+  const comment = `
+    /**
+     * A variable with example
+     * 
+     * @example {
+     *   "test": "foo"
+     * }
+     */
+  `;
+
+  const expected: JSDoc = {
+    summary: 'A variable with example',
+    // @ts-expect-error parser doesn't properly infer type
+    tags: {
+      example: { test: 'foo' },
+    },
+  };
+
+  assert.deepEqual(parseJSDoc(comment), expected);
+});
+
+test('parameter with a comment and an example array', () => {
+  const comment = `
+    /**
+     * A variable with example
+     * 
+     * @example ["foo", "bar", "baz"]
+     */
+  `;
+
+  const expected: JSDoc = {
+    summary: 'A variable with example',
+    // @ts-expect-error parser doesn't properly infer type
+    tags: {
+      example: ['foo', 'bar', 'baz'],
+    },
+  };
+
+  assert.deepEqual(parseJSDoc(comment), expected);
+});
+
+test('parameter with a comment and an invalid example object', () => {
+  const comment = `
+    /**
+     * A variable with example
+     * 
+     * @example { "test": "foo"
+     */
+  `;
+
+  assert.throws(() => parseJSDoc(comment), {
+    message: '@example contains invalid JSON',
+  });
+});
+
+test('parameter with a comment and an invalid example object (multi-line)', () => {
+  const comment = `
+    /**
+     * A variable with example
+     * 
+     * @example {
+     *   "test": "foo"
+     */
+  `;
+
+  assert.throws(() => parseJSDoc(comment), {
+    message: '@example contains invalid JSON',
+  });
+});
+
+test('parameter with a comment and an invalid example array', () => {
+  const comment = `
+    /**
+     * A variable with example
+     * 
+     * @example ["foo", "bar", "baz"
+     */
+  `;
+
+  assert.throws(() => parseJSDoc(comment), {
+    message: '@example contains invalid JSON',
+  });
+});

--- a/packages/openapi-generator/test/jsdoc.test.ts
+++ b/packages/openapi-generator/test/jsdoc.test.ts
@@ -276,3 +276,49 @@ test('parameter with a comment and an invalid example array', () => {
     message: '@example contains invalid JSON',
   });
 });
+
+test('parameter with a comment, an example object and a tag', () => {
+  const comment = `
+    /**
+     * A variable with example
+     * 
+     * @example { "test": "foo" }
+     * @tag api.example.test
+     */
+  `;
+
+  const expected: JSDoc = {
+    summary: 'A variable with example',
+    // @ts-expect-error parser doesn't properly infer type
+    tags: {
+      example: { test: 'foo' },
+      tag: 'api.example.test',
+    },
+  };
+
+  assert.deepEqual(parseJSDoc(comment), expected);
+});
+
+test('parameter with a comment, an example object (multi-line) and a tag', () => {
+  const comment = `
+    /**
+     * A variable with example
+     * 
+     * @example {
+     *   "test": "foo"
+     * }
+     * @tag api.example.test
+     */
+  `;
+
+  const expected: JSDoc = {
+    summary: 'A variable with example',
+    // @ts-expect-error parser doesn't properly infer type
+    tags: {
+      example: { test: 'foo' },
+      tag: 'api.example.test',
+    },
+  };
+
+  assert.deepEqual(parseJSDoc(comment), expected);
+});

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -927,3 +927,194 @@ testCase('optional parameter', OPTIONAL_PARAM, {
     schemas: {},
   },
 });
+
+const ROUTE_WITH_RESPONSE_EXAMPLE_STRING = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * A simple route
+ *
+ * @operationId api.v1.test
+ * @tag Test Routes
+ * @example bar
+ */
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({}),
+  response: {
+    200: t.string
+  },
+});
+`;
+
+testCase('route with example string', ROUTE_WITH_RESPONSE_EXAMPLE_STRING, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/foo': {
+      get: {
+        summary: 'A simple route',
+        operationId: 'api.v1.test',
+        tags: ['Test Routes'],
+        parameters: [],
+        responses: {
+          200: {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+                example: 'bar',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});
+
+const ROUTE_WITH_RESPONSE_EXAMPLE_OBJECT = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * A simple route
+ *
+ * @operationId api.v1.test
+ * @tag Test Routes
+ * @example { "test": "bar" }
+ */
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({}),
+  response: {
+    200: {
+      test: t.string
+    }
+  },
+});
+`;
+
+testCase('route with example object', ROUTE_WITH_RESPONSE_EXAMPLE_OBJECT, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/foo': {
+      get: {
+        summary: 'A simple route',
+        operationId: 'api.v1.test',
+        tags: ['Test Routes'],
+        parameters: [],
+        responses: {
+          200: {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    test: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['test'],
+                },
+                example: {
+                  test: 'bar',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});
+
+const ROUTE_WITH_RESPONSE_EXAMPLE_OBJECT_MULTILINE = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * A simple route
+ *
+ * @operationId api.v1.test
+ * @tag Test Routes
+ * @example {
+ *   "test": "bar"
+ * }
+ */
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({}),
+  response: {
+    200: {
+      test: t.string
+    }
+  },
+});
+`;
+
+testCase(
+  'route with example object multi-line',
+  ROUTE_WITH_RESPONSE_EXAMPLE_OBJECT_MULTILINE,
+  {
+    openapi: '3.0.3',
+    info: {
+      title: 'Test',
+      version: '1.0.0',
+    },
+    paths: {
+      '/foo': {
+        get: {
+          summary: 'A simple route',
+          operationId: 'api.v1.test',
+          tags: ['Test Routes'],
+          parameters: [],
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      test: {
+                        type: 'string',
+                      },
+                    },
+                    required: ['test'],
+                  },
+                  example: {
+                    test: 'bar',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {},
+    },
+  },
+);


### PR DESCRIPTION
The OpenAPI generator module will now accept `@example` tags in the JSDoc, which will translate into OpenAPI examples. 
They may be used in the route definition to declare a response example, or in a schema definition to declare a schema usage example

## Usage: 

### Schema definition

Given the following JSDoc schema definition 
```javascript
/**
 * A variable with example
 * 
 * @example foo
 */
```

The resulting YAML declaration will be
```yaml
summary: A variable with example
tags:
  example:
    test: foo
```

### Endpoint definition

Given the following endpoint definition

```javascript
import * as t from 'io-ts';
import * as h from '@api-ts/io-ts-http';

/**
 * A simple route
 *
 * @operationId api.v1.test
 * @tag Test Routes
 * @example {
 *   "test": "bar"
 * }
 */
export const route = h.httpRoute({
  path: '/foo',
  method: 'GET',
  request: h.httpRequest({}),
  response: {
    200: {
      test: t.string
    }
  },
});
```

The resulting YAML declaration will be
```yaml
openapi: 3.0.3
info:
  title: Test
  version: 1.0.0
paths:
  "/foo":
    get:
      summary: A simple route
      operationId: api.v1.test
      tags:
      - Test Routes
      parameters: []
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                type: object
                properties:
                  test:
                    type: string
                required:
                - test
              example:
                test: bar
components:
  schemas: {}
```