### PR TITLE
feat(openapi-generator): parse `examples` and `default` in apiSpec as the schema type

### DIFF
--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -133,6 +133,30 @@ function schemaToOpenAPI(
     }
   };
 
+  /**
+   *  This function will return the field value parsed as the type of the schema. i.e. if the schema is a number, it will return the field as a JS number.
+   *
+   * @param schema A schema object
+   * @param field The target field to parse in that schema
+   * @returns the parsed value
+   */
+  const parseField = (schema: Schema, field: string): any => {
+    const fieldValue = getTagName(schema, field);
+    if (!fieldValue) {
+      return;
+    }
+
+    if (schema.type === 'number' || schema.type === 'integer') {
+      return Number(fieldValue);
+    } else if (schema.type === 'boolean') {
+      return fieldValue === 'true';
+    } else if (schema.type === 'null') {
+      return null;
+    } else {
+      return fieldValue;
+    }
+  };
+
   function buildDefaultOpenAPIObject(schema: Schema): OpenAPIV3.SchemaObject {
     const defaultValue = getTagName(schema, 'default');
     const example = getTagName(schema, 'example');
@@ -157,10 +181,10 @@ function schemaToOpenAPI(
     const description = schema.comment?.description;
 
     const defaultOpenAPIObject = {
-      ...(defaultValue ? { default: defaultValue } : {}),
+      ...(defaultValue ? { default: parseField(schema, 'default') } : {}),
       ...(deprecated ? { deprecated: true } : {}),
       ...(description ? { description } : {}),
-      ...(example ? { example } : {}),
+      ...(example ? { example: parseField(schema, 'example') } : {}),
       ...(maxLength ? { maxLength: Number(maxLength) } : {}),
       ...(minLength ? { minLength: Number(minLength) } : {}),
       ...(pattern ? { pattern } : {}),

--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -137,15 +137,10 @@ function schemaToOpenAPI(
    *  This function will return the field value parsed as the type of the schema. i.e. if the schema is a number, it will return the field as a JS number.
    *
    * @param schema A schema object
-   * @param field The target field to parse in that schema
+   * @param fieldValue The value to parse
    * @returns the parsed value
    */
-  const parseField = (schema: Schema, field: string): any => {
-    const fieldValue = getTagName(schema, field);
-    if (!fieldValue) {
-      return;
-    }
-
+  const parseField = (schema: Schema, fieldValue: string): any => {
     if (schema.type === 'number' || schema.type === 'integer') {
       return Number(fieldValue);
     } else if (schema.type === 'boolean') {
@@ -181,10 +176,10 @@ function schemaToOpenAPI(
     const description = schema.comment?.description;
 
     const defaultOpenAPIObject = {
-      ...(defaultValue ? { default: parseField(schema, 'default') } : {}),
+      ...(defaultValue ? { default: parseField(schema, defaultValue) } : {}),
       ...(deprecated ? { deprecated: true } : {}),
       ...(description ? { description } : {}),
-      ...(example ? { example: parseField(schema, 'example') } : {}),
+      ...(example ? { example: parseField(schema, example) } : {}),
       ...(maxLength ? { maxLength: Number(maxLength) } : {}),
       ...(minLength ? { minLength: Number(minLength) } : {}),
       ...(pattern ? { pattern } : {}),

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -2119,7 +2119,7 @@ testCase('route with descriptions, patterns, and examples', ROUTE_WITH_DESCRIPTI
                   foo: {
                     type: 'number',
                     description: 'foo description',
-                    example: '12345',
+                    example: 12345,
                     pattern: '^[1-9][0-9]{4}$'
                   },
                   child: {


### PR DESCRIPTION
DX-458