### PR TITLE
feat: Add test case for private headers with x-internal tag

### DIFF
--- a/packages/openapi-generator/test/openapi/jsdoc.test.ts
+++ b/packages/openapi-generator/test/openapi/jsdoc.test.ts
@@ -139,6 +139,78 @@ testCase('schema parameter with title tag', TITLE_TAG, {
   },
 });
 
+const ROUTE_WITH_PRIVATE_HEADERS = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+export const route = h.httpRoute({
+  path: '/foo',
+  method: 'GET',
+  request: h.httpRequest({
+    headers: {
+      /**
+       * A private header
+       * @private
+       */
+      'x-private-header': t.string,
+      'public-header': t.string
+    }
+  }),
+  response: {
+    200: t.string
+  },
+});
+`;
+
+testCase("route with private headers", ROUTE_WITH_PRIVATE_HEADERS, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0'
+  },
+  paths: {
+    '/foo': {
+      get: {
+        parameters: [
+          {
+            'x-internal': true,
+            description: 'A private header',
+            in: 'header',
+            name: 'x-private-header',
+            required: true,
+            schema: {
+              type: 'string'
+            }
+          },
+          {
+            in: 'header',
+            name: 'public-header',
+            required: true,
+            schema: {
+              type: 'string'
+            }
+          }
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {}
+  }
+});
+
 
 const ROUTE_WITH_RESPONSE_EXAMPLE_STRING = `
 import * as t from 'io-ts';


### PR DESCRIPTION
This commit adds a new test case to verify that headers with the @private JSDoc tag are correctly marked with x-internal in the OpenAPI specification. The test checks that:

1. A header with @private is marked with x-internal: true
2. The description is preserved
3. Public headers are not marked with x-internal
4. The header is still required and has the correct schema type

The test uses a sample route with both a private and a public header to demonstrate the behavior.

Co-authored-by: aider <aider@bitgo.com>