### PR TITLE
feat(openapi-generator): Improved OpenAPI schema generation 

### DIFF
--- a/packages/openapi-generator/src/knownImports.ts
+++ b/packages/openapi-generator/src/knownImports.ts
@@ -297,7 +297,7 @@ export const KNOWN_IMPORTS: KnownImports = {
       E.right({
         type: 'string',
         format: 'number',
-        maximum: 0,
+        minimum: 0,
         decodedType: 'bigint',
       }),
     NonPositiveBigInt: () =>

--- a/packages/openapi-generator/src/route.ts
+++ b/packages/openapi-generator/src/route.ts
@@ -11,7 +11,6 @@ export type Parameter = {
   type: 'path' | 'query' | 'header';
   name: string;
   schema: Schema;
-  explode?: boolean;
   required: boolean;
 };
 
@@ -151,7 +150,6 @@ function parseRequestUnion(
     parameters.push({
       type: 'query',
       name: 'union',
-      explode: true,
       required: true,
       schema: querySchema,
     });

--- a/packages/openapi-generator/test/openapi/base.test.ts
+++ b/packages/openapi-generator/test/openapi/base.test.ts
@@ -287,8 +287,6 @@ testCase('request union route', UNION, {
             in: 'query',
             name: 'union',
             required: true,
-            style: 'form',
-            explode: true,
             schema: {
               oneOf: [
                 {

--- a/packages/openapi-generator/test/openapi/jsdoc.test.ts
+++ b/packages/openapi-generator/test/openapi/jsdoc.test.ts
@@ -60,8 +60,6 @@ testCase('schema parameter with title tag', TITLE_TAG, {
             in: 'query',
             name: 'union',
             required: true,
-            style: 'form',
-            explode: true,
             schema: {
               oneOf: [
                 {

--- a/packages/openapi-generator/test/openapi/openapiSchemaTest.ts
+++ b/packages/openapi-generator/test/openapi/openapiSchemaTest.ts
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { schemaToOpenAPI } from '../../src/openapi';
+import { OpenAPIV3 } from 'openapi-types';
+import { Schema } from '../../src/ir';
+
+test('numeric constraints are properly mapped', () => {
+  const schema: Schema = {
+    type: 'number',
+    minimum: 0,
+    maximum: 100,
+    multipleOf: 5,
+    comment: {
+      description: 'A number with constraints',
+      tags: [],
+      source: [],
+      problems: [],
+    },
+  };
+
+  const result = schemaToOpenAPI(schema) as OpenAPIV3.SchemaObject;
+
+  assert.equal(result.type, 'number');
+  assert.equal(result.description, 'A number with constraints');
+
+  assert.equal(result.minimum, 0);
+  assert.equal(result.maximum, 100);
+  assert.equal(result.multipleOf, 5);
+});
+
+test('exclusive numeric constraints are properly mapped', () => {
+  const schema: Schema = {
+    type: 'number',
+    minimum: 0,
+    maximum: 100,
+    exclusiveMinimum: true,
+    exclusiveMaximum: true,
+    comment: {
+      description: 'A number with exclusive constraints',
+      tags: [],
+      source: [],
+      problems: [],
+    },
+  };
+
+  const result = schemaToOpenAPI(schema) as OpenAPIV3.SchemaObject;
+
+  assert.equal(result.type, 'number');
+  assert.equal(result.description, 'A number with exclusive constraints');
+
+  assert.equal(result.minimum, 0);
+  assert.equal(result.maximum, 100);
+  assert.equal(result.exclusiveMinimum, true);
+  assert.equal(result.exclusiveMaximum, true);
+});
+
+test('string-encoded numeric types are properly mapped', () => {
+  const schema: Schema = {
+    type: 'string',
+    format: 'number',
+    decodedType: 'number',
+  };
+
+  const result = schemaToOpenAPI(schema) as OpenAPIV3.SchemaObject;
+
+  assert.equal(result.type, 'number');
+});
+
+test('string-encoded integer types are properly mapped', () => {
+  const schema: Schema = {
+    type: 'string',
+    format: 'integer',
+    decodedType: 'number',
+  };
+
+  const result = schemaToOpenAPI(schema) as OpenAPIV3.SchemaObject;
+
+  assert.equal(result.type, 'integer');
+});
+
+test('BigInt types are properly mapped', () => {
+  const schema: Schema = {
+    type: 'string',
+    format: 'number',
+    decodedType: 'bigint',
+  };
+
+  const result = schemaToOpenAPI(schema) as OpenAPIV3.SchemaObject;
+
+  assert.equal(result.type, 'integer');
+  assert.equal(result.format, 'int64');
+});
+
+test('BigInt types with constraints are properly mapped', () => {
+  const schema: Schema = {
+    type: 'string',
+    format: 'number',
+    decodedType: 'bigint',
+    minimum: 0,
+    maximum: 1000000000000000000,
+  };
+
+  const result = schemaToOpenAPI(schema) as OpenAPIV3.SchemaObject;
+
+  assert.equal(result.type, 'integer');
+  assert.equal(result.format, 'int64');
+  assert.equal(result.minimum, 0);
+  assert.equal(result.maximum, 1000000000000000000);
+});

--- a/packages/openapi-generator/test/openapi/queryParams.test.ts
+++ b/packages/openapi-generator/test/openapi/queryParams.test.ts
@@ -1,0 +1,480 @@
+import { testCase } from './testHarness';
+
+const BASIC_CODEC_TEST = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+import { NumberFromString, IntFromString, BooleanFromString } from 'io-ts-types';
+import { NaturalFromString, NegativeFromString, NegativeIntFromString, NonNegativeFromString, NonPositiveFromString, NonPositiveIntFromString, NonZeroFromString, NonZeroIntFromString, PositiveFromString, ZeroFromString } from 'io-ts-numbers';
+import { BigIntFromString, NegativeBigIntFromString, NonNegativeBigIntFromString, NonPositiveBigIntFromString, NonZeroBigIntFromString, PositiveBigIntFromString, ZeroBigIntFromString } from 'io-ts-bigint';
+import { DateFromISOString, JsonFromString, UUID, Json, date } from 'io-ts-types';
+export const route = h.httpRoute({
+  path: '/basic-codecs',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      // Base number types
+      numberParam: t.number,
+      
+      // Codec types that should be transformed
+      numberFromString: NumberFromString,
+      intFromString: IntFromString,
+      naturalFromString: NaturalFromString,
+      negativeFromString: NegativeFromString,
+      negativeIntFromString: NegativeIntFromString,
+      nonNegativeFromString: NonNegativeFromString,
+      nonPositiveFromString: NonPositiveFromString,
+      nonPositiveIntFromString: NonPositiveIntFromString,
+      nonZeroFromString: NonZeroFromString,
+      nonZeroIntFromString: NonZeroIntFromString,
+      positiveFromString: PositiveFromString,
+      zeroFromString: ZeroFromString,
+      // io-ts-bigint
+      bigIntFromString: BigIntFromString,
+      negativeBigIntFromString: NegativeBigIntFromString,
+      nonNegativeBigIntFromString: NonNegativeBigIntFromString,
+      nonPositiveBigIntFromString: NonPositiveBigIntFromString,
+      nonZeroBigIntFromString: NonZeroBigIntFromString,
+      positiveBigIntFromString: PositiveBigIntFromString,
+      zeroBigIntFromString: ZeroBigIntFromString,
+      // io-ts-types
+      booleanFromString: BooleanFromString,
+      dateFromISOString: DateFromISOString,
+      jsonFromString: JsonFromString,
+      uUID: UUID,
+      json: Json,
+      date: date
+    }
+  }),
+  response: {
+    200: t.type({
+      result: t.string
+    })
+  }
+});
+`;
+
+testCase('query params test', BASIC_CODEC_TEST, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/basic-codecs': {
+      get: {
+        parameters: [
+          {
+            name: 'numberParam',
+            in: 'query',
+            required: true,
+            schema: { type: 'number' },
+          },
+          {
+            name: 'numberFromString',
+            in: 'query',
+            required: true,
+            schema: { type: 'number' },
+          },
+          {
+            name: 'intFromString',
+            in: 'query',
+            required: true,
+            schema: { type: 'integer' },
+          },
+          {
+            name: 'naturalFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'number',
+            },
+          },
+          {
+            name: 'negativeFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'number',
+              maximum: 0,
+              exclusiveMaximum: true,
+            },
+          },
+          {
+            name: 'negativeIntFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'integer',
+              maximum: 0,
+              exclusiveMaximum: true,
+            },
+          },
+          {
+            name: 'nonNegativeFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'number',
+              minimum: 0,
+            },
+          },
+          {
+            name: 'nonPositiveFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'number',
+              maximum: 0,
+            },
+          },
+          {
+            name: 'nonPositiveIntFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'integer',
+              maximum: 0,
+            },
+          },
+          {
+            name: 'nonZeroFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'number',
+            },
+          },
+          {
+            name: 'nonZeroIntFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'integer',
+            },
+          },
+          {
+            name: 'positiveFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'number',
+              minimum: 0,
+              exclusiveMinimum: true,
+            },
+          },
+          {
+            name: 'zeroFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'number',
+            },
+          },
+          {
+            name: 'bigIntFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'integer',
+              format: 'int64',
+            },
+          },
+          {
+            name: 'negativeBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'integer',
+              format: 'int64',
+              maximum: -1,
+            },
+          },
+          {
+            name: 'nonNegativeBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'integer',
+              format: 'int64',
+              minimum: 0,
+            },
+          },
+          {
+            name: 'nonPositiveBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'integer',
+              format: 'int64',
+              maximum: 0,
+            },
+          },
+          {
+            name: 'nonZeroBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'integer',
+              format: 'int64',
+            },
+          },
+          {
+            name: 'positiveBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'integer',
+              format: 'int64',
+              minimum: 1,
+            },
+          },
+          {
+            name: 'zeroBigIntFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'integer',
+              format: 'int64',
+            },
+          },
+          {
+            name: 'booleanFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'boolean',
+            },
+          },
+          {
+            name: 'dateFromISOString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+              format: 'date-time',
+            },
+          },
+          {
+            name: 'jsonFromString',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+              format: 'json',
+            },
+          },
+          {
+            name: 'uUID',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+              format: 'uuid',
+            },
+          },
+          {
+            name: 'json',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+              format: 'json',
+              additionalProperties: true,
+            },
+          },
+          {
+            name: 'date',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+              format: 'date',
+            },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    result: { type: 'string' },
+                  },
+                  required: ['result'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});
+
+const ARRAY_CODEC_TEST = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+import { NumberFromString, IntFromString } from 'io-ts-types';
+export const route = h.httpRoute({
+  path: '/array-codecs',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      numberArray: t.array(t.number),
+      numberFromStringArray: t.array(NumberFromString),
+      intFromStringArray: t.array(IntFromString)
+    }
+  }),
+  response: {
+    200: t.type({
+      result: t.string
+    })
+  }
+});
+`;
+
+testCase('query params (array codec) transformation test', ARRAY_CODEC_TEST, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/array-codecs': {
+      get: {
+        parameters: [
+          {
+            name: 'numberArray',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'array',
+              items: { type: 'number' },
+            },
+          },
+          {
+            name: 'numberFromStringArray',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'array',
+              items: { type: 'number' },
+            },
+          },
+          {
+            name: 'intFromStringArray',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'array',
+              items: { type: 'integer' },
+            },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    result: { type: 'string' },
+                  },
+                  required: ['result'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});
+
+// Test union types with codecs
+const UNION_CODEC_TEST = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+import { NumberFromString, IntFromString } from 'io-ts-types';
+export const route = h.httpRoute({
+  path: '/union-codecs',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      // Union types with codecs
+      mixedUnion: t.union([t.string, NumberFromString, IntFromString]),
+      numberUnion: t.union([t.number, NumberFromString]),
+      intUnion: t.union([t.number, IntFromString])
+    }
+  }),
+  response: {
+    200: t.type({
+      result: t.string
+    })
+  }
+});
+`;
+
+testCase('query params (union codec) transformation test', UNION_CODEC_TEST, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/union-codecs': {
+      get: {
+        parameters: [
+          {
+            name: 'mixedUnion',
+            in: 'query',
+            required: true,
+            schema: {
+              oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'integer' }],
+            },
+          },
+          {
+            name: 'numberUnion',
+            in: 'query',
+            required: true,
+            schema: { type: 'number' },
+          },
+          {
+            name: 'intUnion',
+            in: 'query',
+            required: true,
+            schema: { type: 'number' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    result: { type: 'string' },
+                  },
+                  required: ['result'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});

--- a/packages/openapi-generator/test/openapi/union.test.ts
+++ b/packages/openapi-generator/test/openapi/union.test.ts
@@ -201,7 +201,7 @@ testCase(
               in: 'query',
               required: true,
               schema: {
-                oneOf: [{ type: 'boolean' }, { type: 'string', format: 'number' }],
+                oneOf: [{ type: 'boolean' }, { type: 'number' }],
               },
             },
             {
@@ -222,7 +222,7 @@ testCase(
               name: 'secondNonUnion',
               in: 'query',
               required: true,
-              schema: { type: 'string', format: 'number' },
+              schema: { type: 'number' },
             },
             {
               name: 'thirdNonUnion',

--- a/packages/openapi-generator/test/route.test.ts
+++ b/packages/openapi-generator/test/route.test.ts
@@ -271,7 +271,6 @@ testCase('query param union route', QUERY_PARAM_UNION, {
         type: 'query',
         name: 'union',
         required: true,
-        explode: true,
         schema: {
           type: 'union',
           schemas: [
@@ -338,7 +337,6 @@ testCase('path param union route', PATH_PARAM_UNION, {
         type: 'query',
         name: 'union',
         required: true,
-        explode: true,
         schema: {
           type: 'union',
           schemas: [


### PR DESCRIPTION
This update enhances the OpenAPI specification generation with several improvements:

1. Numeric type handling:
- Changed `number` to `integer` type for integer schemas
- Added proper numeric constraints (minimum/maximum/multipleOf) for:
  - Regular numbers
  - BigInt values (now properly formatted as int64)
  - String-encoded numbers

2. Special type handling:
- Added proper format for UUID strings
- Improved date/time formatting
- Added JSON string format support
- Better handling of numeric unions

3. Parameter processing:
- Removed redundant `explode` and `style` parameters
- Added parent/paramName context for better schema inference
- Improved handling of numeric constraints in unions

4. Fix minimum/maximum bug in openapi.ts and add tests for numeric constraints

- Fixed a bug in openapi.ts where minimum and maximum values were swapped
- Added comprehensive tests for numeric constraints in openapi.ts
- Ensured all custom mappings in openapi.ts are properly tested
- Fixed the handling of undefined minimum and maximum values