### PR TITLE
feat: support private fields in the openapi generator

### DIFF
--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -3942,7 +3942,11 @@ import * as h from '@api-ts/io-ts-http';
 const SampleType = t.type({
   foo: t.string,
   /** @private */
-  bar: t.string, // This should show up with x-internal
+  bar: t.string, // This should show up with x-internal,
+  /** @private */
+  privateObject: t.type({
+    privateFieldInObject: t.boolean
+  })
 });
 
 export const route = h.httpRoute({
@@ -3963,7 +3967,7 @@ export const route = h.httpRoute({
     200: SampleType
   },
 });
-`
+`;
 
 testCase("route with private properties in request query, params, body, and response", ROUTE_WITH_PRIVATE_PROPERTIES, {
   openapi: "3.0.3",
@@ -4007,11 +4011,24 @@ testCase("route with private properties in request query, params, body, and resp
                   },
                   foo: {
                     type: 'string'
+                  },
+                  privateObject: {
+                    'x-internal': true,
+                    properties: {
+                      privateFieldInObject: {
+                        type: 'boolean'
+                      }
+                    },
+                    required: [
+                      'privateFieldInObject'
+                    ],
+                    type: 'object'
                   }
                 },
                 required: [
                   'foo',
-                  'bar'
+                  'bar',
+                  'privateObject'
                 ],
                 type: 'object'
               }
@@ -4043,11 +4060,24 @@ testCase("route with private properties in request query, params, body, and resp
           },
           foo: {
             type: 'string'
+          },
+          privateObject: {
+            'x-internal': true,
+            properties: {
+              privateFieldInObject: {
+                type: 'boolean'
+              }
+            },
+            required: [
+              'privateFieldInObject'
+            ],
+            type: 'object'
           }
         },
         required: [
           'foo',
-          'bar'
+          'bar',
+          'privateObject'
         ],
         title: 'SampleType',
         type: 'object'

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -4085,3 +4085,139 @@ testCase("route with private properties in request query, params, body, and resp
     }
   },
 });
+
+const ROUTE_WITH_RECORD_TYPES = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+const ValidKeys = t.keyof({ name: "name", age: "age", address: "address" });
+const PersonObject = t.type({ bigName: t.string, bigAge: t.number });
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      name: t.string,
+    },
+  }),
+  response: {
+    200: {
+      person: t.record(ValidKeys, t.string),
+      anotherPerson: t.record(ValidKeys, PersonObject),
+      bigPerson: t.record(t.string, t.string),
+      anotherBigPerson: t.record(t.string, PersonObject),
+    }
+  },
+});
+`;
+
+testCase("route with record types", ROUTE_WITH_RECORD_TYPES, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0'
+  },
+  paths: {
+    '/foo': {
+      get: {
+        parameters: [
+          {
+            name: 'name',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string'
+            }
+          }
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    // becomes t.type()
+                    person: {
+                      type: 'object',
+                      properties: {
+                        name: { type: 'string' },
+                        age: { type: 'string' },
+                        address: { type: 'string' }
+                      },
+                      required: [ 'name', 'age', 'address' ]
+                    },
+                    // becomes t.type()
+                    anotherPerson: {
+                      type: 'object',
+                      properties: {
+                        name: {
+                          type: 'object',
+                          properties: {
+                            bigName: { type: 'string' },
+                            bigAge: { type: 'number' }
+                          },
+                          required: [ 'bigName', 'bigAge' ]
+                        },
+                        age: {
+                          type: 'object',
+                          properties: {
+                            bigName: { type: 'string' },
+                            bigAge: { type: 'number' }
+                          },
+                          required: [ 'bigName', 'bigAge' ]
+                        },
+                        address: {
+                          type: 'object',
+                          properties: {
+                            bigName: { type: 'string' },
+                            bigAge: { type: 'number' }
+                          },
+                          required: [ 'bigName', 'bigAge' ]
+                        }
+                      },
+                      required: [ 'name', 'age', 'address' ]
+                    },
+                    bigPerson: {
+                      // stays as t.record()
+                      type: 'object',
+                      additionalProperties: { type: 'string' }
+                    },
+                    anotherBigPerson: {
+                      // stays as t.record()
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'object',
+                        properties: {
+                          bigName: { type: 'string' },
+                          bigAge: { type: 'number' }
+                        },
+                        required: [ 'bigName', 'bigAge' ]
+                      }
+                    }
+                  },
+                  required: [ 'person', 'anotherPerson', 'bigPerson', 'anotherBigPerson' ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      ValidKeys: {
+        title: 'ValidKeys',
+        type: 'string',
+        enum: [ 'name', 'age', 'address' ]
+      },
+      PersonObject: {
+        title: 'PersonObject',
+        type: 'object',
+        properties: { bigName: { type: 'string' }, bigAge: { type: 'number' } },
+        required: [ 'bigName', 'bigAge' ]
+      }
+    }
+  }
+});


### PR DESCRIPTION
DX-613

This PR enables downstream users of api-ts to mark fields in their codecs with a `@private` jsdoc tag, which in turn will add the `x-internal: true` field within the respective schema for that field. 