### PR TITLE
chore: remove `@BitGo/developer-relations-team` as `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BitGo/developer-relations-team @BitGo/developer-experience @BitGo/velocity
+* @BitGo/developer-experience @BitGo/velocity


### PR DESCRIPTION
This commit removes `@BitGo/developer-relations-team` as `CODEOWNERS`