### PR TITLE
Add instructions for copilot workspace

### DIFF
--- a/.github/copilot-workspace/CONTRIBUTING.md
+++ b/.github/copilot-workspace/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+The packages in this repository are published using semantic-release. Use the
+Conventional Commit standard for all commit messages. Possible scopes include `feat`,
+`fix`, `chore`, `ci`, and `docs`.


### PR DESCRIPTION
Attempts to tell Copilot Workspace to use conventional commits. I'm not sure if this will work, but [custom instructions are documented](https://github.com/githubnext/copilot-workspace-user-manual/blob/main/changes.md)