### PR TITLE
fix: revert pipe import

### DIFF
--- a/packages/io-ts-http/src/combinators.ts
+++ b/packages/io-ts-http/src/combinators.ts
@@ -1,4 +1,4 @@
-import { pipe } from 'fp-ts/function';
+import { pipe } from 'fp-ts/pipeable';
 import * as E from 'fp-ts/Either';
 import * as R from 'fp-ts/Record';
 import * as t from 'io-ts';


### PR DESCRIPTION
This ensures compatibility all the way back to fp-ts v2.0.0