### PR TITLE
feat: add optional name param to httpRequest

### DIFF
--- a/packages/io-ts-http/src/combinators.ts
+++ b/packages/io-ts-http/src/combinators.ts
@@ -1,4 +1,4 @@
-import { pipe } from 'fp-ts/pipeable';
+import { pipe } from 'fp-ts/function';
 import * as E from 'fp-ts/Either';
 import * as R from 'fp-ts/Record';
 import * as t from 'io-ts';
@@ -101,12 +101,12 @@ export const flattened = <Props extends NestedProps>(
     const innerProps = props[key];
     flatProps = { ...flatProps, ...innerProps };
   }
-  const flatCodec = t.exact(optionalized(flatProps));
+  const flatCodec = t.exact(optionalized(flatProps), name);
 
   const nestedProps = R.map((innerProps: t.Props) => t.exact(optionalized(innerProps)))(
     props,
   );
-  const nestedCodec = t.strict(nestedProps);
+  const nestedCodec = t.strict(nestedProps, name);
 
   return new t.Type(
     name,

--- a/packages/io-ts-http/src/httpRequest.ts
+++ b/packages/io-ts-http/src/httpRequest.ts
@@ -52,8 +52,8 @@ type EmitPropsErrors<P extends HttpRequestCombinatorProps> = {
 
 export function httpRequest<
   Props extends HttpRequestCombinatorProps & EmitPropsErrors<Props>,
->(props: Props) {
-  return flattened('httpRequest', {
+>(props: Props, name?: string) {
+  return flattened(name ?? 'httpRequest', {
     query: {},
     params: {},
     ...(props as Omit<Props, 'query' | 'params'>),

--- a/packages/io-ts-http/test/utils.ts
+++ b/packages/io-ts-http/test/utils.ts
@@ -7,6 +7,11 @@ export const assertRight = E.getOrElseW(() => {
   throw new Error('Failed to decode object');
 });
 
+export const assertLeft = <T>(e: E.Either<t.Errors, T>) => {
+  assert(E.isLeft(e), 'Expected a failure, got a success');
+  return e.left;
+};
+
 export const assertEncodes = (codec: t.Mixed, test: unknown, expected = test) => {
   const encoded = codec.encode(test);
   assert.deepEqual(encoded, expected);


### PR DESCRIPTION
DX-634

This ticket adds an optional name parameter to the httpRequest function. Now, if a decode fails (and the httpRequest has a name), the name can be used for logging / debugging purposes to improve inspection, rather than only seeing the expected schema and trying to figure out the request from there.