### PR TITLE
Revert "feat: add type error if path doesn't start with /"

### DIFF
--- a/packages/io-ts-http/src/httpRoute.ts
+++ b/packages/io-ts-http/src/httpRoute.ts
@@ -13,10 +13,8 @@ export const Method = t.keyof({
 
 export type Method = t.TypeOf<typeof Method>;
 
-export type PathString = `/${string}`;
-
 export type HttpRoute<M extends Method = Method> = {
-  readonly path: PathString;
+  readonly path: string;
   readonly method: Uppercase<M>;
   readonly request: HttpRequestCodec<any>;
   readonly response: HttpResponse;

--- a/packages/superagent-wrapper/src/request.ts
+++ b/packages/superagent-wrapper/src/request.ts
@@ -201,7 +201,7 @@ export const requestForRoute =
     let path = route.path;
     for (const key in reqProps.params) {
       if (reqProps.params.hasOwnProperty(key)) {
-        path = path.replace(`{${key}}`, reqProps.params[key]) as h.PathString;
+        path = path.replace(`{${key}}`, reqProps.params[key]);
       }
     }
 


### PR DESCRIPTION
Causes type errors when multiple copies of `io-ts-http` 3.x are in node_modules, which is unfortunately easy to do.

Fixes:
```
Types of property 'path' are incompatible.
                Type 'string' is not assignable to type '`/${string}`'.
```

This reverts commit a27e388397c48f4e3fdf35971aab595904223766.