### PR TITLE
feat: add support for more tags in `openapi-generator`

### DIFF
--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -139,6 +139,18 @@ function schemaToOpenAPI(
     const maxLength = getTagName(schema, 'maxLength');
     const minLength = getTagName(schema, 'minLength');
     const pattern = getTagName(schema, 'pattern');
+    const minimum = getTagName(schema, 'minimum');
+    const maximum = getTagName(schema, 'maximum');
+    const minItems = getTagName(schema, 'minItems');
+    const maxItems = getTagName(schema, 'maxItems');
+    const minProperties = getTagName(schema, 'minProperties');
+    const maxProperties = getTagName(schema, 'maxProperties');
+    const exclusiveMinimum = getTagName(schema, 'exclusiveMinimum');
+    const exclusiveMaximum = getTagName(schema, 'exclusiveMaximum');
+    const multipleOf = getTagName(schema, 'multipleOf');
+    const uniqueItems = getTagName(schema, 'uniqueItems');
+    const readOnly = getTagName(schema, 'readOnly');
+    const writeOnly = getTagName(schema, 'writeOnly');
     const format = getTagName(schema, 'format');
 
     const deprecated = schema.comment?.tags.find((t) => t.tag === 'deprecated');
@@ -152,6 +164,18 @@ function schemaToOpenAPI(
       ...(maxLength ? { maxLength: Number(maxLength) } : {}),
       ...(minLength ? { minLength: Number(minLength) } : {}),
       ...(pattern ? { pattern } : {}),
+      ...(minimum ? { minimum: Number(minimum) } : {}),
+      ...(maximum ? { maximum: Number(maximum) } : {}),
+      ...(minItems ? { minItems: Number(minItems) } : {}),
+      ...(maxItems ? { maxItems: Number(maxItems) } : {}),
+      ...(minProperties ? { minProperties: Number(minProperties) } : {}),
+      ...(maxProperties ? { maxProperties: Number(maxProperties) } : {}),
+      ...(exclusiveMinimum ? { exclusiveMinimum: true } : {}),
+      ...(exclusiveMaximum ? { exclusiveMaximum: true } : {}),
+      ...(multipleOf ? { multipleOf: Number(multipleOf) } : {}),
+      ...(uniqueItems ? { uniqueItems: true } : {}),
+      ...(readOnly ? { readOnly: true } : {}),
+      ...(writeOnly ? { writeOnly: true } : {}),
       ...(format ? { format } : {}),
     };
     return defaultOpenAPIObject;

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -2531,3 +2531,117 @@ testCase('route with deprecated tag', ROUTE_WITH_DEPRECATED_TAG, {
     schemas: {}
   }
 });
+
+const ROUTE_WITH_MIN_MAX_AND_OTHER_TAGS = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * A simple route with type descriptions for references
+ *
+ * @operationId api.v1.test
+ * @tag Test Routes
+ */
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({
+    body: {
+      /** 
+       * This is a foo description. 
+       * @minimum 5
+       * @maximum 10
+       * @minItems 1
+       * @maxItems 5
+       * @minProperties 1
+       * @maxProperties 500
+       * @exclusiveMinimum true
+       * @exclusiveMaximum true
+       * @multipleOf 7
+       * @uniqueItems true
+       * @readOnly true
+       * @writeOnly true
+      */
+      foo: t.number()
+    },
+  }),
+  response: {
+    200: {
+      test: t.string
+    }
+  },
+});
+`;
+
+testCase('route with min and max tags', ROUTE_WITH_MIN_MAX_AND_OTHER_TAGS, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0'
+  },
+  paths: {
+    '/foo': {
+      get: {
+        summary: 'A simple route with type descriptions for references',
+        operationId: 'api.v1.test',
+        parameters: [],
+        tags: [
+          'Test Routes'
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  foo: {
+                    type: 'number',
+                    description: 'This is a foo description.',
+                    minimum: 5,
+                    maximum: 10,
+                    minItems: 1,
+                    maxItems: 5,
+                    minProperties: 1,
+                    multipleOf: 7,
+                    maxProperties: 500,
+                    exclusiveMinimum: true,
+                    exclusiveMaximum: true,
+                    uniqueItems: true,
+                    readOnly: true,
+                    writeOnly: true
+                  }
+                },
+                required: [
+                  'foo'
+                ]
+              }
+            }
+          }
+        },
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    test: {
+                      type: 'string'
+                    }
+                  },
+                  required: [
+                    'test'
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {}
+  }
+});


### PR DESCRIPTION
Adds support for the `minimum`, `maximum`, `minItems`, `maxItems`, `minProperties`, `maxProperties`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `uniqueItems`, `readOnly`, and `writeOnly` tags in the OpenAPI schema.

Ticket: DX-447