### PR TITLE
fix(deps): update whatwg-url to v14.0.0

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -36,7 +36,5 @@ updates:
         versions: ['2.x']
       - dependency-name: typescript
         versions: ['>4.8']
-      - dependency-name: whatwg-url
-        versions: ['>=13']
       - dependency-name: '@semantic-release-extras/github-comment-specific'
         versions: ['>1.0.7']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1973,9 +1973,9 @@
       "dev": true
     },
     "node_modules/@types/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-4F6szvZP3FM5HvJAmcInXBfrAhvM4tLIc8MO1nXwabG5TZVOLxVmAXRpICqXYd3lBlomSRGmLCopYV+yTocgpQ==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
       "dev": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
@@ -11757,9 +11757,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -13707,14 +13707,14 @@
       }
     },
     "node_modules/tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
       "dependencies": {
-        "punycode": "^2.3.0"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/traverse": {
@@ -13946,15 +13946,15 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
       "dependencies": {
-        "tr46": "^4.1.1",
+        "tr46": "^5.0.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -14314,7 +14314,7 @@
         "@api-ts/io-ts-http": "0.0.0-semantically-released",
         "fp-ts": "^2.0.0",
         "io-ts": "2.1.3",
-        "whatwg-url": "12.0.1"
+        "whatwg-url": "14.0.0"
       },
       "devDependencies": {
         "@swc-node/register": "1.10.7",
@@ -14322,7 +14322,7 @@
         "@types/node": "20.14.0",
         "@types/superagent": "8.1.7",
         "@types/supertest": "6.0.2",
-        "@types/whatwg-url": "11.0.0",
+        "@types/whatwg-url": "11.0.5",
         "c8": "10.1.2",
         "express": "4.19.2",
         "io-ts-types": "0.5.19",

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -20,7 +20,7 @@
     "@api-ts/io-ts-http": "0.0.0-semantically-released",
     "fp-ts": "^2.0.0",
     "io-ts": "2.1.3",
-    "whatwg-url": "12.0.1"
+    "whatwg-url": "14.0.0"
   },
   "devDependencies": {
     "@swc-node/register": "1.10.7",
@@ -28,7 +28,7 @@
     "@types/node": "20.14.0",
     "@types/superagent": "8.1.7",
     "@types/supertest": "6.0.2",
-    "@types/whatwg-url": "11.0.0",
+    "@types/whatwg-url": "11.0.5",
     "c8": "10.1.2",
     "express": "4.19.2",
     "io-ts-types": "0.5.19",


### PR DESCRIPTION
whatwg-url v14 drops support for Node.js 16 and Node.js 14, which may
be notable. Since these are not current LTS versions, I'm inclined to not
consider this a breaking change from the api-ts side.

Closes Ticket: VL-497