### PR TITLE
Add support for parsing template strings

### DIFF
--- a/packages/openapi-generator/test/codec.test.ts
+++ b/packages/openapi-generator/test/codec.test.ts
@@ -870,3 +870,42 @@ testCase('computed property is parsed', COMPUTED_PROPERTY, {
     enum: ['foo'],
   }
 });
+
+const TEMPLATE_LITERAL = `
+import * as t from 'io-ts';
+const test = 'foo';
+export const FOO = \`\${test}bar\`;
+`;
+
+testCase('basic template literal is parsed', TEMPLATE_LITERAL, {
+  FOO: {
+    type: 'string',
+    enum: ['foobar'],
+  },
+  test: {
+    type: 'string',
+    enum: ['foo'],
+  },
+});
+
+const MULTI_TEMPLATE_LITERAL = `
+import * as t from 'io-ts';
+const test = 'foo';
+const test2 = 'baz';
+export const FOO = \`aaa\${test}bar\${test2}bat\`;
+`;
+
+testCase('compound template literal is parsed', MULTI_TEMPLATE_LITERAL, {
+  FOO: {
+    type: 'string',
+    enum: ['aaafoobarbazbat'],
+  },
+  test: {
+    type: 'string',
+    enum: ['foo'],
+  },
+  test2: {
+    type: 'string',
+    enum: ['baz'],
+  },
+});


### PR DESCRIPTION
Adds support for parsing basic template strings in `packages/openapi-generator`.

* **Add template string parsing function**
  - Add `parseTemplateLiteral` function to handle template strings in `packages/openapi-generator/src/codec.ts`.
  - Update `parsePlainInitializer` to call `parseTemplateLiteral` when encountering a template literal.

* **Add tests for template string parsing**
  - Add test cases for basic and compound template literals in `packages/openapi-generator/test/codec.test.ts`.

