### PR TITLE
feat: add support for comments from declarations

### DIFF
--- a/packages/openapi-generator/src/cli.ts
+++ b/packages/openapi-generator/src/cli.ts
@@ -177,7 +177,7 @@ const app = command({
           );
           process.exit(1);
         }
-        const [newSourceFile, init] = initE.right;
+        const [newSourceFile, init, comment] = initE.right;
 
         const codecE = parseCodecInitializer(project.right, newSourceFile, init);
         if (E.isLeft(codecE)) {
@@ -186,6 +186,10 @@ const app = command({
           );
           process.exit(1);
         }
+        if (comment !== undefined) {
+          codecE.right.comment = comment;
+        }
+
         components[ref.name] = codecE.right;
         queue.push(codecE.right);
       }

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -669,6 +669,91 @@ testCase('request body ref', SCHEMA_REF, {
   },
 });
 
+const SCHEMA_REF_WITH_COMMENT_AT_DECLARATION = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({
+    params: {
+      body: t.string,
+      /**
+       * Size of the body
+       * @example 10
+       */
+      size: t.number,
+    }
+  }),
+  response: {
+    200: Foo
+  },
+});
+
+/**
+ * a Foo of type 'string'
+ * @example "foo"
+ */
+const Foo = t.string;
+`;
+
+testCase('request body ref with comments', SCHEMA_REF_WITH_COMMENT_AT_DECLARATION, {
+  openapi: "3.0.3",
+  info: {
+    title: "Test",
+    version: "1.0.0"
+  },
+  paths: {
+    "/foo": {
+      get: {
+        parameters: [
+          {
+            name: "body",
+            in: "path",
+            required: true,
+            schema: {
+              type: "string"
+            }
+          },
+          {
+            name: "size",
+            description: "Size of the body",
+            in: "path",
+            required: true,
+            schema: {
+              type: "number",
+              example: 10
+            }
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Foo"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      Foo: {
+        title: "Foo",
+        type: "string",
+        description: "a Foo of type 'string'",
+        example: "foo"
+      }
+    }
+  }
+});
+
 const SCHEMA_DOUBLE_REF = `
 import * as t from 'io-ts';
 import * as h from '@api-ts/io-ts-http';


### PR DESCRIPTION
In `wallet-platform-types` there are a lot of types (like `walletId` and `coin`) which are used in a LOT of files. If you want to add a `description` to that field then you need to copy-paste the comment for EVERY instance. But, if you try factoring out the fields to a common schema file and then export it where needed, openapi-generator ignores any comments and/or tags that you add to that declaration. We need to add support for this to allow for the refactors. 

This PR fixes that and adds a test for it.

Ticket: DX-494