### PR TITLE
feat(docs): spotlight component for an article

### DIFF
--- a/website/docs/how-to-guides/intermediate-semantic-analysis.md
+++ b/website/docs/how-to-guides/intermediate-semantic-analysis.md
@@ -4,102 +4,13 @@ sidebar_position: 1
 
 # How to Parse a number from a Query Parameter
 
+import { Spotlight } from '@site/src/components/CodeHike';
+
 Query parameters are represented as the type
 `Record<string, string | string[] | undefined>`, so using a codec that doesn't decode
 from a `string | string[] | undefined` will produce a type error.
 
-Consider this `httpRoute` that compiles successfully.
-
-```typescript
-import * as t from 'io-ts';
-import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
-
-const GetHello = httpRoute({
-  path: '/hello/{name}',
-  method: 'GET',
-  request: httpRequest({
-    params: {
-      name: t.string,
-    },
-  }),
-  response: {
-    200: t.string,
-  },
-});
-```
-
-If you add an expected `number` value to the `httpRoute`'s query parameters, you'll see
-the following compilation error:
-
-```typescript
-import * as t from 'io-ts';
-import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
-
-const GetHello = httpRoute({
-  path: '/hello/{name}',
-  method: 'GET',
-  request: httpRequest({
-    params: {
-      name: t.string,
-    },
-    query: {
-      repeat: t.number, // Compilation error!
-    },
-  }),
-  response: {
-    200: t.string,
-  },
-});
-```
-
-If you add an expected `number` value to the `httpRoute`'s query parameters, you'll see
-the following compilation error:
-
-```
-index.ts:16:7 - error TS2322:
-  Codec's output type is not assignable to
-  string | string[] | undefined.
-  Try using one like `NumberFromString`
-
-13       repeat: t.number
-```
-
-Recall that `t.number` decodes an `unknown` value into a `number` without any
-manipulation of the starting value. If you started with a number, you'll decode a
-number.
-
-We need a codec that decodes a `string` into a `number` and converts the
-string-representation of a number into the `number` type.
-
-This is a fairly common requirement, so this codec already exists: [io-ts-types] offers
-the [NumberFromString] codec that decodes a `string` value into a `number`. Use
-`NumberFromString` to fix your compilation error.
-
-[io-ts-types]: https://github.com/gcanti/io-ts-types
-[numberfromstring]:
-  https://gcanti.github.io/io-ts-types/modules/NumberFromString.ts.html
-
-```typescript
-import * as t from 'io-ts';
-import { NumberFromString } from 'io-ts-types';
-import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
-
-const GetHello = httpRoute({
-  path: '/hello/{name}',
-  method: 'GET',
-  request: httpRequest({
-    params: {
-      name: t.string,
-    },
-    query: {
-      repeat: NumberFromString,
-    },
-  }),
-  response: {
-    200: t.string,
-  },
-});
-```
+<Spotlight />
 
 In general, the solution to decoding a query parameter into a non-string type is to use
 a codec that decodes and encodes from a `string` into your desired type.

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16,7 +16,8 @@
         "docusaurus-theme-mdx-v2": "^0.1.2",
         "prism-react-renderer": "^1.3.5",
         "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react-dom": "^18.0.0",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.7.0"
@@ -21079,6 +21080,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,8 @@
     "docusaurus-theme-mdx-v2": "^0.1.2",
     "prism-react-renderer": "^1.3.5",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.7.0"

--- a/website/src/components/CodeHike/Spotlight.jsx
+++ b/website/src/components/CodeHike/Spotlight.jsx
@@ -1,0 +1,256 @@
+import React from 'react';
+import { useColorMode } from '@docusaurus/theme-common';
+
+// A simpler implementation of the Spotlight component
+export default function Spotlight() {
+  // State to track the selected step
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+  // Get the current color mode (light or dark)
+  const { colorMode } = useColorMode();
+  const isDarkTheme = colorMode === 'dark';
+
+  // Define theme-specific colors
+  const colors = {
+    background: isDarkTheme ? '#1e293b' : '#f8fafc',
+    border: isDarkTheme ? '#334155' : '#e2e8f0',
+    borderActive: isDarkTheme ? '#60a5fa' : '#3b82f6',
+    text: isDarkTheme ? '#f1f5f9' : '#0f172a',
+    codeBackground: isDarkTheme ? '#0f172a' : '#f1f5f9',
+    highlightBlue: isDarkTheme ? 'rgba(59, 130, 246, 0.3)' : 'rgba(59, 130, 246, 0.15)',
+    highlightRed: isDarkTheme ? 'rgba(239, 68, 68, 0.3)' : 'rgba(239, 68, 68, 0.15)',
+    highlightGreen: isDarkTheme
+      ? 'rgba(16, 185, 129, 0.3)'
+      : 'rgba(16, 185, 129, 0.15)',
+  };
+
+  // Define the steps manually based on the structure in the MDX file
+  const steps = [
+    {
+      title: 'Working Route',
+      content: (
+        <div>
+          <p>
+            Consider this <code>httpRoute</code> that compiles successfully.
+          </p>
+        </div>
+      ),
+      code: (
+        <pre className="language-typescript">
+          <code className="language-typescript">
+            {`import * as t from 'io-ts';
+import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
+
+const GetHello = httpRoute({
+  path: '/hello/{name}',
+  method: 'GET',
+  request: httpRequest({
+    params: {
+      name: t.string,
+    },
+  }),`}
+            <span
+              style={{
+                backgroundColor: colors.highlightBlue,
+                display: 'block',
+                margin: '0 -1rem',
+                padding: '0 1rem',
+              }}
+            >
+              {`  response: {
+    200: t.string,
+  },`}
+            </span>
+            {`});
+`}
+          </code>
+        </pre>
+      ),
+    },
+    {
+      title: 'Compilation Error',
+      content: (
+        <div>
+          <p>
+            If you add an expected <code>number</code> value to the{' '}
+            <code>httpRoute</code>'s query parameters, you'll see the following
+            compilation error:
+          </p>
+          <p>The error message looks like this:</p>
+          <pre>
+            <code>
+              {`index.ts:16:7 - error TS2322:
+  Codec's output type is not assignable to
+  string | string[] | undefined.
+  Try using one like \`NumberFromString\`
+
+13       repeat: t.number`}
+            </code>
+          </pre>
+          <p>
+            Recall that <code>t.number</code> decodes an <code>unknown</code> value into
+            a <code>number</code> without any manipulation of the starting value. If you
+            started with a number, you'll decode a number.
+          </p>
+          <p>
+            We need a codec that decodes a <code>string</code> into a{' '}
+            <code>number</code> and converts the string-representation of a number into
+            the <code>number</code> type.
+          </p>
+        </div>
+      ),
+      code: (
+        <pre className="language-typescript">
+          <code className="language-typescript">
+            {`import * as t from 'io-ts';
+import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
+
+const GetHello = httpRoute({
+  path: '/hello/{name}',
+  method: 'GET',
+  request: httpRequest({
+    params: {
+      name: t.string,
+    },
+    query: {`}
+            <span
+              style={{
+                backgroundColor: colors.highlightRed,
+                display: 'block',
+                margin: '0 -1rem',
+                padding: '0 1rem',
+              }}
+            >
+              {`      repeat: t.number, // Compilation error!`}
+            </span>
+            {`    },
+  }),
+  response: {
+    200: t.string,
+  },
+});`}
+          </code>
+        </pre>
+      ),
+    },
+    {
+      title: 'Solution',
+      content: (
+        <div>
+          <p>
+            This is a fairly common requirement, so this codec already exists:{' '}
+            <a href="https://github.com/gcanti/io-ts-types">io-ts-types</a> offers the{' '}
+            <a href="https://gcanti.github.io/io-ts-types/modules/NumberFromString.ts.html">
+              NumberFromString
+            </a>{' '}
+            codec that decodes a <code>string</code> value into a <code>number</code>.
+            Use
+            <code>NumberFromString</code> to fix your compilation error.
+          </p>
+        </div>
+      ),
+      code: (
+        <pre className="language-typescript">
+          <code className="language-typescript">
+            {`import * as t from 'io-ts';
+`}
+            <span
+              style={{
+                backgroundColor: colors.highlightGreen,
+                display: 'block',
+                margin: '0 -1rem',
+                padding: '0 1rem',
+              }}
+            >
+              {`import { NumberFromString } from 'io-ts-types';`}
+            </span>
+            {`import { httpRoute, httpRequest } from '@api-ts/io-ts-http';
+
+const GetHello = httpRoute({
+  path: '/hello/{name}',
+  method: 'GET',
+  request: httpRequest({
+    params: {
+      name: t.string,
+    },
+    query: {`}
+            <span
+              style={{
+                backgroundColor: colors.highlightGreen,
+                display: 'block',
+                margin: '0 -1rem',
+                padding: '0 1rem',
+              }}
+            >
+              {`      repeat: NumberFromString,`}
+            </span>
+            {`    },
+  }),
+  response: {
+    200: t.string,
+  },
+});`}
+          </code>
+        </pre>
+      ),
+    },
+  ];
+
+  return (
+    <div className="spotlight-container">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            gap: '1rem',
+            flexWrap: 'wrap',
+          }}
+        >
+          <div style={{ flex: 1, minWidth: '300px' }}>
+            {steps.map((step, i) => (
+              <div
+                key={i}
+                onClick={() => setSelectedIndex(i)}
+                style={{
+                  borderLeft: `4px solid ${selectedIndex === i ? colors.borderActive : colors.border}`,
+                  padding: '1rem',
+                  marginBottom: '1rem',
+                  borderRadius: '0.25rem',
+                  backgroundColor: colors.background,
+                  color: colors.text,
+                  cursor: 'pointer',
+                  transition: 'all 0.2s ease',
+                }}
+              >
+                <h3
+                  style={{
+                    marginTop: '0.5rem',
+                    fontSize: '1.25rem',
+                    fontWeight: 'bold',
+                  }}
+                >
+                  {step.title}
+                </h3>
+                <div>{step.content}</div>
+              </div>
+            ))}
+          </div>
+          <div
+            style={{
+              flex: 1,
+              minWidth: '300px',
+              position: 'sticky',
+              top: '5rem',
+              backgroundColor: colors.codeBackground,
+              borderRadius: '0.25rem',
+              padding: '0.5rem',
+              transition: 'background-color 0.2s ease',
+            }}
+          >
+            <div style={{ overflow: 'auto' }}>{steps[selectedIndex]?.code}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/CodeHike/index.js
+++ b/website/src/components/CodeHike/index.js
@@ -1,0 +1,1 @@
+export { default as Spotlight } from './Spotlight';

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -119,3 +119,17 @@
   border-color: white;
   color: white;
 }
+
+/* CodeHike Spotlight Component Styles */
+.spotlight-container {
+  margin: 2rem 0;
+}
+
+.spotlight-container pre {
+  margin: 0;
+  border-radius: 0.5rem;
+}
+
+.spotlight-container code {
+  font-size: 0.9rem;
+}

--- a/website/src/theme/MDXComponents.js
+++ b/website/src/theme/MDXComponents.js
@@ -1,0 +1,8 @@
+import MDXComponents from '@theme-original/MDXComponents';
+import { Spotlight } from '../components/CodeHike';
+
+export default {
+  ...MDXComponents,
+  // Add custom components here
+  Spotlight,
+};


### PR DESCRIPTION
Due to the recent migration to Code Hike v1.0.5 from codehike.mdx v0.9.0, there is a discrepancy in how the article `website/docs/how-to-guides/intermediate-semantic-analysis.md` looks.

Please reference our recent [PR](https://github.com/BitGo/api-ts/pull/1035#issuecomment-2805291474).

This PR attempts to completely rewrite the Spotlight component implementation to work with CodeHike 1.0.5:

- Created a custom React component that renders a side-by-side layout with steps and code
- Implemented theme-aware styling that dynamically changes colors based on light/dark mode
- Added specific code highlighting for important sections (blue for response, red for errors, green for solutions)
- Fixed responsive layout issues with proper wrapping and minimum widths
- Added transition effects for smoother theme switching

This change specifically updates the intermediate-semantic-analysis.md documentation file while maintaining the same educational content and interactive experience from codehike/mdx version 0.9.0.

UI experience in version 0.9.0:

https://github.com/user-attachments/assets/67261dc9-adcb-4750-8449-59b708d5f439

Ui experience now:

https://github.com/user-attachments/assets/7d630a19-34e2-431f-9765-8d30d5c729a3

