### PR TITLE
feat: support custom codec files in host repositories

### DIFF
--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -5,7 +5,7 @@ API specification into an OpenAPI specification.
 
 ## Install
 
-```
+```shell
 npm install --save-dev @api-ts/openapi-generator
 ```
 
@@ -15,7 +15,7 @@ The **openapi-generator** assumes the io-ts-http `apiSpec` is exported in the to
 of the Typescript file passed as an input parameter. The OpenAPI specification will be
 written to stdout.
 
-```
+```shell
 ARGUMENTS:
   <file> - API route definition file
 
@@ -35,32 +35,122 @@ For example:
 npx openapi-generator src/index.ts
 ```
 
-## Custom codec file
+## Preparing a types package for reusable codecs
 
-`openapi-generator` only reads files in the specified package, and stops at the module
-boundary. This allows it to work even without `node_modules` installed. It has built-in
-support for `io-ts`, `io-ts-types`, and `@api-ts/io-ts-http` imports. If your package
-imports codecs from another external library, then you will have to define them in a
-custom configuration file so that `openapi-generator` will understand them. To do so,
-create a JS file with the following format:
+In order to use types from external `io-ts` types packages, you must ensure two things
+are done.
 
-```typescript
-module.exports = (E) => {
-  return {
-    'io-ts-bigint': {
-      BigIntFromString: () => E.right({ type: 'string' }),
-      NonZeroBigInt: () => E.right({ type: 'number' }),
-      NonZeroBigIntFromString: () => E.right({ type: 'string' }),
-      NegativeBigIntFromString: () => E.right({ type: 'string' }),
-      NonNegativeBigIntFromString: () => E.right({ type: 'string' }),
-      PositiveBigIntFromString: () => E.right({ type: 'string' }),
-    },
-    // ... and so on for other packages
-  };
-};
-```
+1. The package source code must be included in the bundle, as the generator is built to
+   generate specs based from the Typescript AST. It is not set up to work with
+   transpiled js code. You can do this by modifying your `package.json` to include your
+   source code in the bundle. For example, if the source code is present in the `src/`
+   directory, then add `src/` to the files array in the `package.json` of your project.
+2. After Step 1, change the `types` field in the `package.json` to be the entry point of
+   the types in the source code. For example, if the entrypoint is `src/index.ts`, then
+   set `"types": "src/index.ts"` in the `package.json`
 
-The input parameter `E` is the namespace import of `fp-ts/Either` (so that trying to
-`require` it from the config file isn't an issue), and the return type is a `Record`
-containing AST definitions for external libraries.
-[Refer to KNOWN_IMPORTS here for info on the structure](./src/knownImports.ts)
+## Defining Custom Codecs
+
+When working with `openapi-generator`, you may encounter challenges with handling custom
+codecs that require JavaScript interpretation or aren't natively supported by the
+generator. These issues typically arise with codecs such as `new t.Type(...)` and other
+primitives that aren't directly supported. However, there are two solutions to address
+these challenges effectively. Click [here](#list-of-supported-io-ts-primitives) for the
+list of supported primitives.
+
+### Solution 1: Using a Custom Codec Configuration File
+
+`openapi-generator` supports importing codecs from other packages in `node_modules`, but
+it struggles with primitives that need JavaScript interpretation, such as
+`new t.Type(...)`. To work around this, you can define schemas for these codecs in a
+configuration file within your downstream types package (where you generate the API
+docs). This allows the generator to understand and use these schemas where necessary.
+Follow these steps to create and use a custom codec configuration file:
+
+1. Create a JavaScript file with the following format:
+
+   ```javascript
+   module.exports = (E) => {
+     return {
+       'io-ts-bigint': {
+         BigIntFromString: () => E.right({ type: 'string' }),
+         NonZeroBigInt: () => E.right({ type: 'number' }),
+         NonZeroBigIntFromString: () => E.right({ type: 'string' }),
+         NegativeBigIntFromString: () => E.right({ type: 'string' }),
+         NonNegativeBigIntFromString: () => E.right({ type: 'string' }),
+         PositiveBigIntFromString: () => E.right({ type: 'string' }),
+       },
+       // ... and so on for other packages
+     };
+   };
+   ```
+
+2. The input parameter `E` is the namespace import of `fp-ts/Either`, which avoids
+   issues with `require`. The return type should be a `Record` containing AST
+   definitions for external libraries. For more information on the structure, refer to
+   [KNOWN_IMPORTS](./src/knownImports.ts).
+
+### Solution 2: Defining Custom Codec Schemas in the Types Package (recommended)
+
+`openapi-generator` now offers the ability to define the schema of custom codecs
+directly within the types package that defines them, rather than the downstream package
+that uses them. This approach is particularly useful for codecs that are used in many
+different types packages. Here’s how you can define schemas for your custom codecs in
+the upstream repository:
+
+1. Create a file named `openapi-gen.config.js` in the root of your repository.
+
+2. Add the following line to the `package.json` of the types package:
+
+   ```json
+   "customCodecFile": "openapi-gen.config.js"
+   ```
+
+3. In the `openapi-gen.config.js` file, define your custom codecs:
+
+   ```javascript
+   module.exports = (E) => {
+     return {
+       SampleCodecDefinition: () =>
+         E.right({
+           type: 'string',
+           default: 'defaultString',
+           minLength: 1,
+         }),
+       // ... rest of your custom codec definitions
+     };
+   };
+   ```
+
+By following these steps, the schemas for your custom codecs will be included in the
+generated API docs for any endpoints that use the respective codecs. The input parameter
+`E` is the namespace import of `fp-ts/Either`, and the return type should be a `Record`
+containing AST definitions for external libraries. For more details, see
+[KNOWN_IMPORTS](./src/knownImports.ts).
+
+## List of supported io-ts primitives
+
+- string
+- number
+- bigint
+- boolean
+- null
+- nullType
+- undefined
+- unknown
+- any
+- array
+- readonlyArray
+- object
+- type
+- partial
+- exact
+- strict
+- record
+- union
+- intersection
+- literal
+- keyof
+- brand
+- UnknownRecord
+- void

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -102,7 +102,7 @@ containing AST definitions for external libraries. For more details, see
 ### Solution 2: Using a Custom Codec Configuration File
 
 `openapi-generator` supports importing codecs from other packages in `node_modules`, but
-it struggles with `io-ts`primitives that need JavaScript interpretation, such as
+it struggles with `io-ts` primitives that need JavaScript interpretation, such as
 `new t.Type(...)`. To work around this, you can define schemas for these codecs in a
 configuration file within your downstream types package (where you generate the API
 docs). This allows the generator to understand and use these schemas where necessary.

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -58,39 +58,7 @@ primitives that aren't directly supported. However, there are two solutions to a
 these challenges effectively. Click [here](#list-of-supported-io-ts-primitives) for the
 list of supported primitives.
 
-### Solution 1: Using a Custom Codec Configuration File
-
-`openapi-generator` supports importing codecs from other packages in `node_modules`, but
-it struggles with primitives that need JavaScript interpretation, such as
-`new t.Type(...)`. To work around this, you can define schemas for these codecs in a
-configuration file within your downstream types package (where you generate the API
-docs). This allows the generator to understand and use these schemas where necessary.
-Follow these steps to create and use a custom codec configuration file:
-
-1. Create a JavaScript file with the following format:
-
-   ```javascript
-   module.exports = (E) => {
-     return {
-       'io-ts-bigint': {
-         BigIntFromString: () => E.right({ type: 'string' }),
-         NonZeroBigInt: () => E.right({ type: 'number' }),
-         NonZeroBigIntFromString: () => E.right({ type: 'string' }),
-         NegativeBigIntFromString: () => E.right({ type: 'string' }),
-         NonNegativeBigIntFromString: () => E.right({ type: 'string' }),
-         PositiveBigIntFromString: () => E.right({ type: 'string' }),
-       },
-       // ... and so on for other packages
-     };
-   };
-   ```
-
-2. The input parameter `E` is the namespace import of `fp-ts/Either`, which avoids
-   issues with `require`. The return type should be a `Record` containing AST
-   definitions for external libraries. For more information on the structure, refer to
-   [KNOWN_IMPORTS](./src/knownImports.ts).
-
-### Solution 2: Defining Custom Codec Schemas in the Types Package (recommended)
+### Solution 1: Defining Custom Codec Schemas in the Types Package (recommended)
 
 `openapi-generator` now offers the ability to define the schema of custom codecs
 directly within the types package that defines them, rather than the downstream package
@@ -130,6 +98,38 @@ generated API docs for any endpoints that use the respective codecs. The input p
 `E` is the namespace import of `fp-ts/Either`, and the return type should be a `Record`
 containing AST definitions for external libraries. For more details, see
 [KNOWN_IMPORTS](./src/knownImports.ts).
+
+### Solution 2: Using a Custom Codec Configuration File
+
+`openapi-generator` supports importing codecs from other packages in `node_modules`, but
+it struggles with `io-ts` primitives that need JavaScript interpretation, such as
+`new t.Type(...)`. To work around this, you can define schemas for these codecs in a
+configuration file within your downstream types package (where you generate the API
+docs). This allows the generator to understand and use these schemas where necessary.
+Follow these steps to create and use a custom codec configuration file:
+
+1. Create a JavaScript file with the following format:
+
+   ```javascript
+   module.exports = (E) => {
+     return {
+       'io-ts-bigint': {
+         BigIntFromString: () => E.right({ type: 'string' }),
+         NonZeroBigInt: () => E.right({ type: 'number' }),
+         NonZeroBigIntFromString: () => E.right({ type: 'string' }),
+         NegativeBigIntFromString: () => E.right({ type: 'string' }),
+         NonNegativeBigIntFromString: () => E.right({ type: 'string' }),
+         PositiveBigIntFromString: () => E.right({ type: 'string' }),
+       },
+       // ... and so on for other packages
+     };
+   };
+   ```
+
+2. The input parameter `E` is the namespace import of `fp-ts/Either`, which avoids
+   issues with `require`. The return type should be a `Record` containing AST
+   definitions for external libraries. For more information on the structure, refer to
+   [KNOWN_IMPORTS](./src/knownImports.ts).
 
 ## List of supported io-ts primitives
 

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -102,7 +102,7 @@ containing AST definitions for external libraries. For more details, see
 ### Solution 2: Using a Custom Codec Configuration File
 
 `openapi-generator` supports importing codecs from other packages in `node_modules`, but
-it struggles with `io-ts` primitives that need JavaScript interpretation, such as
+it struggles with `io-ts`primitives that need JavaScript interpretation, such as
 `new t.Type(...)`. To work around this, you can define schemas for these codecs in a
 configuration file within your downstream types package (where you generate the API
 docs). This allows the generator to understand and use these schemas where necessary.

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -106,6 +106,9 @@ the upstream repository:
    "customCodecFile": "openapi-gen.config.js"
    ```
 
+   You must also add `"openapi-gen.config.js"` to the files field in the package.json,
+   so that it is included in the final bundle.
+
 3. In the `openapi-gen.config.js` file, define your custom codecs:
 
    ```javascript

--- a/packages/openapi-generator/src/cli.ts
+++ b/packages/openapi-generator/src/cli.ts
@@ -171,8 +171,8 @@ const app = command({
 
         const initE = findSymbolInitializer(project.right, sourceFile, ref.name);
         if (E.isLeft(initE)) {
-          console.error(
-            `[ERROR] Could not find symbol '${ref.name}' in '${ref.location}': ${initE.left}`,
+          logError(
+            `Could not find symbol '${ref.name}' in '${ref.location}': ${initE.left}`,
           );
           process.exit(1);
         }
@@ -180,8 +180,8 @@ const app = command({
 
         const codecE = parseCodecInitializer(project.right, newSourceFile, init);
         if (E.isLeft(codecE)) {
-          console.error(
-            `[ERROR] Could not parse codec '${ref.name}' in '${ref.location}': ${codecE.left}`,
+          logError(
+            `Could not parse codec '${ref.name}' in '${ref.location}': ${codecE.left}`,
           );
           process.exit(1);
         }

--- a/packages/openapi-generator/src/cli.ts
+++ b/packages/openapi-generator/src/cli.ts
@@ -125,7 +125,7 @@ const app = command({
       } else if (!isApiSpec(entryPoint, symbol.init.callee)) {
         continue;
       }
-      logInfo(`[INFO] Found API spec in ${symbol.name}`);
+      logInfo(`Found API spec in ${symbol.name}`);
 
       const result = parseApiSpec(
         project.right,

--- a/packages/openapi-generator/src/project.ts
+++ b/packages/openapi-generator/src/project.ts
@@ -183,8 +183,8 @@ export class Project {
 
         const customCodecs = module.default(E);
         this.knownImports[packageName] = {
-          ...this.knownImports[packageName],
           ...customCodecs,
+          ...this.knownImports[packageName],
         };
 
         logInfo(`Loaded custom codecs for ${packageName}`);

--- a/packages/openapi-generator/src/project.ts
+++ b/packages/openapi-generator/src/project.ts
@@ -6,7 +6,7 @@ import resolve from 'resolve';
 
 import { KNOWN_IMPORTS, type KnownCodec } from './knownImports';
 import { parseSource, type SourceFile } from './sourceFile';
-import { errorLeft } from './error';
+import { errorLeft, logError, logInfo } from './error';
 
 const readFile = promisify(fs.readFile);
 
@@ -177,7 +177,7 @@ export class Project {
         );
         const module = await import(customCodecPath);
         if (module.default === undefined) {
-          console.error(`Could not find default export in ${customCodecPath}`);
+          logError(`Could not find default export in ${customCodecPath}`);
           return;
         }
 
@@ -187,7 +187,7 @@ export class Project {
           ...customCodecs,
         };
 
-        console.error(`Loaded custom codecs for ${packageName}`);
+        logInfo(`Loaded custom codecs for ${packageName}`);
       }
     } catch (e) {
       return;

--- a/packages/openapi-generator/src/sourceFile.ts
+++ b/packages/openapi-generator/src/sourceFile.ts
@@ -1,7 +1,7 @@
 import * as swc from '@swc/core';
 
 import { parseTopLevelSymbols, type SymbolTable } from './symbol';
-import { logError } from './error';
+import { logWarn } from './error';
 
 export type SourceFile = {
   path: string;
@@ -42,7 +42,7 @@ export async function parseSource(
       span: module.span,
     };
   } catch (e: unknown) {
-    logError(`Error parsing source file: ${path}, ${e}`);
+    logWarn(`Error parsing source file: ${path}, ${e}`);
     return undefined;
   }
 }

--- a/packages/openapi-generator/src/sourceFile.ts
+++ b/packages/openapi-generator/src/sourceFile.ts
@@ -1,6 +1,7 @@
 import * as swc from '@swc/core';
 
 import { parseTopLevelSymbols, type SymbolTable } from './symbol';
+import { logError } from './error';
 
 export type SourceFile = {
   path: string;
@@ -41,7 +42,7 @@ export async function parseSource(
       span: module.span,
     };
   } catch (e: unknown) {
-    console.error(`Error parsing source file: ${path}`, e);
+    logError(`Error parsing source file: ${path}, ${e}`);
     return undefined;
   }
 }

--- a/packages/openapi-generator/test/externalModuleApiSpec.test.ts
+++ b/packages/openapi-generator/test/externalModuleApiSpec.test.ts
@@ -126,8 +126,8 @@ async function testCase(
       components,
     );
 
-    assert.deepEqual(errors, expectedErrors);
-    assert.deepEqual(openapi, expected);
+    assert.deepStrictEqual(errors, expectedErrors); 
+    assert.deepStrictEqual(openapi, expected);
   });
 }
 
@@ -319,3 +319,48 @@ testCase(
   },
   []
 )
+
+testCase("simple api spec with custom codec", "test/sample-types/apiSpecWithCustomCodec.ts", {
+  openapi: "3.0.3",
+  info: {
+    title: "simple api spec with custom codec",
+    version: "4.7.4",
+    description: "simple api spec with custom codec"
+  },
+  paths: {
+    "/test": {
+      get: {
+        parameters: [],
+        responses: {
+          200: {
+            description: "OK",
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                  description: 'Sample custom codec',
+                  example: 'sample',
+                  format: 'sample'
+                }
+              }
+            }
+          },
+          201: {
+            description: 'Created',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'number',
+                  description: 'Another sample codec',
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {}
+  }
+}, []);

--- a/packages/openapi-generator/test/sample-types/apiSpecWithCustomCodec.ts
+++ b/packages/openapi-generator/test/sample-types/apiSpecWithCustomCodec.ts
@@ -1,0 +1,16 @@
+import { SampleCustomCodec, AnotherSampleCodec } from '@bitgo/custom-codecs';
+import * as h from '@api-ts/io-ts-http';
+
+export const apiSpec = h.apiSpec({
+    'api.get.test': {
+        get: h.httpRoute({
+            path: '/test',
+            method: 'GET',
+            request: h.httpRequest({}),
+            response: {
+                200: SampleCustomCodec,
+                201: AnotherSampleCodec,
+            },
+        }),
+    },
+})

--- a/packages/openapi-generator/test/sample-types/node_modules/@bitgo/custom-codecs/openapi-gen.config.js
+++ b/packages/openapi-generator/test/sample-types/node_modules/@bitgo/custom-codecs/openapi-gen.config.js
@@ -1,0 +1,14 @@
+module.exports = (E) => {
+    return {
+        SampleCustomCodec: () => E.right({
+            type: 'string',
+            description: 'Sample custom codec',
+            example: 'sample',
+            format: 'sample'
+        }),
+        AnotherSampleCodec: () => E.right({
+            type: 'number',
+            description: 'Another sample codec',
+        })
+    }
+}

--- a/packages/openapi-generator/test/sample-types/node_modules/@bitgo/custom-codecs/package.json
+++ b/packages/openapi-generator/test/sample-types/node_modules/@bitgo/custom-codecs/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "custom-codecs",
+    "version": "0.0.1",
+    "main": "dist/src/index.js",
+    "types": "src/index.ts",
+    "files": [
+      "dist/src/**/*",
+      "src/**/*"
+    ],
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "",
+    "license": "ISC",
+    "description": "",
+    "customCodecFile": "openapi-gen.config.js"
+  }

--- a/packages/openapi-generator/test/sample-types/node_modules/@bitgo/custom-codecs/src/index.ts
+++ b/packages/openapi-generator/test/sample-types/node_modules/@bitgo/custom-codecs/src/index.ts
@@ -1,0 +1,12 @@
+import * as t from 'io-ts';
+
+export const SampleCustomCodec: t.Type<undefined, undefined, unknown> = new t.Type(
+    'SampleCustomCodec',
+    (u): u is undefined => u === undefined,
+    (u, c) =>
+      u === null || u === undefined ? t.success(undefined) : t.failure(u, c),
+    () => undefined,
+  );
+export type SampleCustomCodec = t.TypeOf<typeof SampleCustomCodec>;
+
+export const AnotherSampleCodec = t.number;

--- a/packages/openapi-generator/test/sample-types/node_modules/@bitgo/custom-codecs/tsconfig.json
+++ b/packages/openapi-generator/test/sample-types/node_modules/@bitgo/custom-codecs/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "include": ["src/**/*.ts"],
+    "compilerOptions": {
+      "outDir": "dist"
+    },
+    "references": []
+  }


### PR DESCRIPTION
DX-658

This ticket adds support for types packages to define schemas for their own custom codecs (that are defined with `t.Type` or other un-supported primitives). 

To make use of this feature in the types package, first create a file titled `openapi-gen.config.js`. Then, add the following to the package.json in the package `"customCodecFile": "openapi-gen.config.js"`. Then, you can populate the file with your schemas like this:

```javascript
module.exports = E => {
    return { 
         CustomSchema: () => E.right({ type: 'string' })
    }
}
```