### PR TITLE
feat: allow for `JSDoc`'s in `request` declarations

### DIFF
--- a/packages/openapi-generator/src/codec.ts
+++ b/packages/openapi-generator/src/codec.ts
@@ -374,8 +374,13 @@ export function parseCodecInitializer(
         if (E.isLeft(initE)) {
           return initE;
         }
-        const [newSourceFile, init] = initE.right;
-        return parsePlainInitializer(project, newSourceFile, init);
+        const [newSourceFile, init, comment] = initE.right;
+        const plainInitE = parsePlainInitializer(project, newSourceFile, init);
+
+        if (E.isLeft(plainInitE)) return plainInitE;
+        if (comment !== undefined) plainInitE.right.comment = comment;
+
+        return plainInitE;
       }
     }
     const args = init.arguments.map<E.Either<string, Schema>>(({ expression }) => {

--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -260,25 +260,13 @@ function routeToOpenAPI(route: Route): [string, string, OpenAPIV3.OperationObjec
     {},
   );
 
-  const stripTopLevelComment = (schema: Schema) => {
-    const copy = { ...schema };
-
-    if (copy.comment?.description !== undefined && copy.comment?.description !== '') {
-      copy.comment.description = '';
-    }
-
-    return copy;
-  };
-
-  const topLevelStripped = stripTopLevelComment(route.body!);
-
   const requestBody =
     route.body === undefined
       ? {}
       : {
           requestBody: {
             content: {
-              'application/json': { schema: schemaToOpenAPI(topLevelStripped) },
+              'application/json': { schema: schemaToOpenAPI(route.body) },
             },
           },
         };


### PR DESCRIPTION
For some routes with union types in the request body, if there were no `@title` tags in the source repo definition of the route, then `dev-portal` would fallback to using the type (which was object). Trying to add these `@title` tags to declarations in `openapi-generator` was also not working since it wasn’t supported. 

Not cool:
![image](https://github.com/BitGo/api-ts/assets/45408169/4dbe5dea-dd6f-489c-9f6c-02f8b9ae9382)

Very cool:
<img width="792" alt="image" src="https://github.com/BitGo/api-ts/assets/45408169/8dcbcb34-bf44-41e4-9a32-ba7bafca33fe">

Shoutout to @ad-world for finding this issue!

Ticket: DX-551