### PR TITLE
chore: use `import type` to import only swc types

### DIFF
--- a/packages/openapi-generator/src/resolveInit.ts
+++ b/packages/openapi-generator/src/resolveInit.ts
@@ -1,4 +1,4 @@
-import * as swc from '@swc/core';
+import type * as swc from '@swc/core';
 import type { Block } from 'comment-parser';
 import * as E from 'fp-ts/Either';
 import { dirname } from 'path';


### PR DESCRIPTION
to make it clear to humans and the compiler that no values are imported.