### PR TITLE
refactor: introduce standardized error messages and stacktraces

### DIFF
--- a/packages/openapi-generator/src/apiSpec.ts
+++ b/packages/openapi-generator/src/apiSpec.ts
@@ -8,6 +8,7 @@ import { resolveLiteralOrIdentifier } from './resolveInit';
 import { parseRoute, type Route } from './route';
 import { SourceFile } from './sourceFile';
 import { OpenAPIV3 } from 'openapi-types';
+import { errorLeft } from './error';
 
 export function parseApiSpec(
   project: Project,
@@ -15,7 +16,7 @@ export function parseApiSpec(
   expr: swc.Expression,
 ): E.Either<string, Route[]> {
   if (expr.type !== 'ObjectExpression') {
-    return E.left(`unimplemented route expression type ${expr.type}`);
+    return errorLeft(`unimplemented route expression type ${expr.type}`);
   }
 
   const result: Route[] = [];
@@ -34,7 +35,7 @@ export function parseApiSpec(
       if (spreadExpr.type === 'CallExpression') {
         const arg = spreadExpr.arguments[0];
         if (arg === undefined) {
-          return E.left(`unimplemented spread argument type ${arg}`);
+          return errorLeft(`unimplemented spread argument type ${arg}`);
         }
         spreadExpr = arg.expression;
       }
@@ -47,7 +48,7 @@ export function parseApiSpec(
     }
 
     if (apiAction.type !== 'KeyValueProperty') {
-      return E.left(`unimplemented route property type ${apiAction.type}`);
+      return errorLeft(`unimplemented route property type ${apiAction.type}`);
     }
     const routes = apiAction.value;
     const routesInitE = resolveLiteralOrIdentifier(project, sourceFile, routes);
@@ -56,11 +57,11 @@ export function parseApiSpec(
     }
     const [routesSource, routesInit] = routesInitE.right;
     if (routesInit.type !== 'ObjectExpression') {
-      return E.left(`unimplemented routes type ${routes.type}`);
+      return errorLeft(`unimplemented routes type ${routes.type}`);
     }
     for (const route of Object.values(routesInit.properties)) {
       if (route.type !== 'KeyValueProperty') {
-        return E.left(`unimplemented route type ${route.type}`);
+        return errorLeft(`unimplemented route type ${route.type}`);
       }
       const routeExpr = route.value;
       const routeInitE = resolveLiteralOrIdentifier(project, routesSource, routeExpr);

--- a/packages/openapi-generator/src/cli.ts
+++ b/packages/openapi-generator/src/cli.ts
@@ -87,7 +87,7 @@ const app = command({
       const codecFilePath = p.resolve(codecFile);
       const codecModule = await import(codecFilePath);
       if (codecModule.default === undefined) {
-        console.error(`Could not find default export in ${codecFilePath}`);
+        console.error(`[ERROR] Could not find default export in ${codecFilePath}`);
         process.exit(1);
       }
       const customCodecs = codecModule.default(E);
@@ -96,13 +96,13 @@ const app = command({
 
     const project = await new Project({}, knownImports).parseEntryPoint(filePath);
     if (E.isLeft(project)) {
-      console.error(project.left);
+      console.error(`[ERROR] ${project.left}`);
       process.exit(1);
     }
 
     const entryPoint = project.right.get(filePath);
     if (entryPoint === undefined) {
-      console.error(`Could not find entry point ${filePath}`);
+      console.error(`[ERROR] Could not find entry point ${filePath}`);
       process.exit(1);
     }
 
@@ -120,13 +120,13 @@ const app = command({
         symbol.init.callee.type === 'Import'
       ) {
         console.error(
-          `Skipping ${symbol.name} because it is a ${symbol.init.callee.type}`,
+          `[WARN] Skipping ${symbol.name} because it is a ${symbol.init.callee.type}`,
         );
         continue;
       } else if (!isApiSpec(entryPoint, symbol.init.callee)) {
         continue;
       }
-      console.error(`Found API spec in ${symbol.name}`);
+      console.error(`[INFO] Found API spec in ${symbol.name}`);
 
       const result = parseApiSpec(
         project.right,
@@ -134,7 +134,7 @@ const app = command({
         symbol.init.arguments[0]!.expression,
       );
       if (E.isLeft(result)) {
-        console.error(`Error parsing ${symbol.name}: ${result.left}`);
+        console.error(`[ERROR] Error when parsing ${symbol.name}: ${result.left}`);
         process.exit(1);
       }
 
@@ -145,7 +145,7 @@ const app = command({
       apiSpec.push(...result.right);
     }
     if (apiSpec.length === 0) {
-      console.error(`Could not find API spec in ${filePath}`);
+      console.error(`[ERROR] Could not find API spec in ${filePath}`);
       process.exit(1);
     }
 
@@ -166,14 +166,14 @@ const app = command({
         }
         const sourceFile = project.right.get(ref.location);
         if (sourceFile === undefined) {
-          console.error(`Could not find '${ref.name}' from '${ref.location}'`);
+          console.error(`[ERROR] Could not find '${ref.name}' from '${ref.location}'`);
           process.exit(1);
         }
 
         const initE = findSymbolInitializer(project.right, sourceFile, ref.name);
         if (E.isLeft(initE)) {
           console.error(
-            `Could not find symbol '${ref.name}' in '${ref.location}': ${initE.left}`,
+            `[ERROR] Could not find symbol '${ref.name}' in '${ref.location}': ${initE.left}`,
           );
           process.exit(1);
         }
@@ -182,7 +182,7 @@ const app = command({
         const codecE = parseCodecInitializer(project.right, newSourceFile, init);
         if (E.isLeft(codecE)) {
           console.error(
-            `Could not parse codec '${ref.name}' in '${ref.location}': ${codecE.left}`,
+            `[ERROR] Could not parse codec '${ref.name}' in '${ref.location}': ${codecE.left}`,
           );
           process.exit(1);
         }

--- a/packages/openapi-generator/src/error.ts
+++ b/packages/openapi-generator/src/error.ts
@@ -11,3 +11,12 @@ export function errorLeft(message: string): E.Either<string, never> {
 
   return E.left(messageWithStacktrace);
 }
+
+/**
+ * Testing utility to strip the stacktrace from errors.
+ * @param errors the list of errors to strip
+ * @returns the errors without the stacktrace
+ */
+export function stripStacktraceOfErrors(errors: string[]) {
+  return errors.map((e) => e!.split('\n')[0]);
+}

--- a/packages/openapi-generator/src/error.ts
+++ b/packages/openapi-generator/src/error.ts
@@ -20,3 +20,16 @@ export function errorLeft(message: string): E.Either<string, never> {
 export function stripStacktraceOfErrors(errors: string[]) {
   return errors.map((e) => e!.split('\n')[0]);
 }
+
+// helper functions for logging
+export function logError(message: string): void {
+  console.error(`[ERROR] ${message}`);
+}
+
+export function logWarn(message: string): void {
+  console.error(`[WARN] ${message}`);
+}
+
+export function logInfo(message: string): void {
+  console.error(`[INFO] ${message}`);
+}

--- a/packages/openapi-generator/src/error.ts
+++ b/packages/openapi-generator/src/error.ts
@@ -1,0 +1,13 @@
+import * as E from 'fp-ts/Either';
+
+/**
+ * A wrapper around `E.left` that includes a stacktrace.
+ * @param message the error message
+ * @returns an `E.left` with the error message and a stacktrace
+ */
+export function errorLeft(message: string): E.Either<string, never> {
+  const stacktrace = new Error().stack!.split('\n').slice(2).join('\n');
+  const messageWithStacktrace = message + '\n' + stacktrace;
+
+  return errorLeft(messageWithStacktrace);
+}

--- a/packages/openapi-generator/src/error.ts
+++ b/packages/openapi-generator/src/error.ts
@@ -9,5 +9,5 @@ export function errorLeft(message: string): E.Either<string, never> {
   const stacktrace = new Error().stack!.split('\n').slice(2).join('\n');
   const messageWithStacktrace = message + '\n' + stacktrace;
 
-  return errorLeft(messageWithStacktrace);
+  return E.left(messageWithStacktrace);
 }

--- a/packages/openapi-generator/src/project.ts
+++ b/packages/openapi-generator/src/project.ts
@@ -6,6 +6,7 @@ import resolve from 'resolve';
 
 import { KNOWN_IMPORTS, type KnownCodec } from './knownImports';
 import { parseSource, type SourceFile } from './sourceFile';
+import { errorLeft } from './error';
 
 const readFile = promisify(fs.readFile);
 
@@ -110,7 +111,7 @@ export class Project {
       }
 
       if (!typesEntryPoint) {
-        return E.left(`Could not find types entry point for ${library}`);
+        return errorLeft(`Could not find types entry point for ${library}`);
       }
 
       const entryPoint = resolve.sync(`${library}/${typesEntryPoint}`, {
@@ -119,7 +120,7 @@ export class Project {
       });
       return E.right(entryPoint);
     } catch (err) {
-      return E.left(`Could not resolve entry point for ${library}: ${err}`);
+      return errorLeft(`Could not resolve entry point for ${library}: ${err}`);
     }
   }
 
@@ -132,10 +133,10 @@ export class Project {
       return E.right(result);
     } catch (e: unknown) {
       if (e instanceof Error && e.message) {
-        return E.left(e.message);
+        return errorLeft(e.message);
       }
 
-      return E.left(JSON.stringify(e));
+      return errorLeft(JSON.stringify(e));
     }
   }
 

--- a/packages/openapi-generator/test/apiSpec.test.ts
+++ b/packages/openapi-generator/test/apiSpec.test.ts
@@ -6,6 +6,7 @@ import type { NestedDirectoryJSON } from 'memfs';
 import { TestProject } from './testProject';
 import { parseApiSpec, parseApiSpecComment, type Route } from '../src';
 import { MOCK_NODE_MODULES_DIR } from './externalModules';
+import { stripStacktraceOfErrors } from '../src/error';
 
 async function testCase(
   description: string,
@@ -51,7 +52,7 @@ async function testCase(
       }
     }
 
-    assert.deepEqual(errors, expectedErrors);
+    assert.deepEqual(stripStacktraceOfErrors(errors), expectedErrors);
     assert.deepEqual(actual, expected);
   });
 }

--- a/packages/openapi-generator/test/externalModule.test.ts
+++ b/packages/openapi-generator/test/externalModule.test.ts
@@ -5,6 +5,7 @@ import * as p from 'path';
 
 import { parsePlainInitializer, Project, type Schema } from '../src';
 import { KNOWN_IMPORTS } from '../src/knownImports';
+import { stripStacktraceOfErrors } from '../src/error';
 
 /** External library parsing test case
  *
@@ -49,7 +50,7 @@ async function testCase(
       }
 
       assert.deepEqual(actual, expected[path]);
-      assert.deepEqual(errors, expectedErrors[path] ?? []);
+      assert.deepEqual(stripStacktraceOfErrors(errors), expectedErrors[path] ?? []);
     }
 
     // If we are expecting errors in a file that wasn't parsed, raise that here

--- a/packages/openapi-generator/test/resolve.test.ts
+++ b/packages/openapi-generator/test/resolve.test.ts
@@ -6,6 +6,7 @@ import test from 'node:test';
 import { TestProject } from './testProject';
 import { parseCodecInitializer, Project, type Schema } from '../src';
 import { MOCK_NODE_MODULES_DIR } from './externalModules';
+import { stripStacktraceOfErrors } from '../src/error';
 
 async function testCase(
   description: string,
@@ -43,7 +44,7 @@ async function testCase(
       }
     }
 
-    assert.deepEqual(errors, expectedErrors);
+    assert.deepEqual(stripStacktraceOfErrors(errors), expectedErrors);
     assert.deepEqual(actual, expected);
   });
 }


### PR DESCRIPTION
This update adds `[INFO]`, `[WARN]`, and `[ERROR]` prefixes to error messages to make them easier to read and understand during debugging. It also includes stack traces for `E.left` returns outside of `cli.ts` to help with troubleshooting.

---
How logging looks:
<img width="518" alt="image" src="https://github.com/user-attachments/assets/0db4d21f-3dff-43aa-9810-93dc3502dc41">


How errors look:
<img width="888" alt="image" src="https://github.com/user-attachments/assets/88d3ebff-ece0-468e-ac08-06108f838a99">

Ticket: DX-660
