### PR TITLE
chore: update `CODEOWNERS` to include `DevEx`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BitGo/velocity
+* @BitGo/developer-relations-team @BitGo/developer-experience @BitGo/velocity


### PR DESCRIPTION
`DevEx` has been doing a good amount of work in this repo, would be nice for our team to review PR's as well.