### PR TITLE
fix: openapi spec schmema.type

### DIFF
--- a/packages/openapi-generator/src/ir.ts
+++ b/packages/openapi-generator/src/ir.ts
@@ -81,7 +81,11 @@ export type SchemaMetadata = Omit<
   | 'discriminator'
   | 'xml'
   | 'externalDocs'
->;
+> & {
+  allowReserved?: boolean;
+  style?: 'form' | 'spaceDelimited' | 'pipeDelimited' | 'deepObject';
+  explode?: boolean;
+};
 
 type SchemaTypeInfo = {
   primitive?: boolean;

--- a/packages/openapi-generator/test/openapi/base.test.ts
+++ b/packages/openapi-generator/test/openapi/base.test.ts
@@ -100,6 +100,8 @@ testCase('simple route', SIMPLE, {
             schema: {
               type: 'string',
             },
+            style: 'form',
+            explode: true
           },
         ],
         responses: {
@@ -131,6 +133,8 @@ testCase('simple route', SIMPLE, {
             schema: {
               type: 'string',
             },
+            style: 'form',
+            explode: true
           },
         ],
         responses: {
@@ -161,6 +165,8 @@ testCase('simple route', SIMPLE, {
             schema: {
               type: 'string',
             },
+            style: 'form',
+            explode: true
           },
         ],
         responses: {
@@ -511,6 +517,8 @@ testCase('optional parameter', OPTIONAL_PARAM, {
             schema: {
               type: 'string',
             },
+            style: 'form',
+            explode: true
           },
         ],
         responses: {
@@ -595,7 +603,9 @@ testCase('route with optional array query parameter and documentation', ROUTE_WI
                 pattern: '^[a-z]+$'
               },
               type: 'array'
-            }
+            },
+            style: 'form',
+            explode: true
           }
         ],
         responses: {
@@ -685,7 +695,9 @@ testCase('route with array union of null and undefined', ROUTE_WITH_ARRAY_UNION_
                 pattern: '^[a-z]+$'
               },
               type: 'array'
-            }
+            },
+            style: 'form',
+            explode: true
           }
         ],
         responses: {
@@ -778,6 +790,8 @@ testCase('multiple routes', MULTIPLE_ROUTES, {
             schema: {
               type: 'string',
             },
+            style: 'form',
+            explode: true
           },
         ],
         responses: {
@@ -804,6 +818,8 @@ testCase('multiple routes', MULTIPLE_ROUTES, {
             schema: {
               type: 'string',
             },
+            style: 'form',
+            explode: true
           },
         ],
         responses: {
@@ -830,6 +846,8 @@ testCase('multiple routes', MULTIPLE_ROUTES, {
             schema: {
               type: 'string',
             },
+            style: 'form',
+            explode: true
           },
         ],
         responses: {
@@ -914,6 +932,8 @@ testCase('multiple routes with methods', MULTIPLE_ROUTES_WITH_METHODS, {
             schema: {
               type: 'string',
             },
+            style: 'form',
+            explode: true
           },
         ],
         responses: {
@@ -938,6 +958,8 @@ testCase('multiple routes with methods', MULTIPLE_ROUTES_WITH_METHODS, {
             schema: {
               type: 'string',
             },
+            style: 'form',
+            explode: true
           },
         ],
         responses: {
@@ -962,6 +984,8 @@ testCase('multiple routes with methods', MULTIPLE_ROUTES_WITH_METHODS, {
             schema: {
               type: 'string',
             },
+            style: 'form',
+            explode: true
           },
         ],
         responses: {

--- a/packages/openapi-generator/test/openapi/comments.test.ts
+++ b/packages/openapi-generator/test/openapi/comments.test.ts
@@ -51,6 +51,8 @@ testCase('route with type descriptions', ROUTE_WITH_TYPE_DESCRIPTIONS, {
         tags: ['Test Routes'],
         parameters: [
           {
+            explode: true,
+            style: 'form',
             description: 'bar param',
             in: 'query',
             name: 'bar',
@@ -175,6 +177,8 @@ testCase('route with type descriptions with optional fields', ROUTE_WITH_TYPE_DE
         tags: ['Test Routes'],
         parameters: [
           {
+            explode: true,
+            style: 'form',
             description: 'bar param',
             in: 'query',
             name: 'bar',
@@ -302,6 +306,8 @@ testCase('route with mixed types and descriptions', ROUTE_WITH_MIXED_TYPES_AND_D
           ],
           parameters: [
             {
+              explode: true,
+              style: 'form',
               name: "bar",
               description: "bar param",
               in: "query",
@@ -476,6 +482,8 @@ testCase('route with array types and descriptions', ROUTE_WITH_ARRAY_TYPES_AND_D
         ],
         parameters: [
           {
+            explode: true,
+            style: 'form',
             name: 'bar',
             description: 'bar param',
             in: 'query',
@@ -616,6 +624,8 @@ testCase('route with record types and descriptions', ROUTE_WITH_RECORD_TYPES_AND
         ],
         parameters: [
           {
+            explode: true,
+            style: 'form',
             name: 'bar',
             description: 'bar param',
             in: 'query',
@@ -763,6 +773,8 @@ testCase('route with descriptions, patterns, and examples', ROUTE_WITH_DESCRIPTI
         ],
         parameters: [
           {
+            explode: true,
+            style: 'form',
             name: 'bar',
             description: 'This is a bar param.',
             in: 'query',
@@ -902,6 +914,8 @@ testCase('route with descriptions for references', ROUTE_WITH_DESCRIPTIONS_FOR_R
         ],
         parameters: [
           {
+            explode: false,
+            style: 'form',
             name: 'bar',
             in: 'query',
             required: true,
@@ -1047,6 +1061,8 @@ testCase('route with min and max values for strings and default value', ROUTE_WI
         ],
         parameters: [
           {
+            explode: false,
+            style: 'form',
             name: 'bar',
             in: 'query',
             required: true,

--- a/packages/openapi-generator/test/openapi/jsdoc.test.ts
+++ b/packages/openapi-generator/test/openapi/jsdoc.test.ts
@@ -108,6 +108,8 @@ testCase('schema parameter with title tag', TITLE_TAG, {
       get: {
         parameters: [
           {
+            explode: true,
+            style: 'form',
             in: 'query',
             name: 'bar',
             description: 'bar param',
@@ -1157,6 +1159,8 @@ testCase("route with private properties in request query, params, body, and resp
       get: {
         parameters: [
           {
+            explode: true,
+            style: 'form',
             'x-internal': true,
             description: '',
             in: 'query',

--- a/packages/openapi-generator/test/openapi/knownImports.test.ts
+++ b/packages/openapi-generator/test/openapi/knownImports.test.ts
@@ -32,12 +32,14 @@ testCase('route with schema with default metadata', ROUTE_WITH_SCHEMA_WITH_DEFAU
       get: {
         parameters: [
           {
+            explode: true,
             in: 'query',
             name: 'ipRestrict',
             required: true,
             schema: {
               type: 'boolean',
-            }
+            },
+            style: 'form'
           }
         ],
         responses: {
@@ -107,12 +109,14 @@ testCase('route with schema with default metadata', ROUTE_WITH_OVERIDDEN_METADAT
       get: {
         parameters: [
           {
+            explode: true,
             in: 'query',
             name: 'ipRestrict',
             required: true,
             schema: {
               type: 'boolean',
-            }
+            },
+            style: 'form'
           }
         ],
         responses: {

--- a/packages/openapi-generator/test/openapi/misc.test.ts
+++ b/packages/openapi-generator/test/openapi/misc.test.ts
@@ -197,7 +197,9 @@ testCase("route with record types", ROUTE_WITH_RECORD_TYPES, {
             required: true,
             schema: {
               type: 'string'
-            }
+            },
+            style: 'form',
+            explode: true
           }
         ],
         responses: {

--- a/packages/openapi-generator/test/openapi/queryParams.test.ts
+++ b/packages/openapi-generator/test/openapi/queryParams.test.ts
@@ -1,0 +1,529 @@
+import { testCase } from "./testHarness";
+
+const BASIC_CODEC_TEST = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+import { NumberFromString, IntFromString, BooleanFromString } from 'io-ts-types';
+import { NaturalFromString, NegativeFromString, NegativeIntFromString, NonNegativeFromString, NonPositiveFromString, NonPositiveIntFromString, NonZeroFromString, NonZeroIntFromString, PositiveFromString, ZeroFromString } from 'io-ts-numbers';
+import { BigIntFromString, NegativeBigIntFromString, NonNegativeBigIntFromString, NonPositiveBigIntFromString, NonZeroBigIntFromString, PositiveBigIntFromString, ZeroBigIntFromString } from 'io-ts-bigint';
+import { DateFromISOString, UUID, Json, date } from 'io-ts-types';
+
+export const route = h.httpRoute({
+  path: '/basic-codecs',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      // Base number types
+      numberParam: t.number,
+      
+      // Codec types that should be transformed
+      numberFromString: NumberFromString,
+      intFromString: IntFromString,
+      naturalFromString: NaturalFromString,
+      negativeFromString: NegativeFromString,
+      negativeIntFromString: NegativeIntFromString,
+      nonNegativeFromString: NonNegativeFromString,
+      nonPositiveFromString: NonPositiveFromString,
+      nonPositiveIntFromString: NonPositiveIntFromString,
+      nonZeroFromString: NonZeroFromString,
+      nonZeroIntFromString: NonZeroIntFromString,
+      positiveFromString: PositiveFromString,
+      zeroFromString: ZeroFromString,
+
+      // io-ts-bigint
+      bigIntFromString: BigIntFromString,
+      negativeBigIntFromString: NegativeBigIntFromString,
+      nonNegativeBigIntFromString: NonNegativeBigIntFromString,
+      nonPositiveBigIntFromString: NonPositiveBigIntFromString,
+      nonZeroBigIntFromString: NonZeroBigIntFromString,
+      positiveBigIntFromString: PositiveBigIntFromString,
+      zeroBigIntFromString: ZeroBigIntFromString,
+
+      // io-ts-types
+      dateFromISOString: DateFromISOString,
+      uUID: UUID,
+      json: Json,
+      date: date
+    }
+  }),
+  response: {
+    200: t.type({
+      result: t.string
+    })
+  }
+});
+`;
+
+testCase("query params test", BASIC_CODEC_TEST, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0'
+  },
+  paths: {
+    '/basic-codecs': {
+      get: {
+        parameters: [
+          {
+            name: 'numberParam',
+            in: 'query',
+            required: true,
+            schema: { type: 'number' },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'numberFromString',
+            in: 'query',
+            required: true,
+            schema: { type: 'number' },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'intFromString',
+            in: 'query',
+            required: true,
+            schema: { type: 'integer' },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'naturalFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'number',
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'negativeFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'number',
+              maximum: 0,
+              exclusiveMaximum: true
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'negativeIntFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'integer',
+              maximum: 0,
+              exclusiveMaximum: true
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'nonNegativeFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'number',
+              minimum: 0,
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'nonPositiveFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'number',
+              maximum: 0,
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'nonPositiveIntFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'integer',
+              maximum: 0,
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'nonZeroFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'number',
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'nonZeroIntFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'integer',
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'positiveFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'number',
+              minimum: 0,
+              exclusiveMinimum: true,
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'zeroFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'number',
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'bigIntFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'integer',
+              format: 'int64' 
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'negativeBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'integer',
+              format: 'int64',
+              maximum: -1
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'nonNegativeBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'integer',
+              format: 'int64',
+              maximum: 0
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'nonPositiveBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'integer',
+              format: 'int64',
+              maximum: 0
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'nonZeroBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'integer',
+              format: 'int64',
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'positiveBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'integer',
+              format: 'int64',
+              minimum: 1
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'zeroBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'integer',
+              format: 'int64',
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'dateFromISOString',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'string',
+              format: 'date-time'
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'uUID',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'string',
+              format: 'uuid'
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'json',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'object',
+              additionalProperties: true
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'date',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'string',
+              format: 'date'
+            },
+            style: 'form',
+            explode: true
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    result: { type: 'string' }
+                  },
+                  required: ['result']
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {}
+  }
+});
+
+const ARRAY_CODEC_TEST = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+import { NumberFromString, IntFromString } from 'io-ts-types';
+
+export const route = h.httpRoute({
+  path: '/array-codecs',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      numberArray: t.array(t.number),
+      numberFromStringArray: t.array(NumberFromString),
+      intFromStringArray: t.array(IntFromString)
+    }
+  }),
+  response: {
+    200: t.type({
+      result: t.string
+    })
+  }
+});
+`;
+
+testCase("query params (array codec) transformation test", ARRAY_CODEC_TEST, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0'
+  },
+  paths: {
+    '/array-codecs': {
+      get: {
+        parameters: [
+          {
+            name: 'numberArray',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'array', 
+              items: { type: 'number' } 
+            },
+            style: 'form',
+            explode: false
+          },
+          {
+            name: 'numberFromStringArray',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'array', 
+              items: { type: 'number' } 
+            },
+            style: 'form',
+            explode: false
+          },
+          {
+            name: 'intFromStringArray',
+            in: 'query',
+            required: true,
+            schema: { 
+              type: 'array', 
+              items: { type: 'integer' } 
+            },
+            style: 'form',
+            explode: false
+          }
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    result: { type: 'string' }
+                  },
+                  required: ['result']
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {}
+  }
+});
+
+// Test union types with codecs
+const UNION_CODEC_TEST = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+import { NumberFromString, IntFromString } from 'io-ts-types';
+
+export const route = h.httpRoute({
+  path: '/union-codecs',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      // Union types with codecs
+      mixedUnion: t.union([t.string, NumberFromString, IntFromString]),
+      numberUnion: t.union([t.number, NumberFromString]),
+      intUnion: t.union([t.number, IntFromString])
+    }
+  }),
+  response: {
+    200: t.type({
+      result: t.string
+    })
+  }
+});
+`;
+
+testCase("query params (union codec) transformation test", UNION_CODEC_TEST, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0'
+  },
+  paths: {
+    '/union-codecs': {
+      get: {
+        parameters: [
+          {
+            name: 'mixedUnion',
+            in: 'query',
+            required: true,
+            schema: {
+              oneOf: [
+                { type: 'string' },
+                { type: 'number' },
+                { type: 'integer' }
+              ]
+            },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'numberUnion',
+            in: 'query',
+            required: true,
+            schema: { type: 'number' },
+            style: 'form',
+            explode: true
+          },
+          {
+            name: 'intUnion',
+            in: 'query',
+            required: true,
+            schema: { type: 'number' },
+            style: 'form',
+            explode: true
+          }
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    result: { type: 'string' }
+                  },
+                  required: ['result']
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {}
+  }
+});

--- a/packages/openapi-generator/test/openapi/union.test.ts
+++ b/packages/openapi-generator/test/openapi/union.test.ts
@@ -42,22 +42,27 @@ testCase('route with reduntant response schemas', SCHEMA_WITH_REDUNDANT_UNIONS, 
       get: {
         parameters: [
           {
+            explode: true,
             in: 'query',
             name: 'foo',
             required: true,
             schema: {
               type: 'string'
-            }
+            },
+            style: 'form'
           },
           {
+            explode: true,
             in: 'query',
             name: 'bar',
             required: true,
             schema: {
               type: 'number'
-            }
+            },
+            style: 'form'
           },
           {
+            explode: true,
             in: 'query',
             name: 'bucket',
             required: true,
@@ -67,7 +72,8 @@ testCase('route with reduntant response schemas', SCHEMA_WITH_REDUNDANT_UNIONS, 
                 { type: 'number' },
                 { type: 'boolean' }
               ]
-            }
+            },
+            style: 'form'
           }
         ],
         requestBody: {
@@ -199,6 +205,7 @@ testCase("route with consolidatable union schemas", ROUTE_WITH_CONSOLIDATABLE_UN
       get: {
         parameters: [
           {
+            explode: true,
             name: 'firstUnion',
             in: 'query',
             required: true,
@@ -207,20 +214,24 @@ testCase("route with consolidatable union schemas", ROUTE_WITH_CONSOLIDATABLE_UN
                 { type: 'string' },
                 { type: 'number' }
               ]
-            }
+            },
+            style: 'form'
           },
           {
+            explode: true,
             name: 'secondUnion',
             in: 'query',
             required: true,
             schema: {
               oneOf: [
                 { type: 'boolean' },
-                { type: 'string', format: 'number' }
+                { type: 'number'}
               ]
-            }
+            },
+            style: 'form'
           },
           {
+            explode: true,
             name: 'thirdUnion',
             in: 'query',
             required: true,
@@ -229,25 +240,32 @@ testCase("route with consolidatable union schemas", ROUTE_WITH_CONSOLIDATABLE_UN
                 { type: 'string' },
                 { type: 'boolean' }
               ]
-            }
+            },
+            style: 'form'
           },
           {
+            explode: true,
             name: 'firstNonUnion',
             in: 'query',
             required: true,
-            schema: { type: 'boolean' }
+            schema: { type: 'boolean' },
+            style: 'form'
           },
           {
+            explode: true,
             name: 'secondNonUnion',
             in: 'query',
             required: true,
-            schema: { type: 'string', format: 'number' }
+            schema: { type: 'number' },
+            style: 'form'
           },
           {
+            explode: true,
             name: 'thirdNonUnion',
             in: 'query',
             required: true,
-            schema: { type: 'string' }
+            schema: { type: 'string' },
+            style: 'form'
           }
         ],
         responses: {

--- a/packages/openapi-generator/test/route.test.ts
+++ b/packages/openapi-generator/test/route.test.ts
@@ -291,6 +291,7 @@ testCase('query param union route', QUERY_PARAM_UNION, {
             },
           ],
         },
+        style: 'form'
       },
     ],
     response: {
@@ -358,6 +359,7 @@ testCase('path param union route', PATH_PARAM_UNION, {
             },
           ],
         },
+        style: 'form'
       },
       {
         type: 'path',


### PR DESCRIPTION
Fix the bug in OpenAPI specs where query parameter types are incorrectly defined as strings