### PR TITLE
chore(codeowners): add DevEx as code owners of the GitHub pages site

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @BitGo/velocity
+website @BitGo/velocity @BitGo/developer-experience


### PR DESCRIPTION
Closes Ticket: DX-1103

DevEx is currently working to improve the website and associated
documentaiton. Adding them as code owners allows our technical writers
to review changes effectively.