### PR TITLE
chore: upgrade io-ts version in io-ts-http

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13512,7 +13512,7 @@
         "@api-ts/typed-express-router": "0.0.0-semantically-released",
         "express": "4.19.2",
         "fp-ts": "^2.0.0",
-        "io-ts": "2.1.3"
+        "io-ts": "2.2.21"
       },
       "devDependencies": {
         "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
@@ -13520,6 +13520,14 @@
         "@types/express": "4.17.21",
         "c8": "9.1.0",
         "typescript": "4.7.4"
+      }
+    },
+    "packages/express-wrapper/node_modules/io-ts": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.21.tgz",
+      "integrity": "sha512-zz2Z69v9ZIC3mMLYWIeoUcwWD6f+O7yP92FMVVaXEOSZH1jnVBmET/urd/uoarD1WGBY4rCj8TAyMPzsGNzMFQ==",
+      "peerDependencies": {
+        "fp-ts": "^2.5.0"
       }
     },
     "packages/express-wrapper/node_modules/typescript": {
@@ -13542,13 +13550,32 @@
       "dependencies": {
         "@api-ts/response": "0.0.0-semantically-released",
         "fp-ts": "^2.0.0",
-        "io-ts": "2.1.3",
-        "io-ts-types": "^0.5.15"
+        "io-ts": "2.2.21",
+        "io-ts-types": "0.5.16"
       },
       "devDependencies": {
         "@swc-node/register": "1.9.1",
         "c8": "9.1.0",
         "typescript": "4.7.4"
+      }
+    },
+    "packages/io-ts-http/node_modules/io-ts": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.21.tgz",
+      "integrity": "sha512-zz2Z69v9ZIC3mMLYWIeoUcwWD6f+O7yP92FMVVaXEOSZH1jnVBmET/urd/uoarD1WGBY4rCj8TAyMPzsGNzMFQ==",
+      "peerDependencies": {
+        "fp-ts": "^2.5.0"
+      }
+    },
+    "packages/io-ts-http/node_modules/io-ts-types": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.16.tgz",
+      "integrity": "sha512-h9noYVfY9rlbmKI902SJdnV/06jgiT2chxG6lYDxaYNp88HscPi+SBCtmcU+m0E7WT5QSwt7sIMj93+qu0FEwQ==",
+      "peerDependencies": {
+        "fp-ts": "^2.0.0",
+        "io-ts": "^2.0.0",
+        "monocle-ts": "^2.0.0",
+        "newtype-ts": "^0.3.2"
       }
     },
     "packages/io-ts-http/node_modules/typescript": {
@@ -13634,7 +13661,7 @@
       "dependencies": {
         "@api-ts/io-ts-http": "0.0.0-semantically-released",
         "fp-ts": "^2.0.0",
-        "io-ts": "2.1.3",
+        "io-ts": "2.2.21",
         "whatwg-url": "12.0.1"
       },
       "devDependencies": {
@@ -13653,6 +13680,14 @@
       },
       "peerDependencies": {
         "superagent": "*"
+      }
+    },
+    "packages/superagent-wrapper/node_modules/io-ts": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.21.tgz",
+      "integrity": "sha512-zz2Z69v9ZIC3mMLYWIeoUcwWD6f+O7yP92FMVVaXEOSZH1jnVBmET/urd/uoarD1WGBY4rCj8TAyMPzsGNzMFQ==",
+      "peerDependencies": {
+        "fp-ts": "^2.5.0"
       }
     },
     "packages/superagent-wrapper/node_modules/typescript": {
@@ -13677,13 +13712,21 @@
         "@types/express": "4.17.21",
         "express": "4.19.2",
         "fp-ts": "^2.0.0",
-        "io-ts": "2.1.3"
+        "io-ts": "2.2.21"
       },
       "devDependencies": {
         "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
         "@swc-node/register": "1.9.1",
         "c8": "9.1.0",
         "typescript": "4.7.4"
+      }
+    },
+    "packages/typed-express-router/node_modules/io-ts": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.21.tgz",
+      "integrity": "sha512-zz2Z69v9ZIC3mMLYWIeoUcwWD6f+O7yP92FMVVaXEOSZH1jnVBmET/urd/uoarD1WGBY4rCj8TAyMPzsGNzMFQ==",
+      "peerDependencies": {
+        "fp-ts": "^2.5.0"
       }
     },
     "packages/typed-express-router/node_modules/typescript": {

--- a/packages/express-wrapper/package.json
+++ b/packages/express-wrapper/package.json
@@ -21,7 +21,7 @@
     "@api-ts/typed-express-router": "0.0.0-semantically-released",
     "express": "4.19.2",
     "fp-ts": "^2.0.0",
-    "io-ts": "2.1.3"
+    "io-ts": "2.2.21"
   },
   "devDependencies": {
     "@api-ts/superagent-wrapper": "0.0.0-semantically-released",

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@api-ts/response": "0.0.0-semantically-released",
     "fp-ts": "^2.0.0",
-    "io-ts": "2.1.3",
-    "io-ts-types": "^0.5.15"
+    "io-ts": "2.2.21",
+    "io-ts-types": "0.5.16"
   },
   "devDependencies": {
     "@swc-node/register": "1.9.1",

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "fp-ts": "^2.0.0",
-    "io-ts": "2.1.3",
+    "io-ts": "2.2.21",
     "whatwg-url": "12.0.1"
   },
   "devDependencies": {

--- a/packages/superagent-wrapper/test/request.test.ts
+++ b/packages/superagent-wrapper/test/request.test.ts
@@ -26,7 +26,7 @@ const PostTestRoute = h.httpRoute({
       foo: t.string,
     },
     params: {
-      id: NumberFromString,
+      id: NumberFromString as any,
     },
     body: {
       bar: t.number,
@@ -100,7 +100,7 @@ const createTestServer = (port: number) => {
       const response = PostTestRoute.response[200].encode({
         ...params,
         baz: true,
-      });
+      } as any);
       res.send(response);
     }
   });
@@ -283,11 +283,11 @@ describe('superagent', async () => {
         },
         params: {
           id: NumberFromString,
-        },
+        } as any,
         body: {
           bar: t.number,
         },
-      }),
+      }) as any,
       response: {
         200: t.type({
           id: t.number,

--- a/packages/typed-express-router/package.json
+++ b/packages/typed-express-router/package.json
@@ -21,7 +21,7 @@
     "@types/express": "4.17.21",
     "express": "4.19.2",
     "fp-ts": "^2.0.0",
-    "io-ts": "2.1.3"
+    "io-ts": "2.2.21"
   },
   "devDependencies": {
     "@api-ts/superagent-wrapper": "0.0.0-semantically-released",


### PR DESCRIPTION
We will be upgrading the io-ts version to `2.2.21` in entity validation. To resolve the conflicts caused by the update, we need to upgrade io-ts version in api-ts/io-ts-http to `2.2.21` as well.

Ticket: COPS-1139