### PR TITLE
Don't silently drop properties when processing an `httpRoute`

### DIFF
--- a/packages/openapi-generator/src/knownImports.ts
+++ b/packages/openapi-generator/src/knownImports.ts
@@ -206,13 +206,14 @@ export const KNOWN_IMPORTS: KnownImports = {
       if (schema.type !== 'object') {
         return E.left('httpRoute parameter must be object');
       }
-      const props = Object.entries(schema.properties).reduce((acc, [key, prop]) => {
-        const derefedE = deref(prop);
+      const props: Record<string, Schema> = {};
+      for (const [key, value] of Object.entries(schema.properties)) {
+        const derefedE = deref(value);
         if (E.isLeft(derefedE)) {
-          return acc;
+          return derefedE;
         }
-        return { ...acc, [key]: derefedE.right };
-      }, {});
+        props[key] = derefedE.right;
+      }
       return E.right({
         type: 'object',
         properties: props,

--- a/packages/openapi-generator/test/apiSpec.test.ts
+++ b/packages/openapi-generator/test/apiSpec.test.ts
@@ -265,3 +265,28 @@ test('api spec comment parser', async () => {
 
   assert(commentParsed);
 });
+
+const MISSING_REFERENCE = {
+  '/index.ts': `
+    import * as t from 'io-ts';
+    import * as h from '@api-ts/io-ts-http';
+
+    import { Foo } from 'foo';
+
+    export const test = h.apiSpec({
+      'api.test': {
+        get: h.httpRoute({
+          path: '/test',
+          method: 'GET',
+          request: Foo,
+          response: {
+            200: t.string,
+          },
+        })
+      }
+    });`,
+};
+
+testCase('missing reference', MISSING_REFERENCE, '/index.ts', {}, [
+  "Cannot find 'Foo' from 'foo'",
+]);


### PR DESCRIPTION
Fixes an issue where errors are swallowed while processing an `httpRoute`. Generally this happens while processing a request type, the error just gets swallowed and the `request` property is omitted from the resulting schema. This then errors out later on in the section of the codebase that expects a request to be there, causing this hard-to-debug error:

> Error parsing SomeApiSpec: Route must have a request

With this change, the _actual_ error is passed all the way through, making it much easier to see what went wrong.