### PR TITLE
chore: transfer code ownership to DevEx

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @BitGo/velocity
-website @BitGo/velocity @BitGo/developer-experience
+* @BitGo/developer-experience


### PR DESCRIPTION
DevEx owns all things APIs, so this is a natural fit, now that the team
has support to take on maintenance.

Closes Ticket: DX-1472