### PR TITLE
test: fix `openapi.test.ts` to properly test `@example` tag behaviour

### DIFF
--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -2054,7 +2054,7 @@ export const route = h.httpRoute({
     query: {
       /** 
        * This is a bar param.
-       * @example { "foo": "bar" }
+       * @example "{ 'foo': 'bar' }"
       */
       bar: t.record(t.string, t.string),
     },
@@ -2103,6 +2103,7 @@ testCase('route with descriptions, patterns, and examples', ROUTE_WITH_DESCRIPTI
             required: true,
             schema: {
               type: 'object',
+              example: "{ 'foo': 'bar' }",
               additionalProperties: {
                 type: 'string'
               }


### PR DESCRIPTION
The test I wrote before didn't test `@example` behaviour properly, this fixes it.