### PR TITLE
feat: consolidate unknown unions with well defined codecs

### DIFF
--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -4623,7 +4623,7 @@ export const route = h.httpRoute({
     }
   },
 });
-`
+`;
 
 testCase("route with unknown unions", ROUTE_WITH_UNKNOWN_UNIONS, {
   info: {
@@ -4699,5 +4699,4 @@ testCase("route with unknown unions", ROUTE_WITH_UNKNOWN_UNIONS, {
       }
     }
   },
- 
-})
+});

--- a/packages/openapi-generator/test/openapi.test.ts
+++ b/packages/openapi-generator/test/openapi.test.ts
@@ -4602,3 +4602,102 @@ testCase("route with record types", ROUTE_WITH_RECORD_TYPES, {
   }
 });
 
+const ROUTE_WITH_UNKNOWN_UNIONS = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+const UnknownUnion = t.union([t.string, t.number, t.boolean, t.unknown]);
+const SingleUnknownUnion = t.union([t.unknown, t.string]);
+
+const NestedUnknownUnion = t.union([t.union([t.string, t.unknown]), t.union([t.boolean, t.unknown])]);
+
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({}),
+  response: {
+    200: {
+      single: SingleUnknownUnion,
+      unknown: UnknownUnion,
+      nested: NestedUnknownUnion,
+    }
+  },
+});
+`
+
+testCase("route with unknown unions", ROUTE_WITH_UNKNOWN_UNIONS, {
+  info: {
+    title: 'Test',
+    version: '1.0.0'
+  },
+  openapi: '3.0.3',
+  paths: {
+    '/foo': {
+      get: {
+        parameters: [],
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  properties: {
+                    nested: {
+                      '$ref': '#/components/schemas/NestedUnknownUnion'
+                    },
+                    single: {
+                      '$ref': '#/components/schemas/SingleUnknownUnion'
+                    },
+                    unknown: {
+                      '$ref': '#/components/schemas/UnknownUnion'
+                    }
+                  },
+                  required: [
+                    'single',
+                    'unknown',
+                    'nested'
+                  ],
+                  type: 'object'
+                }
+              }
+            },
+            description: 'OK'
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      NestedUnknownUnion: {
+        oneOf: [
+          {
+            type: 'string'
+          },
+          {
+            type: 'boolean'
+          }
+        ],
+        title: 'NestedUnknownUnion'
+      },
+      SingleUnknownUnion: {
+        title: 'SingleUnknownUnion',
+        type: 'string'
+      },
+      UnknownUnion: {
+        oneOf: [
+          {
+            type: 'string'
+          },
+          {
+            type: 'number'
+          },
+          {
+            type: 'boolean'
+          }
+        ],
+        title: 'UnknownUnion'
+      }
+    }
+  },
+ 
+})


### PR DESCRIPTION
DX-644

This is a change to consolidate unknown unions in the openapi generator. For example, if we have something like this:

`t.union([WellDefinedCodec, t.unknown])` then it doesn’t make sense to pass through the t.unknown codec into the API docs, as we have our ‘best guess’ shape of the data present as well. This is a ticket to filter out these unknowns as they aren’t required, and add bloat to the generator’s output. 