### PR TITLE
feat: add support for `descriptions` in OpenAPI specs

### DIFF
--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -50,6 +50,7 @@ function schemaToOpenAPI(
       case 'object':
         return {
           type: 'object',
+          ...defaultObject,
           properties: Object.entries(schema.properties).reduce(
             (acc, [name, prop]) => {
               const innerSchema = schemaToOpenAPI(prop);
@@ -72,6 +73,7 @@ function schemaToOpenAPI(
             }
             return [innerSchema];
           }),
+          ...defaultObject,
         };
       case 'union':
         let nullable = false;
@@ -95,10 +97,15 @@ function schemaToOpenAPI(
             )[0] === '$ref'
           )
             // OpenAPI spec doesn't allow $ref properties to have siblings, so they're wrapped in an 'allOf' array
-            return { ...(nullable ? { nullable } : {}), allOf: oneOf };
-          else return { ...(nullable ? { nullable } : {}), ...oneOf[0] };
+            return {
+              ...(nullable ? { nullable } : {}),
+              allOf: oneOf,
+              ...defaultObject,
+            };
+          else
+            return { ...(nullable ? { nullable } : {}), ...oneOf[0], ...defaultObject };
         } else {
-          return { ...(nullable ? { nullable } : {}), oneOf };
+          return { ...(nullable ? { nullable } : {}), oneOf, ...defaultObject };
         }
       case 'record':
         const additionalProperties = schemaToOpenAPI(schema.codomain);

--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -115,6 +115,7 @@ function schemaToOpenAPI(
         return {
           type: 'object',
           additionalProperties,
+          ...defaultObject,
         };
       case 'undefined':
         return undefined;

--- a/packages/openapi-generator/src/optimize.ts
+++ b/packages/openapi-generator/src/optimize.ts
@@ -137,8 +137,18 @@ export function optimize(schema: Schema): Schema {
     return simplified;
   } else if (schema.type === 'array') {
     const optimized = optimize(schema.items);
+    if (schema.comment) {
+      return { type: 'array', items: optimized, comment: schema.comment };
+    }
     return { type: 'array', items: optimized };
   } else if (schema.type === 'record') {
+    if (schema.comment) {
+      return {
+        type: 'record',
+        codomain: optimize(schema.codomain),
+        comment: schema.comment,
+      };
+    }
     return { type: 'record', codomain: optimize(schema.codomain) };
   } else if (schema.type === 'tuple') {
     const schemas = schema.schemas.map(optimize);

--- a/packages/openapi-generator/src/optimize.ts
+++ b/packages/openapi-generator/src/optimize.ts
@@ -106,7 +106,13 @@ export function optimize(schema: Schema): Schema {
         continue;
       }
       const [isOptional, filteredSchema] = filterUndefinedUnion(optimized);
+
+      if (prop.comment) {
+        filteredSchema.comment = prop.comment;
+      }
+
       properties[key] = filteredSchema;
+
       if (schema.required.indexOf(key) >= 0 && !isOptional) {
         required.push(key);
       }
@@ -123,7 +129,12 @@ export function optimize(schema: Schema): Schema {
   } else if (schema.type === 'intersection') {
     return foldIntersection(schema, optimize);
   } else if (schema.type === 'union') {
-    return simplifyUnion(schema, optimize);
+    const simplified = simplifyUnion(schema, optimize);
+    if (schema.comment) {
+      return { ...simplified, comment: schema.comment };
+    }
+
+    return simplified;
   } else if (schema.type === 'array') {
     const optimized = optimize(schema.items);
     return { type: 'array', items: optimized };

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -1899,3 +1899,140 @@ testCase('route with array types and descriptions', ROUTE_WITH_ARRAY_TYPES_AND_D
   }
 });
 
+const ROUTE_WITH_RECORD_TYPES_AND_DESCRIPTIONS = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * A simple route with type descriptions
+ *
+ * @operationId api.v1.test
+ * @tag Test Routes
+ */
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      /** bar param */
+      bar: t.record(t.string, t.string),
+    },
+    body: {
+      /** foo description */
+      foo: t.record(t.string, t.number),
+      child: {
+        /** child description */
+        child: t.record(t.string, t.array(t.union([t.string, t.number]))),
+      }
+    },
+  }),
+  response: {
+    200: {
+      test: t.string
+    }
+  },
+});
+`;
+
+testCase('route with record types and descriptions', ROUTE_WITH_RECORD_TYPES_AND_DESCRIPTIONS, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0'
+  },
+  paths: {
+    '/foo': {
+      get: {
+        summary: 'A simple route with type descriptions',
+        operationId: 'api.v1.test',
+        tags: [
+          'Test Routes'
+        ],
+        parameters: [
+          {
+            name: 'bar',
+            description: 'bar param',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'object',
+              additionalProperties: {
+                type: 'string'
+              }
+            }
+          }
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  foo: {
+                    type: 'object',
+                    additionalProperties: {
+                      type: 'number'
+                    },
+                    description: 'foo description'
+                  },
+                  child: {
+                    type: 'object',
+                    properties: {
+                      child: {
+                        type: 'object',
+                        additionalProperties: {
+                          type: 'array',
+                          items: {
+                            oneOf: [
+                              {
+                                type: 'string'
+                              },
+                              {
+                                type: 'number'
+                              }
+                            ]
+                          }
+                        },
+                        description: 'child description'
+                      }
+                    },
+                    required: [
+                      'child'
+                    ]
+                  }
+                },
+                required: [
+                  'foo',
+                  'child'
+                ]
+              }
+            }
+          }
+        },
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    test: {
+                      type: 'string'
+                    }
+                  },
+                  required: [
+                    'test'
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {}
+  }
+});

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -1454,3 +1454,122 @@ testCase('route with type descriptions', ROUTE_WITH_TYPE_DESCRIPTIONS, {
     schemas: {},
   },
 });
+
+
+const ROUTE_WITH_TYPE_DESCRIPTIONS_OPTIONAL = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * A simple route with type descriptions
+ *
+ * @operationId api.v1.test
+ * @tag Test Routes
+ */
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      /** bar param */
+      bar: t.string,
+    },
+    body: {
+      /** foo description */
+      foo: h.optional(t.string),
+      /** bar description */
+      bar: h.optional(t.number),
+      child: {
+        /** child description */
+        child: h.optional(t.string),
+      }
+    },
+  }),
+  response: {
+    200: {
+      test: t.string
+    }
+  },
+});
+`;
+
+
+testCase('route with type descriptions with optional fields', ROUTE_WITH_TYPE_DESCRIPTIONS_OPTIONAL, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/foo': {
+      get: {
+        summary: 'A simple route with type descriptions',
+        operationId: 'api.v1.test',
+        tags: ['Test Routes'],
+        parameters: [
+          {
+            description: 'bar param',
+            in: 'query',
+            name: 'bar',
+            required: true,
+            schema: {
+              type: 'string'
+            }
+          }
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                properties: {
+                  bar: {
+                    description: 'bar description',
+                    type: 'number'
+                  },
+                  child: {
+                    properties: {
+                      child: {
+                        description: 'child description',
+                        type: 'string'
+                      }
+                    },
+                    type: 'object'
+                  },
+                  foo: {
+                    description: 'foo description',
+                    type: 'string'
+                  }
+                },
+                required: [
+                  'child'
+                ],
+                type: 'object'
+              }
+            }
+          }
+        },
+        responses: {
+          200: {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    test: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['test'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -60,7 +60,6 @@ async function testCase(
       schemas,
     );
 
-
     assert.deepEqual(errors, expectedErrors);
     assert.deepEqual(actual, expected);
   });
@@ -1757,3 +1756,146 @@ testCase('route with mixed types and descriptions', ROUTE_WITH_MIXED_TYPES_AND_D
     schemas: {}
   }
 });
+
+const ROUTE_WITH_ARRAY_TYPES_AND_DESCRIPTIONS = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * A simple route with type descriptions
+ *
+ * @operationId api.v1.test
+ * @tag Test Routes
+ */
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      /** bar param */
+      bar: t.string,
+    },
+    body: {
+      /** foo description */
+      foo: t.array(t.string),
+      /** bar description */
+      bar: t.array(t.number),
+      child: {
+        /** child description */
+        child: t.array(t.union([t.string, t.number])),
+      }
+    },
+  }),
+  response: {
+    200: {
+      test: t.string
+    }
+  },
+});
+`;
+
+testCase('route with array types and descriptions', ROUTE_WITH_ARRAY_TYPES_AND_DESCRIPTIONS, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0'
+  },
+  paths: {
+    '/foo': {
+      get: {
+        summary: 'A simple route with type descriptions',
+        operationId: 'api.v1.test',
+        tags: [
+          'Test Routes'
+        ],
+        parameters: [
+          {
+            name: 'bar',
+            description: 'bar param',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string'
+            }
+          }
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  foo: {
+                    type: 'array',
+                    items: {
+                      type: 'string'
+                    },
+                    description: 'foo description'
+                  },
+                  bar: {
+                    type: 'array',
+                    items: {
+                      type: 'number'
+                    },
+                    description: 'bar description'
+                  },
+                  child: {
+                    type: 'object',
+                    properties: {
+                      child: {
+                        type: 'array',
+                        items: {
+                          oneOf: [
+                            {
+                              type: 'string'
+                            },
+                            {
+                              type: 'number'
+                            }
+                          ]
+                        },
+                        description: 'child description'
+                      }
+                    },
+                    required: [
+                      'child'
+                    ]
+                  }
+                },
+                required: [
+                  'foo',
+                  'bar',
+                  'child'
+                ]
+              }
+            }
+          }
+        },
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    test: {
+                      type: 'string'
+                    }
+                  },
+                  required: [
+                    'test'
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {}
+  }
+});
+

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -29,6 +29,7 @@ async function testCase(
       throw new Error('Failed to parse source file');
     }
 
+
     const project = new Project();
     const routes: Route[] = [];
     const schemas: Record<string, Schema> = {};
@@ -58,6 +59,7 @@ async function testCase(
       routes,
       schemas,
     );
+
 
     assert.deepEqual(errors, expectedErrors);
     assert.deepEqual(actual, expected);
@@ -1572,4 +1574,186 @@ testCase('route with type descriptions with optional fields', ROUTE_WITH_TYPE_DE
   components: {
     schemas: {},
   },
+});
+
+const ROUTE_WITH_MIXED_TYPES_AND_DESCRIPTIONS = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * A simple route with type descriptions
+ *
+ * @operationId api.v1.test
+ * @tag Test Routes
+ */
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      /** bar param */
+      bar: t.string,
+    },
+    body: {
+      /** description to describe an optional string */
+      foo: h.optional(t.string),
+      /** description to describe an optional union of number and string */
+      bar: h.optional(t.union([t.number, t.string])),
+      /** description to describe an object */
+      child: {
+        /** dsecription to describe an intersection of a type and a partial */
+        child: t.intersection([t.type({ foo: t.string }), t.partial({ bar: t.number })]),
+      },
+      /** description to describe a t.type */
+      error: t.type({ error: t.string }),
+      /** description to describe an optional t.object */
+      obj: h.optional(t.object({})),
+      /** description to describe a t.exact */
+      exact: t.exact(t.type({ foo: t.string })),
+    },
+  }),
+  response: {
+    200: {
+      test: t.string
+    }
+  },
+});
+`;
+
+testCase('route with mixed types and descriptions', ROUTE_WITH_MIXED_TYPES_AND_DESCRIPTIONS, 
+{
+  openapi: "3.0.3",
+  info: {
+    title: "Test",
+    version: "1.0.0"
+  },
+  paths: {
+    '/foo': {
+      get: {
+        summary: "A simple route with type descriptions",
+        operationId: "api.v1.test",
+        tags: [
+          "Test Routes"
+        ],
+        parameters: [
+          {
+            name: "bar",
+            description: "bar param",
+            in: "query",
+            required: true,
+            schema: {
+              type: "string"
+            }
+          }
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: "object",
+                properties: {
+                  foo: {
+                    type: "string",
+                    description: "description to describe an optional string"
+                  },
+                  bar: {
+                    oneOf: [
+                      {
+                        type: "number"
+                      },
+                      {
+                        type: "string"
+                      }
+                    ],
+                    description: "description to describe an optional union of number and string"
+                  },
+                  child: {
+                    type: "object",
+                    description: "description to describe an object",
+                    properties: {
+                      child: {
+                        type: "object",
+                        description: "dsecription to describe an intersection of a type and a partial",
+                        properties: {
+                          foo: {
+                            type: "string"
+                          },
+                          bar: {
+                            type: "number"
+                          }
+                        },
+                        required: [
+                          "foo"
+                        ]
+                      }
+                    },
+                    required: [
+                      "child"
+                    ]
+                  },
+                  error: {
+                    type: "object",
+                    description: "description to describe a t.type",
+                    properties: {
+                      error: {
+                        type: "string"
+                      }
+                    },
+                    required: [
+                      "error"
+                    ]
+                  },
+                  obj: {
+                    type: "object",
+                    description: "description to describe an optional t.object",
+                    properties: {}
+                  },
+                  exact: {
+                    type: "object",
+                    description: "description to describe a t.exact",
+                    properties: {
+                      foo: {
+                        type: "string"
+                      }
+                    },
+                    required: [
+                      "foo"
+                    ]
+                  }
+                },
+                required: [
+                  "child",
+                  "error",
+                  "exact"
+                ]
+              }
+            }
+          }
+        },
+        responses: {
+          200: {
+            description: "OK",
+            content: {
+              'application/json': {
+                schema: {
+                  type: "object",
+                  properties: {
+                    test: {
+                      type: "string"
+                    }
+                  },
+                  required: [
+                    "test"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {}
+  }
 });


### PR DESCRIPTION
Ticket: DX-434

This PR adds support for surfacing descriptions for more types, like `t.array`, `h.optional`, `t.record`, etc.