### PR TITLE
Fix parsing of standalong jsdoc tags

### DIFF
--- a/packages/openapi-generator/src/jsdoc.ts
+++ b/packages/openapi-generator/src/jsdoc.ts
@@ -25,30 +25,27 @@ export function parseCommentBlock(comment: Block): JSDoc {
           throw new Error('@example contains invalid JSON');
         else continue;
       }
-    } else {
-      if (summary.length === 0) {
-        if (line.tokens.description === '') {
-          continue;
+    } else if (line.tokens.tag !== undefined && line.tokens.tag.length > 0) {
+      if (line.tokens.tag === '@example') {
+        tags['example'] = line.source.split('@example')[1]?.trim();
+        if (tags['example'].startsWith('{') || tags['example'].startsWith('[')) {
+          try {
+            tags['example'] = JSON.parse(tags['example']);
+          } catch (e) {
+            writingExample = true;
+          }
         }
-        summary = line.tokens.description;
       } else {
-        if (line.tokens.tag !== undefined && line.tokens.tag.length > 0) {
-          if (line.tokens.tag === '@example') {
-            tags['example'] = line.source.split('@example')[1]?.trim();
-            if (tags['example'].startsWith('{') || tags['example'].startsWith('[')) {
-              try {
-                tags['example'] = JSON.parse(tags['example']);
-              } catch (e) {
-                writingExample = true;
-              }
-            }
-          } else
-            tags[line.tokens.tag.slice(1)] =
-              `${line.tokens.name} ${line.tokens.description}`.trim();
-        } else {
-          description = `${description ?? ''}\n${line.tokens.description}`;
-        }
+        tags[line.tokens.tag.slice(1)] =
+          `${line.tokens.name} ${line.tokens.description}`.trim();
       }
+    } else if (summary.length === 0) {
+      if (line.tokens.description === '') {
+        continue;
+      }
+      summary = line.tokens.description;
+    } else {
+      description = `${description ?? ''}\n${line.tokens.description}`;
     }
   }
 

--- a/packages/openapi-generator/test/jsdoc.test.ts
+++ b/packages/openapi-generator/test/jsdoc.test.ts
@@ -157,7 +157,7 @@ test('parameter with a comment and an example string', () => {
   const comment = `
     /**
      * A variable with example
-     * 
+     *
      * @example foo
      */
   `;
@@ -176,7 +176,7 @@ test('parameter with a comment and an example object', () => {
   const comment = `
     /**
      * A variable with example
-     * 
+     *
      * @example { "test": "foo" }
      */
   `;
@@ -196,7 +196,7 @@ test('parameter with a comment and an example object (multi-line)', () => {
   const comment = `
     /**
      * A variable with example
-     * 
+     *
      * @example {
      *   "test": "foo"
      * }
@@ -218,7 +218,7 @@ test('parameter with a comment and an example array', () => {
   const comment = `
     /**
      * A variable with example
-     * 
+     *
      * @example ["foo", "bar", "baz"]
      */
   `;
@@ -238,7 +238,7 @@ test('parameter with a comment and an invalid example object', () => {
   const comment = `
     /**
      * A variable with example
-     * 
+     *
      * @example { "test": "foo"
      */
   `;
@@ -252,7 +252,7 @@ test('parameter with a comment and an invalid example object (multi-line)', () =
   const comment = `
     /**
      * A variable with example
-     * 
+     *
      * @example {
      *   "test": "foo"
      */
@@ -267,7 +267,7 @@ test('parameter with a comment and an invalid example array', () => {
   const comment = `
     /**
      * A variable with example
-     * 
+     *
      * @example ["foo", "bar", "baz"
      */
   `;
@@ -281,7 +281,7 @@ test('parameter with a comment, an example object and a tag', () => {
   const comment = `
     /**
      * A variable with example
-     * 
+     *
      * @example { "test": "foo" }
      * @tag api.example.test
      */
@@ -303,7 +303,7 @@ test('parameter with a comment, an example object (multi-line) and a tag', () =>
   const comment = `
     /**
      * A variable with example
-     * 
+     *
      * @example {
      *   "test": "foo"
      * }
@@ -317,6 +317,22 @@ test('parameter with a comment, an example object (multi-line) and a tag', () =>
     tags: {
       example: { test: 'foo' },
       tag: 'api.example.test',
+    },
+  };
+
+  assert.deepEqual(parseJSDoc(comment), expected);
+});
+
+test('a standalone tag with no summary or description', () => {
+  const comment = `
+    /**
+     * @tag
+     */
+  `;
+
+  const expected: JSDoc = {
+    tags: {
+      tag: '',
     },
   };
 


### PR DESCRIPTION
There is a bug with the jsdoc comment parsing when the comment contains a tag with no summary or description:

```
/**
 * @tag
 */
```

Without this change, the `@tag` gets ignored.