### PR TITLE
feat: allow unions to consolidate into single primitive types

### DIFF
--- a/packages/openapi-generator/src/ir.ts
+++ b/packages/openapi-generator/src/ir.ts
@@ -82,4 +82,9 @@ export type SchemaMetadata = Omit<
   | 'externalDocs'
 >;
 
-export type Schema = BaseSchema & HasComment & SchemaMetadata;
+type ExtendedSchemaMetadata = SchemaMetadata & {
+  primitive?: boolean;
+  decodedType?: string;
+};
+
+export type Schema = BaseSchema & HasComment & ExtendedSchemaMetadata;

--- a/packages/openapi-generator/src/knownImports.ts
+++ b/packages/openapi-generator/src/knownImports.ts
@@ -46,10 +46,10 @@ export const KNOWN_IMPORTS: KnownImports = {
     },
   },
   'io-ts': {
-    string: () => E.right({ type: 'string' }),
-    number: () => E.right({ type: 'number' }),
+    string: () => E.right({ type: 'string', primitive: true }),
+    number: () => E.right({ type: 'number', primitive: true }),
     bigint: () => E.right({ type: 'number' }),
-    boolean: () => E.right({ type: 'boolean' }),
+    boolean: () => E.right({ type: 'boolean', primitive: true }),
     null: () => E.right({ type: 'null' }),
     nullType: () => E.right({ type: 'null' }),
     undefined: () => E.right({ type: 'undefined' }),
@@ -143,11 +143,13 @@ export const KNOWN_IMPORTS: KnownImports = {
         type: 'string',
         format: 'number',
         pattern: '^\\d+$',
+        decodedType: 'number',
       }),
     NaturalFromString: () =>
       E.right({
         type: 'string',
         format: 'number',
+        decodedType: 'number',
       }),
     Negative: () =>
       E.right({
@@ -161,6 +163,7 @@ export const KNOWN_IMPORTS: KnownImports = {
         format: 'number',
         maximum: 0,
         exclusiveMaximum: true,
+        decodedType: 'number',
       }),
     NegativeInt: () =>
       E.right({
@@ -174,6 +177,7 @@ export const KNOWN_IMPORTS: KnownImports = {
         format: 'number',
         maximum: 0,
         exclusiveMaximum: true,
+        decodedType: 'number',
       }),
     NonNegative: () =>
       E.right({
@@ -185,6 +189,7 @@ export const KNOWN_IMPORTS: KnownImports = {
         type: 'string',
         format: 'number',
         minimum: 0,
+        decodedType: 'number',
       }),
     NonNegativeInt: () =>
       E.right({
@@ -195,6 +200,7 @@ export const KNOWN_IMPORTS: KnownImports = {
       E.right({
         type: 'string',
         format: 'number',
+        decodedType: 'number',
       }),
     NonPositive: () =>
       E.right({
@@ -206,6 +212,7 @@ export const KNOWN_IMPORTS: KnownImports = {
         type: 'string',
         format: 'number',
         maximum: 0,
+        decodedType: 'number',
       }),
     NonPositiveInt: () =>
       E.right({
@@ -217,6 +224,7 @@ export const KNOWN_IMPORTS: KnownImports = {
         type: 'string',
         format: 'number',
         maximum: 0,
+        decodedType: 'number',
       }),
     NonZero: () =>
       E.right({
@@ -226,6 +234,7 @@ export const KNOWN_IMPORTS: KnownImports = {
       E.right({
         type: 'string',
         format: 'number',
+        decodedType: 'number',
       }),
     NonZeroInt: () =>
       E.right({
@@ -235,6 +244,7 @@ export const KNOWN_IMPORTS: KnownImports = {
       E.right({
         type: 'string',
         format: 'number',
+        decodedType: 'number',
       }),
     Positive: () =>
       E.right({
@@ -248,6 +258,7 @@ export const KNOWN_IMPORTS: KnownImports = {
         format: 'number',
         minimum: 0,
         exclusiveMinimum: true,
+        decodedType: 'number',
       }),
     Zero: () =>
       E.right({
@@ -257,6 +268,7 @@ export const KNOWN_IMPORTS: KnownImports = {
       E.right({
         type: 'string',
         format: 'number',
+        decodedType: 'number',
       }),
   },
   'io-ts-bigint': {
@@ -264,6 +276,7 @@ export const KNOWN_IMPORTS: KnownImports = {
       E.right({
         type: 'string',
         format: 'number',
+        decodedType: 'bigint',
       }),
     NegativeBigInt: () =>
       E.right({
@@ -275,6 +288,7 @@ export const KNOWN_IMPORTS: KnownImports = {
         type: 'string',
         format: 'number',
         maximum: -1,
+        decodedType: 'bigint',
       }),
     NonEmptyString: () => E.right({ type: 'string', minLength: 1 }),
     NonNegativeBigInt: () => E.right({ type: 'number', minimum: 0 }),
@@ -283,6 +297,7 @@ export const KNOWN_IMPORTS: KnownImports = {
         type: 'string',
         format: 'number',
         maximum: 0,
+        decodedType: 'bigint',
       }),
     NonPositiveBigInt: () =>
       E.right({
@@ -294,12 +309,14 @@ export const KNOWN_IMPORTS: KnownImports = {
         type: 'string',
         format: 'number',
         maximum: 0,
+        decodedType: 'bigint',
       }),
     NonZeroBigInt: () => E.right({ type: 'number' }),
     NonZeroBigIntFromString: () =>
       E.right({
         type: 'string',
         format: 'number',
+        decodedType: 'bigint',
       }),
     PositiveBigInt: () => E.right({ type: 'number', minimum: 1 }),
     PositiveBigIntFromString: () =>
@@ -307,15 +324,21 @@ export const KNOWN_IMPORTS: KnownImports = {
         type: 'string',
         format: 'number',
         minimum: 1,
+        decodedType: 'bigint',
       }),
     ZeroBigInt: () => E.right({ type: 'number' }),
-    ZeroBigIntFromString: () => E.right({ type: 'string', format: 'number' }),
+    ZeroBigIntFromString: () =>
+      E.right({ type: 'string', format: 'number', decodedType: 'bigint' }),
   },
   'io-ts-types': {
-    NumberFromString: () => E.right({ type: 'string', format: 'number' }),
-    BigIntFromString: () => E.right({ type: 'string', format: 'number' }),
-    BooleanFromNumber: () => E.right({ type: 'number', enum: [0, 1] }),
-    BooleanFromString: () => E.right({ type: 'string', enum: ['true', 'false'] }),
+    NumberFromString: () =>
+      E.right({ type: 'string', format: 'number', decodedType: 'number' }),
+    BigIntFromString: () =>
+      E.right({ type: 'string', format: 'number', decodedType: 'bigint' }),
+    BooleanFromNumber: () =>
+      E.right({ type: 'number', enum: [0, 1], decodedType: 'boolean' }),
+    BooleanFromString: () =>
+      E.right({ type: 'string', enum: ['true', 'false'], decodedType: 'boolean' }),
     DateFromISOString: () =>
       E.right({ type: 'string', format: 'date-time', title: 'ISO Date String' }),
     DateFromNumber: () =>
@@ -332,7 +355,8 @@ export const KNOWN_IMPORTS: KnownImports = {
         format: 'number',
         description: 'Number of seconds since the Unix epoch',
       }),
-    IntFromString: () => E.right({ type: 'string', format: 'integer' }),
+    IntFromString: () =>
+      E.right({ type: 'string', format: 'integer', decodedType: 'number' }),
     JsonFromString: () => E.right({ type: 'string', title: 'JSON String' }),
     nonEmptyArray: (_, innerSchema) =>
       E.right({ type: 'array', items: innerSchema, minItems: 1 }),

--- a/packages/openapi-generator/test/apiSpec.test.ts
+++ b/packages/openapi-generator/test/apiSpec.test.ts
@@ -80,7 +80,7 @@ testCase('simple api spec', SIMPLE, '/index.ts', {
       path: '/test',
       method: 'GET',
       parameters: [],
-      response: { 200: { type: 'string' } },
+      response: { 200: { type: 'string', primitive: true } },
     },
   ],
 });
@@ -112,7 +112,7 @@ testCase('const route reference', ROUTE_REF, '/index.ts', {
       path: '/test',
       method: 'GET',
       parameters: [],
-      response: { 200: { type: 'string' } },
+      response: { 200: { type: 'string', primitive: true } },
     },
   ],
 });
@@ -144,7 +144,7 @@ testCase('const action reference', ACTION_REF, '/index.ts', {
       path: '/test',
       method: 'GET',
       parameters: [],
-      response: { 200: { type: 'string' } },
+      response: { 200: { type: 'string', primitive: true } },
     },
   ],
 });
@@ -182,7 +182,7 @@ testCase('spread api spec', SPREAD, '/index.ts', {
       path: '/test',
       method: 'GET',
       parameters: [],
-      response: { 200: { type: 'string' } },
+      response: { 200: { type: 'string', primitive: true } },
     },
   ],
 });
@@ -216,7 +216,7 @@ testCase('computed property api spec', COMPUTED_PROPERTY, '/index.ts', {
       path: '/test',
       method: 'GET',
       parameters: [],
-      response: { 200: { type: 'string' } },
+      response: { 200: { type: 'string', primitive: true } },
     },
   ],
 });

--- a/packages/openapi-generator/test/codec.test.ts
+++ b/packages/openapi-generator/test/codec.test.ts
@@ -46,7 +46,7 @@ export const FOO = t.number;
 `;
 
 testCase('simple codec is parsed', SIMPLE, {
-  FOO: { type: 'number' },
+  FOO: { type: 'number', primitive: true },
 });
 
 const DIRECT = `
@@ -55,7 +55,7 @@ export const FOO = number;
 `;
 
 testCase('direct import is parsed', DIRECT, {
-  FOO: { type: 'number' },
+  FOO: { type: 'number', primitive: true },
 });
 
 const TYPE = `
@@ -66,7 +66,7 @@ export const FOO = t.type({ foo: t.number });
 testCase('type is parsed', TYPE, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
 });
@@ -79,7 +79,7 @@ export const FOO = t.partial({ foo: t.number });
 testCase('partial type is parsed', PARTIAL, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: [],
   },
 });
@@ -91,10 +91,10 @@ export const FOO = t.type({ bar });
 `;
 
 testCase('shorthand property is parsed', SHORTHAND_PROPERTY, {
-  bar: { type: 'number' },
+  bar: { type: 'number', primitive: true },
   FOO: {
     type: 'object',
-    properties: { bar: { type: 'number' } },
+    properties: { bar: { type: 'number', primitive: true } },
     required: ['bar'],
   },
 });
@@ -110,14 +110,14 @@ export const TEST = t.type({ ...foo, bar: t.string });
 testCase('spread property is parsed', SPREAD_PROPERTY, {
   foo: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
   TEST: {
     type: 'object',
     properties: {
-      foo: { type: 'number' },
-      bar: { type: 'string' },
+      foo: { type: 'number', primitive: true },
+      bar: { type: 'string', primitive: true },
     },
     required: ['foo', 'bar'],
   },
@@ -132,12 +132,12 @@ export const FOO = t.type(props);
 testCase('const assertion is parsed', CONST_ASSERTION, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
   props: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
 });
@@ -153,12 +153,12 @@ export const FOO = t.type({
 testCase('spread const assertion is parsed', SPREAD_CONST_ASSERTION, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
   props: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
 });
@@ -172,12 +172,12 @@ export const FOO = t.type(props);
 testCase('as assertion is parsed', AS_ASSERTION, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
   props: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
 });
@@ -193,12 +193,12 @@ export const FOO = t.type({
 testCase('spread const assertion is parsed', SPREAD_AS_ASSERTION, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
   props: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
 });
@@ -209,7 +209,7 @@ export const FOO = t.array(t.number);
 `;
 
 testCase('array type is parsed', ARRAY, {
-  FOO: { type: 'array', items: { type: 'number' } },
+  FOO: { type: 'array', items: { type: 'number', primitive: true } },
 });
 
 const UNION = `
@@ -220,7 +220,7 @@ export const FOO = t.union([t.string, t.number]);
 testCase('union type is parsed', UNION, {
   FOO: {
     type: 'union',
-    schemas: [{ type: 'string' }, { type: 'number' }],
+    schemas: [{ type: 'string', primitive: true }, { type: 'number', primitive: true }],
   },
 });
 
@@ -235,11 +235,11 @@ export const FOO = t.union([...common, t.number]);
 testCase('union type with spread is parsed', UNION_SPREAD, {
   FOO: {
     type: 'union',
-    schemas: [{ type: 'string' }, { type: 'number' }],
+    schemas: [{ type: 'string', primitive: true }, { type: 'number', primitive: true }],
   },
   common: {
     type: 'tuple',
-    schemas: [{ type: 'string' }],
+    schemas: [{ type: 'string', primitive: true }],
   },
 });
 
@@ -252,7 +252,7 @@ export const FOO = t.union([...[t.string], t.number]);
 testCase('union type with inline spread is parsed', UNION_INLINE_SPREAD, {
   FOO: {
     type: 'union',
-    schemas: [{ type: 'string' }, { type: 'number' }],
+    schemas: [{ type: 'string', primitive: true }, { type: 'number', primitive: true }],
   },
 });
 
@@ -267,12 +267,12 @@ testCase('intersection type is parsed', INTERSECTION, {
     schemas: [
       {
         type: 'object',
-        properties: { foo: { type: 'number' } },
+        properties: { foo: { type: 'number', primitive: true } },
         required: ['foo'],
       },
       {
         type: 'object',
-        properties: { bar: { type: 'string' } },
+        properties: { bar: { type: 'string', primitive: true } },
         required: [],
       },
     ],
@@ -285,7 +285,7 @@ export const FOO = t.record(t.string, t.number);
 `;
 
 testCase('record type is parsed', RECORD, {
-  FOO: { type: 'record', codomain: { type: 'number' } },
+  FOO: { type: 'record', codomain: { type: 'number', primitive: true } },
 });
 
 const ENUM = `
@@ -381,7 +381,7 @@ export const FOO = test;
 `;
 
 testCase('aliased import is parsed', ALIAS, {
-  FOO: { type: 'string' },
+  FOO: { type: 'string', primitive: true },
 });
 
 const BRAND = `
@@ -394,7 +394,7 @@ export const FOO = t.brand(t.string, (s): s is FooBranded => s === 'foo', 'Foo')
 `;
 
 testCase('brand type is parsed', BRAND, {
-  FOO: { type: 'string' },
+  FOO: { type: 'string', primitive: true },
 });
 
 const LOCAL_REF = `
@@ -406,7 +406,7 @@ export const BAR = t.type({ bar: FOO });
 testCase('local ref is parsed', LOCAL_REF, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
   BAR: {
@@ -425,7 +425,7 @@ export const BAR = t.type({ bar: FOO });
 testCase('local exported ref is parsed', LOCAL_EXPORTED_REF, {
   FOO: {
     type: 'object',
-    properties: { foo: { type: 'number' } },
+    properties: { foo: { type: 'number', primitive: true } },
     required: ['foo'],
   },
   BAR: {
@@ -476,6 +476,7 @@ export const FOO = t.number;
 testCase('declaration comment is parsed', DECLARATION_COMMENT, {
   FOO: {
     type: 'number',
+    primitive: true,
     comment: {
       description: 'Test codec',
       tags: [],
@@ -553,7 +554,8 @@ testCase(
   DECLARATION_COMMENT_WITHOUT_LINE_BREAK,
   {
     FOO: {
-      type: 'number',
+      type: 'number', 
+      primitive: true,
       comment: {
         description: 'Test codec',
         tags: [],
@@ -633,6 +635,7 @@ testCase('first property comment is parsed', FIRST_PROPERTY_COMMENT, {
     properties: {
       foo: {
         type: 'number',
+        primitive: true,
         comment: {
           description: 'this is a comment',
           problems: [],
@@ -677,9 +680,10 @@ testCase('second property comment is parsed', SECOND_PROPERTY_COMMENT, {
   FOO: {
     type: 'object',
     properties: {
-      foo: { type: 'number' },
+      foo: { type: 'number', primitive: true },
       bar: {
-        type: 'string',
+        type: 'string', 
+        primitive: true,
         comment: {
           description: 'this is a comment',
           problems: [],
@@ -720,7 +724,7 @@ export const FOO = h.optional(t.string);
 testCase('optional combinator is parsed', OPTIONAL_COMBINATOR, {
   FOO: {
     type: 'union',
-    schemas: [{ type: 'string' }, { type: 'undefined' }],
+    schemas: [{ type: 'string', primitive: true }, { type: 'undefined' }],
   },
 });
 
@@ -737,10 +741,10 @@ testCase('optionalized combinator is parsed', OPTIONALIZED_COMBINATOR, {
   FOO: {
     type: 'object',
     properties: {
-      foo: { type: 'string' },
+      foo: { type: 'string', primitive: true },
       bar: {
         type: 'union',
-        schemas: [{ type: 'number' }, { type: 'undefined' }],
+        schemas: [{ type: 'number', primitive: true }, { type: 'undefined' }],
       },
     },
     required: ['foo'],
@@ -766,7 +770,7 @@ testCase('httpRequest combinator is parsed', HTTP_REQUEST_COMBINATOR, {
     properties: {
       params: {
         type: 'object',
-        properties: { foo: { type: 'string' } },
+        properties: { foo: { type: 'string', primitive: true } },
         required: ['foo'],
       },
       query: {
@@ -774,7 +778,7 @@ testCase('httpRequest combinator is parsed', HTTP_REQUEST_COMBINATOR, {
         properties: {
           bar: {
             type: 'union',
-            schemas: [{ type: 'number' }, { type: 'undefined' }],
+            schemas: [{ type: 'number', primitive: true }, { type: 'undefined' }],
           },
         },
         required: [],
@@ -801,15 +805,15 @@ testCase('object property is parsed', OBJECT_PROPERTY, {
   FOO: {
     type: 'object',
     properties: {
-      baz: { type: 'number' },
+      baz: { type: 'number', primitive: true },
     },
     required: ['baz'],
   },
   props: {
     type: 'object',
     properties: {
-      foo: { type: 'number' },
-      bar: { type: 'string' },
+      foo: { type: 'number', primitive: true },
+      bar: { type: 'string', primitive: true },
     },
     required: ['foo', 'bar'],
   },
@@ -830,16 +834,16 @@ testCase('object assign is parsed', OBJECT_ASSIGN, {
   FOO: {
     type: 'object',
     properties: {
-      foo: { type: 'number' },
-      bar: { type: 'string' },
+      foo: { type: 'number', primitive: true },
+      bar: { type: 'string', primitive: true },
     },
     required: ['foo', 'bar'],
   },
   props: {
     type: 'object',
     properties: {
-      foo: { type: 'number' },
-      bar: { type: 'string' },
+      foo: { type: 'number', primitive: true },
+      bar: { type: 'string', primitive: true },
     },
     required: ['foo', 'bar'],
   },

--- a/packages/openapi-generator/test/externalModule.test.ts
+++ b/packages/openapi-generator/test/externalModule.test.ts
@@ -69,9 +69,11 @@ const FoobarObject: Schema = {
   properties: {
     foo: {
       type: 'string',
+      primitive: true,
     },
     bar: {
       type: 'number',
+      primitive: true,
     },
   },
   required: ['foo', 'bar'],
@@ -82,9 +84,11 @@ const RandomTypeObject: Schema = {
   properties: {
     random: {
       type: 'string',
+      primitive: true,
     },
     type: {
       type: 'number',
+      primitive: true,
     },
   },
   required: ['random', 'type'],

--- a/packages/openapi-generator/test/optimize.test.ts
+++ b/packages/openapi-generator/test/optimize.test.ts
@@ -144,3 +144,39 @@ test('comments are exposed in objects', () => {
 
   assert.deepEqual(optimize(input), expected);
 });
+
+test('consolidatable unions are consolidated to single primitive type', () => {
+  const input: Schema = {
+    type: 'union',
+    schemas: [
+      { type: 'string', enum: ['true', 'false'], decodedType: 'boolean' },
+      { type: 'boolean', primitive: true },
+    ],
+    required: [],
+  };
+
+  const expected: Schema = { type: 'boolean', };
+
+  assert.deepEqual(optimize(input), expected);
+});
+
+test('non-consolidatable unions are not consolidated', () => {
+  const input: Schema = {
+    type: 'union',
+    schemas: [
+      { type: 'string', enum: ['true', 'false'], decodedType: 'boolean' },
+      { type: 'string', primitive: true },
+    ],
+    required: [],
+  };
+
+  const expected: Schema = {
+    type: 'union',
+    schemas: [
+      { type: 'string', primitive: true },
+      { type: 'string', enum: [ 'true', 'false' ] },
+    ]
+  };
+
+  assert.deepEqual(optimize(input), expected);
+});

--- a/packages/openapi-generator/test/resolve.test.ts
+++ b/packages/openapi-generator/test/resolve.test.ts
@@ -63,7 +63,7 @@ testCase(
   {
     FOO: {
       type: 'object',
-      properties: { foo: { type: 'string' } },
+      properties: { foo: { type: 'string', primitive: true } },
       required: ['foo'],
     },
   },
@@ -85,7 +85,7 @@ testCase(
   {
     FOO: {
       type: 'union',
-      schemas: [{ type: 'string' }, { type: 'number' }],
+      schemas: [{ type: 'string', primitive: true }, { type: 'number', primitive: true }],
     },
   },
   ['Unimplemented initializer type ArrayExpression'],
@@ -544,7 +544,7 @@ testCase(
     FOO: {
       type: 'object',
       properties: {
-        foo: { type: 'number' },
+        foo: { type: 'number', primitive: true },
       },
       required: ['foo'],
     },

--- a/packages/openapi-generator/test/route.test.ts
+++ b/packages/openapi-generator/test/route.test.ts
@@ -85,12 +85,14 @@ testCase('simple route', SIMPLE, {
         required: true,
         schema: {
           type: 'string',
+          primitive: true,
         },
       },
     ],
     response: {
       200: {
         type: 'string',
+        primitive: true,
       },
     },
   },
@@ -124,6 +126,7 @@ testCase('path params route', PATH_PARAMS, {
         required: true,
         schema: {
           type: 'string',
+          primitive: true,
         },
       },
     ],
@@ -165,13 +168,14 @@ testCase('optional query param route', OPTIONAL_QUERY_PARAM, {
         required: false,
         schema: {
           type: 'union',
-          schemas: [{ type: 'string' }, { type: 'undefined' }],
+          schemas: [{ type: 'string', primitive: true }, { type: 'undefined' }],
         },
       },
     ],
     response: {
       200: {
         type: 'string',
+        primitive: true,
       },
     },
   },
@@ -201,6 +205,7 @@ testCase('const request route', REQUEST_REF, {
     response: {
       200: {
         type: 'string',
+        primitive: true,
       },
     },
   },
@@ -228,7 +233,7 @@ testCase('const response route', RESPONSE_REF, {
     method: 'GET',
     parameters: [],
     response: {
-      200: { type: 'string' },
+      200: { type: 'string', primitive: true },
     },
   },
 });
@@ -273,14 +278,14 @@ testCase('query param union route', QUERY_PARAM_UNION, {
             {
               type: 'object',
               properties: {
-                foo: { type: 'string' },
+                foo: { type: 'string', primitive: true },
               },
               required: ['foo'],
             },
             {
               type: 'object',
               properties: {
-                bar: { type: 'string' },
+                bar: { type: 'string', primitive: true },
               },
               required: ['bar'],
             },
@@ -289,7 +294,7 @@ testCase('query param union route', QUERY_PARAM_UNION, {
       },
     ],
     response: {
-      200: { type: 'string' },
+      200: { type: 'string', primitive: true },
     },
   },
 });
@@ -340,14 +345,14 @@ testCase('path param union route', PATH_PARAM_UNION, {
             {
               type: 'object',
               properties: {
-                foo: { type: 'string' },
+                foo: { type: 'string', primitive: true },
               },
               required: ['foo'],
             },
             {
               type: 'object',
               properties: {
-                bar: { type: 'string' },
+                bar: { type: 'string', primitive: true },
               },
               required: ['bar'],
             },
@@ -358,11 +363,11 @@ testCase('path param union route', PATH_PARAM_UNION, {
         type: 'path',
         name: 'id',
         required: true,
-        schema: { type: 'string' },
+        schema: { type: 'string', primitive: true },
       },
     ],
     response: {
-      200: { type: 'string' },
+      200: { type: 'string', primitive: true },
     },
   },
 });
@@ -402,21 +407,21 @@ testCase('body union route', BODY_UNION, {
         {
           type: 'object',
           properties: {
-            foo: { type: 'string' },
+            foo: { type: 'string', primitive: true },
           },
           required: ['foo'],
         },
         {
           type: 'object',
           properties: {
-            bar: { type: 'string' },
+            bar: { type: 'string', primitive: true },
           },
           required: ['bar'],
         },
       ],
     },
     response: {
-      200: { type: 'string' },
+      200: { type: 'string', primitive: true },
     },
   },
 });
@@ -454,17 +459,17 @@ testCase('request intersection route', REQUEST_INTERSECTION, {
         type: 'query',
         name: 'foo',
         required: true,
-        schema: { type: 'string' },
+        schema: { type: 'string', primitive: true },
       },
       {
         type: 'query',
         name: 'bar',
         required: true,
-        schema: { type: 'string' },
+        schema: { type: 'string', primitive: true },
       },
     ],
     response: {
-      200: { type: 'string' },
+      200: { type: 'string', primitive: true },
     },
   },
 });
@@ -504,21 +509,21 @@ testCase('request body intersection route', BODY_INTERSECTION, {
         {
           type: 'object',
           properties: {
-            foo: { type: 'string' },
+            foo: { type: 'string', primitive: true },
           },
           required: ['foo'],
         },
         {
           type: 'object',
           properties: {
-            bar: { type: 'string' },
+            bar: { type: 'string', primitive: true },
           },
           required: ['bar'],
         },
       ],
     },
     response: {
-      200: { type: 'string' },
+      200: { type: 'string', primitive: true },
     },
   },
 });
@@ -557,12 +562,14 @@ testCase('route with operationId', WITH_OPERATION_ID, {
         required: true,
         schema: {
           type: 'string',
+          primitive: true,
         },
       },
     ],
     response: {
       200: {
         type: 'string',
+        primitive: true,
       },
     },
     comment: {


### PR DESCRIPTION
This PR aims to introduce a union-consolidation step, where we can simplify union schemas if they meet certain conditions.

**Motivation:**

We have encountered multiple codecs that type the same `A` type with different `I` types. For example, a value intended as a `boolean` at runtime might be passed into the API as a `boolean` (`true` or `false`), a `string` (`"true"` or `"false"`), or even a `number` (`0` or `1`). Currently, `dev-portal` displays all these options as valid ways to pass a boolean to the API. However, this can be overwhelming and unnecessary for clients. If the API ultimately expects a `boolean` (typed as `t.boolean`), we should simplify this by presenting only the primitive `boolean` type.

**Solution:**
We propose the following criteria for consolidating union schemas into a single primitive type:

1. The input (`I`) type is a union.
2. The runtime (`A`) type is a primitive type (specifically, `string`, `number`, or `boolean`).
3. The `A` type exists _literally_ within the `I` type.

To support this, we need to address two aspects that are not currently available:

1. **Identifying Primitive Types:**
   Add a `primitive` property to the `schema` type to identify primitive `io-ts` codecs.

2. **Determining Intermediate Types:**
   Add a `decodedType` property (name can be revised) to the `schema` type. This will specify the runtime type of codecs like `BooleanFromString` or `NumberFromString`, enabling us to determine if a union containing these codecs can be consolidated into a single primitive type.

**Ticket:** DX-614
