### PR TITLE
Support decorators

### DIFF
--- a/packages/openapi-generator/src/sourceFile.ts
+++ b/packages/openapi-generator/src/sourceFile.ts
@@ -27,6 +27,7 @@ export async function parseSource(
       syntax: 'typescript',
       target: 'esnext',
       comments: true,
+      decorators: true,
     });
 
     // Set the start of the module to the end of the last span, so that we don't have any


### PR DESCRIPTION
Makes swc not throw an error when encountering a file with decorators