### PR TITLE
feat: support `domain` for `t.record` codec

### DIFF
--- a/packages/openapi-generator/src/ir.ts
+++ b/packages/openapi-generator/src/ir.ts
@@ -38,7 +38,7 @@ export type Object = {
 
 export type RecordObject = {
   type: 'record';
-  domain: Schema;
+  domain?: Schema;
   codomain: Schema;
 };
 

--- a/packages/openapi-generator/src/ir.ts
+++ b/packages/openapi-generator/src/ir.ts
@@ -38,7 +38,7 @@ export type Object = {
 
 export type RecordObject = {
   type: 'record';
-  domain?: Schema;
+  domain: Schema;
   codomain: Schema;
 };
 

--- a/packages/openapi-generator/src/ir.ts
+++ b/packages/openapi-generator/src/ir.ts
@@ -38,6 +38,7 @@ export type Object = {
 
 export type RecordObject = {
   type: 'record';
+  domain?: Schema;
   codomain: Schema;
 };
 

--- a/packages/openapi-generator/src/knownImports.ts
+++ b/packages/openapi-generator/src/knownImports.ts
@@ -94,11 +94,11 @@ export const KNOWN_IMPORTS: KnownImports = {
         required: Object.keys(props),
       });
     },
-    record: (_, _domain, codomain) => {
+    record: (_, domain, codomain) => {
       if (!codomain) {
         return E.left('Codomain of record must be specified');
       } else {
-        return E.right({ type: 'record', codomain });
+        return E.right({ type: 'record', domain, codomain });
       }
     },
     union: (_, schema) => {

--- a/packages/openapi-generator/src/openapi.ts
+++ b/packages/openapi-generator/src/openapi.ts
@@ -148,9 +148,24 @@ function schemaToOpenAPI(
         }
       case 'record':
         const additionalProperties = schemaToOpenAPI(schema.codomain);
-        if (additionalProperties === undefined) {
-          return undefined;
+        if (additionalProperties === undefined) return undefined;
+
+        if (schema.domain !== undefined) {
+          const keys = schemaToOpenAPI(schema.domain) as OpenAPIV3.SchemaObject;
+          if (keys.type === 'string' && keys.enum !== undefined) {
+            const properties = keys.enum.reduce((acc, key) => {
+              return { ...acc, [key]: additionalProperties };
+            }, {});
+
+            return {
+              type: 'object',
+              properties,
+              ...defaultOpenAPIObject,
+              required: keys.enum,
+            };
+          }
         }
+
         return {
           type: 'object',
           additionalProperties,

--- a/packages/openapi-generator/src/optimize.ts
+++ b/packages/openapi-generator/src/optimize.ts
@@ -226,14 +226,12 @@ export function optimize(schema: Schema): Schema {
     }
     return { type: 'array', items: optimized };
   } else if (schema.type === 'record') {
-    if (schema.comment) {
-      return {
-        type: 'record',
-        codomain: optimize(schema.codomain),
-        comment: schema.comment,
-      };
-    }
-    return { type: 'record', codomain: optimize(schema.codomain) };
+    return {
+      type: 'record',
+      ...(schema.domain ? { domain: optimize(schema.domain) } : {}),
+      codomain: optimize(schema.codomain),
+      ...(schema.comment ? { comment: schema.comment } : {}),
+    };
   } else if (schema.type === 'tuple') {
     const schemas = schema.schemas.map(optimize);
     return { type: 'tuple', schemas };

--- a/packages/openapi-generator/test/codec.test.ts
+++ b/packages/openapi-generator/test/codec.test.ts
@@ -285,7 +285,7 @@ export const FOO = t.record(t.string, t.number);
 `;
 
 testCase('record type is parsed', RECORD, {
-  FOO: { type: 'record', codomain: { type: 'number', primitive: true } },
+  FOO: { type: 'record', domain: {type: 'string', primitive: true}, codomain: { type: 'number', primitive: true } },
 });
 
 const ENUM = `

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -3939,3 +3939,141 @@ testCase("route with nested array examples", ROUTE_WITH_NESTED_ARRAY_EXAMPLES, {
     }
   }
 });
+
+const ROUTE_WITH_RECORD_TYPES = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+const ValidKeys = t.keyof({ name: "name", age: "age", address: "address" });
+const PersonObject = t.type({ bigName: t.string, bigAge: t.number });
+
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      name: t.string,
+    },
+  }),
+  response: {
+    200: {
+      person: t.record(ValidKeys, t.string),
+      anotherPerson: t.record(ValidKeys, PersonObject),
+      bigPerson: t.record(t.string, t.string),
+      anotherBigPerson: t.record(t.string, PersonObject),
+    }
+  },
+});
+`;
+
+testCase("route with record types", ROUTE_WITH_RECORD_TYPES, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0'
+  },
+  paths: {
+    '/foo': {
+      get: {
+        parameters: [
+          {
+            name: 'name',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string'
+            }
+          }
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    // becomes t.type()
+                    person: {
+                      type: 'object',
+                      properties: {
+                        name: { type: 'string' },
+                        age: { type: 'string' },
+                        address: { type: 'string' }
+                      },
+                      required: [ 'name', 'age', 'address' ]
+                    },
+                    // becomes t.type()
+                    anotherPerson: {
+                      type: 'object',
+                      properties: {
+                        name: {
+                          type: 'object',
+                          properties: {
+                            bigName: { type: 'string' },
+                            bigAge: { type: 'number' }
+                          },
+                          required: [ 'bigName', 'bigAge' ]
+                        },
+                        age: {
+                          type: 'object',
+                          properties: {
+                            bigName: { type: 'string' },
+                            bigAge: { type: 'number' }
+                          },
+                          required: [ 'bigName', 'bigAge' ]
+                        },
+                        address: {
+                          type: 'object',
+                          properties: {
+                            bigName: { type: 'string' },
+                            bigAge: { type: 'number' }
+                          },
+                          required: [ 'bigName', 'bigAge' ]
+                        }
+                      },
+                      required: [ 'name', 'age', 'address' ]
+                    },
+                    bigPerson: {
+                      // stays as t.record()
+                      type: 'object',
+                      additionalProperties: { type: 'string' }
+                    },
+                    anotherBigPerson: {
+                      // stays as t.record()
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'object',
+                        properties: {
+                          bigName: { type: 'string' },
+                          bigAge: { type: 'number' }
+                        },
+                        required: [ 'bigName', 'bigAge' ]
+                      }
+                    }
+                  },
+                  required: [ 'person', 'anotherPerson', 'bigPerson', 'anotherBigPerson' ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      ValidKeys: {
+        title: 'ValidKeys',
+        type: 'string',
+        enum: [ 'name', 'age', 'address' ]
+      },
+      PersonObject: {
+        title: 'PersonObject',
+        type: 'object',
+        properties: { bigName: { type: 'string' }, bigAge: { type: 'number' } },
+        required: [ 'bigName', 'bigAge' ]
+      }
+    }
+  }
+});


### PR DESCRIPTION
### Problem:

Currently, `openapi-generator` only supports `t.record` with unrestricted domains. However, there can be codecs that use an `enumerable` (usually signified as a `t.keyof`) to specify that only certain keys are allowed and that all of these keys are required in the `t.record`.

Our `dev-portal` doesn't fully support rendering `t.record` that conforms to the [OpenAPI specification](https://swagger.io/docs/specification/data-models/dictionaries/), as the rendering code we ~copied~ adopted from [@stoplight/json-schema-viewer](https://github.com/stoplightio/json-schema-viewer) is outdated and a few versions behind the current release.

### Solution:

Although a `dev-portal` fix to render `t.record` better is in progress (though it won't be fully complete in its first iteration), we decided to circumvent the inadequate rendering by converting a `t.record` to a `t.type`. Both codecs expect all keys to exist in the object and all values of the keys to conform to the specified codec. With this PR, something like:
```typescript
export const SomeCodec = t.record(t.keyof({ foo: "foo", bar: "bar" }), t.type({ baz: t.string }))
```
will have its keys "expanded" and inlined by `openapi-generator` when generated, and will be equivalent to:
```typescript
export const SomeCodec = t.type({
  foo: t.type({ baz: t.string }),
  bar: t.type({ baz: t.string }),
})
```
>[!IMPORTANT]
>Any `t.record` codecs with an unrestricted domain (e.g., `t.string`) will remain unchanged.

Ticket: DX-637