### PR TITLE
fix: import Node.js path module using node: import syntax

### DIFF
--- a/packages/openapi-generator/src/cli.ts
+++ b/packages/openapi-generator/src/cli.ts
@@ -3,7 +3,7 @@
 import { command, run, option, string, optional, positional } from 'cmd-ts';
 import * as E from 'fp-ts/Either';
 import * as fs from 'fs';
-import * as p from 'path';
+import * as p from 'node:path';
 import type { Expression } from '@swc/core';
 import type { OpenAPIV3 } from 'openapi-types';
 

--- a/packages/openapi-generator/src/packageInfo.ts
+++ b/packages/openapi-generator/src/packageInfo.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs/promises';
-import * as p from 'path';
+import * as p from 'node:path';
 
 export async function getPackageJsonPath(
   entryPoint: string,

--- a/packages/openapi-generator/src/project.ts
+++ b/packages/openapi-generator/src/project.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as p from 'path';
+import * as p from 'node:path';
 import { promisify } from 'util';
 import * as E from 'fp-ts/Either';
 import resolve from 'resolve';

--- a/packages/openapi-generator/src/resolveInit.ts
+++ b/packages/openapi-generator/src/resolveInit.ts
@@ -1,7 +1,7 @@
 import * as swc from '@swc/core';
 import type { Block } from 'comment-parser';
 import * as E from 'fp-ts/Either';
-import { dirname } from 'path';
+import { dirname } from 'node:path';
 
 import type { Project } from './project';
 import type { SourceFile } from './sourceFile';

--- a/packages/openapi-generator/test/externalModule.test.ts
+++ b/packages/openapi-generator/test/externalModule.test.ts
@@ -1,7 +1,7 @@
 import * as E from 'fp-ts/lib/Either';
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import * as p from 'path';
+import * as p from 'node:path';
 
 import { parsePlainInitializer, Project, type Schema } from '../src';
 import { KNOWN_IMPORTS } from '../src/knownImports';

--- a/packages/openapi-generator/test/externalModuleApiSpec.test.ts
+++ b/packages/openapi-generator/test/externalModuleApiSpec.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../src';
 import { KNOWN_IMPORTS } from '../src/knownImports';
 import { findSymbolInitializer } from '../src/resolveInit';
-import * as p from 'path';
+import * as p from 'node:path';
 import * as E from 'fp-ts/Either';
 
 /** External library parsing and api spec generation test case

--- a/packages/superagent-wrapper/src/request.ts
+++ b/packages/superagent-wrapper/src/request.ts
@@ -3,7 +3,7 @@ import * as E from 'fp-ts/Either';
 import { pipe } from 'fp-ts/pipeable';
 import * as t from 'io-ts';
 import * as PathReporter from 'io-ts/lib/PathReporter';
-import { posix } from 'path';
+import { posix } from 'node:path';
 import { URL } from 'whatwg-url';
 
 type SuccessfulResponses<Route extends h.HttpRoute> = {


### PR DESCRIPTION
This ensures the Node.js-provided `path` module is always the module
loaded.