### PR TITLE
refactor(openapi-generator): improve error message for reaching the deepest allowed nest

### DIFF
--- a/packages/openapi-generator/src/codec.ts
+++ b/packages/openapi-generator/src/codec.ts
@@ -53,6 +53,10 @@ function codecIdentifier(
   } else if (id.type === 'MemberExpression') {
     const object = id.object;
     if (object.type !== 'Identifier') {
+      if (object.type === 'MemberExpression')
+        return E.left(
+          `Object ${((object as swc.MemberExpression) && { value: String }).value} is deeply nested, which is unsupported`,
+        );
       return E.left(`Unimplemented object type ${object.type}`);
     }
 


### PR DESCRIPTION
DX-420

Deep nesting isn’t yet implemented in the openapi-generator. Until it’s properly implemented, this PR will give developers a clear error message that informs about the missing feature

