### PR TITLE
feat(opentelemetry): create otel instrumentation for typed-express-router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,181 +49,26 @@
       "link": true
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/runtime": {
@@ -357,15 +202,15 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -822,6 +667,152 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
+      "integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
+      "integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
+      "integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.30.1",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/propagator-b3": "1.30.1",
+        "@opentelemetry/propagator-jaeger": "1.30.1",
+        "@opentelemetry/sdk-trace-base": "1.30.1",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@oxc-resolver/binding-darwin-arm64": {
@@ -2186,16 +2177,25 @@
         }
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dependencies": {
-        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2787,11 +2787,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2843,22 +2843,6 @@
       "dev": true,
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/del": {
@@ -2987,6 +2971,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -3096,12 +3093,9 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "engines": {
         "node": ">= 0.4"
       }
@@ -3114,10 +3108,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -3446,12 +3451,12 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -3603,21 +3608,38 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3699,11 +3721,11 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3753,32 +3775,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4627,6 +4627,14 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -4860,9 +4868,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/multi-semantic-release": {
       "version": "3.0.2",
@@ -11179,9 +11187,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -11582,6 +11590,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -13119,11 +13133,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
@@ -13144,22 +13153,6 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -13189,14 +13182,65 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14504,6 +14548,42 @@
         "node": ">=4.2.0"
       }
     },
+    "packages/opentelemetry-instrumentation-express": {
+      "name": "@opentelemetry/instrumentation-express",
+      "version": "0.51.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "mocha": "^10.8.2",
+        "ts-node": "^10.9.2"
+      },
+      "devDependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/context-async-hooks": "^2.0.0",
+        "@opentelemetry/contrib-test-utils": "^0.48.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
+        "@opentelemetry/sdk-trace-node": "^2.0.0",
+        "@types/express": "4.17.21",
+        "@types/mocha": "10.0.10",
+        "@types/node": "18.18.14",
+        "@types/sinon": "17.0.4",
+        "express": "^5.1.0",
+        "nyc": "17.1.0",
+        "rimraf": "5.0.10",
+        "sinon": "15.2.0",
+        "test-all-versions": "6.1.0",
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "packages/response": {
       "name": "@api-ts/response",
       "version": "0.0.0-semantically-released",
@@ -14579,9 +14659,20 @@
       },
       "devDependencies": {
         "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/sdk-trace-base": "1.30.1",
+        "@opentelemetry/sdk-trace-node": "1.30.1",
         "@swc-node/register": "1.10.9",
         "c8": "10.1.3",
         "typescript": "4.7.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "packages/typed-express-router/node_modules/typescript": {

--- a/packages/express-wrapper/src/index.ts
+++ b/packages/express-wrapper/src/index.ts
@@ -6,9 +6,22 @@
 import express from 'express';
 
 import { ApiSpec, HttpRoute, Method as HttpMethod } from '@api-ts/io-ts-http';
-import { createRouter } from '@api-ts/typed-express-router';
+import {
+  createRouter,
+  DecodeErrorFormatterFn,
+  EncodeErrorFormatterFn,
+  GetDecodeErrorStatusCodeFn,
+  GetEncodeErrorStatusCodeFn,
+} from '@api-ts/typed-express-router';
 
-import { handleRequest, onDecodeError, onEncodeError, RouteHandler } from './request';
+import {
+  handleRequest,
+  defaultDecodeErrorFormatter,
+  defaultEncodeErrorFormatter,
+  defaultGetDecodeErrorStatusCode,
+  defaultGetEncodeErrorStatusCode,
+  RouteHandler,
+} from './request';
 import { defaultResponseEncoder, ResponseEncoder } from './response';
 
 export { middlewareFn, MiddlewareChain, MiddlewareChainOutput } from './middleware';
@@ -25,16 +38,26 @@ type CreateRouterProps<Spec extends ApiSpec> = {
     };
   };
   encoder?: ResponseEncoder;
+  decodeErrorFormatter?: DecodeErrorFormatterFn;
+  encodeErrorFormatter?: EncodeErrorFormatterFn;
+  getDecodeErrorStatusCode?: GetDecodeErrorStatusCodeFn;
+  getEncodeErrorStatusCode?: GetEncodeErrorStatusCodeFn;
 };
 
 export function routerForApiSpec<Spec extends ApiSpec>({
   spec,
   routeHandlers,
   encoder = defaultResponseEncoder,
+  decodeErrorFormatter = defaultDecodeErrorFormatter,
+  encodeErrorFormatter = defaultEncodeErrorFormatter,
+  getDecodeErrorStatusCode = defaultGetDecodeErrorStatusCode,
+  getEncodeErrorStatusCode = defaultGetEncodeErrorStatusCode,
 }: CreateRouterProps<Spec>) {
   const router = createRouter(spec, {
-    onDecodeError,
-    onEncodeError,
+    decodeErrorFormatter,
+    encodeErrorFormatter,
+    getDecodeErrorStatusCode,
+    getEncodeErrorStatusCode,
   });
   for (const apiName of Object.keys(spec)) {
     const resource = spec[apiName] as Spec[string];

--- a/packages/express-wrapper/src/request.ts
+++ b/packages/express-wrapper/src/request.ts
@@ -8,8 +8,10 @@ import * as PathReporter from 'io-ts/lib/PathReporter';
 
 import { ApiSpec, HttpRoute, RequestType, ResponseType } from '@api-ts/io-ts-http';
 import {
-  OnDecodeErrorFn,
-  OnEncodeErrorFn,
+  type DecodeErrorFormatterFn,
+  type EncodeErrorFormatterFn,
+  type GetDecodeErrorStatusCodeFn,
+  type GetEncodeErrorStatusCodeFn,
   TypedRequestHandler,
 } from '@api-ts/typed-express-router';
 
@@ -94,17 +96,28 @@ const createNamedFunction = <F extends (...args: any) => void>(
   fn: F,
 ): F => Object.defineProperty(fn, 'name', { value: name });
 
-export const onDecodeError: OnDecodeErrorFn = (errs, _req, res) => {
+export const defaultDecodeErrorFormatter: DecodeErrorFormatterFn = (errs, _req) => {
   const validationErrors = PathReporter.failure(errs);
-  const validationErrorMessage = validationErrors.join('\n');
-  res.writeHead(400, { 'Content-Type': 'application/json' });
-  res.write(JSON.stringify({ error: validationErrorMessage }));
-  res.end();
+  return { error: validationErrors.join('\n') };
 };
 
-export const onEncodeError: OnEncodeErrorFn = (err, _req, res) => {
+export const defaultEncodeErrorFormatter: EncodeErrorFormatterFn = (_err, _req) => {
+  return {};
+};
+
+export const defaultGetDecodeErrorStatusCode: GetDecodeErrorStatusCodeFn = (
+  _errs,
+  _req,
+) => {
+  return 400;
+};
+
+export const defaultGetEncodeErrorStatusCode: GetEncodeErrorStatusCodeFn = (
+  err,
+  _req,
+) => {
   console.warn('Error in route handler:', err);
-  res.status(500).end();
+  return 500;
 };
 
 export const handleRequest = (

--- a/packages/typed-express-router/package.json
+++ b/packages/typed-express-router/package.json
@@ -23,11 +23,22 @@
     "fp-ts": "^2.0.0",
     "io-ts": "2.1.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
     "@swc-node/register": "1.10.9",
     "c8": "10.1.3",
-    "typescript": "4.7.4"
+    "typescript": "4.7.4",
+    "@opentelemetry/sdk-trace-base": "1.30.1",
+    "@opentelemetry/sdk-trace-node": "1.30.1",
+    "@opentelemetry/api": "1.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/typed-express-router/src/errors.ts
+++ b/packages/typed-express-router/src/errors.ts
@@ -1,22 +1,22 @@
-import express from 'express';
-import { Errors } from 'io-ts';
 import * as PathReporter from 'io-ts/lib/PathReporter';
 
-export function defaultOnDecodeError(
-  errs: Errors,
-  _req: express.Request,
-  res: express.Response,
-) {
-  const validationErrors = PathReporter.failure(errs);
-  const validationErrorMessage = validationErrors.join('\n');
-  res.status(400).json({ error: validationErrorMessage }).end();
-}
+import type {
+  DecodeErrorFormatterFn,
+  EncodeErrorFormatterFn,
+  GetDecodeErrorStatusCodeFn,
+  GetEncodeErrorStatusCodeFn,
+} from './types';
 
-export function defaultOnEncodeError(
-  err: unknown,
-  _req: express.Request,
-  res: express.Response,
-) {
-  res.status(500).end();
-  console.warn(`Error in route handler: ${err}`);
-}
+export const defaultDecodeErrorFormatter: DecodeErrorFormatterFn = PathReporter.failure;
+
+export const defaultGetDecodeErrorStatusCode: GetDecodeErrorStatusCodeFn = (
+  _err,
+  _req,
+) => 400;
+
+export const defaultEncodeErrorFormatter: EncodeErrorFormatterFn = () => ({});
+
+export const defaultGetEncodeErrorStatusCode: GetEncodeErrorStatusCodeFn = (
+  _err,
+  _req,
+) => 500;

--- a/packages/typed-express-router/src/telemetry.ts
+++ b/packages/typed-express-router/src/telemetry.ts
@@ -1,0 +1,199 @@
+/*
+ * @api-ts/typed-express-router
+ */
+
+// This module handles the optional dependency on @opentelemetry/api
+// It provides functionality for creating spans for decode and sendEncoded operations
+
+import type { Attributes, Span, Tracer } from '@opentelemetry/api';
+
+import type { Json, SpanMetadata } from './types';
+
+let otelApi: any;
+let tracer: Tracer | undefined;
+
+// Load @opentelemetry/api, if available.
+try {
+  otelApi = require('@opentelemetry/api');
+  if (otelApi) {
+    tracer = otelApi.trace.getTracer('typed-express-router');
+  }
+} catch (e) {
+  // Optional dependency not available, so tracing will be disabled.
+  tracer = undefined;
+}
+
+export const ApiTsAttributes = {
+  /**
+   * The Operation ID of the HTTP request
+   */
+  API_TS_OPERATION_ID: 'api_ts.operation_id',
+
+  /**
+   * The method of the HTTP request
+   */
+  API_TS_METHOD: 'api_ts.method',
+
+  /**
+   * The path of the HTTP request
+   */
+  API_TS_PATH: 'api_ts.path',
+
+  /**
+   * Returned HTTP request status code
+   */
+  API_TS_STATUS_CODE: 'api_ts.status_code',
+};
+
+/**
+ * Create default attributes for decode spans
+ *
+ * @param metadata The metadata for a span
+ * @returns Record of span attributes
+ */
+export function createDefaultDecodeAttributes(metadata: SpanMetadata): Attributes {
+  const attributes: Attributes = {};
+
+  if (metadata.apiName) {
+    attributes[ApiTsAttributes.API_TS_OPERATION_ID] = metadata.apiName;
+  }
+
+  if (metadata.httpRoute) {
+    if (metadata.httpRoute.method) {
+      attributes[ApiTsAttributes.API_TS_METHOD] = metadata.httpRoute.method;
+    }
+    if (metadata.httpRoute.path) {
+      attributes[ApiTsAttributes.API_TS_PATH] = metadata.httpRoute.path;
+    }
+  }
+
+  return attributes;
+}
+
+/**
+ * Create default attributes for encode spans
+ *
+ * @param metadata The metadata for a span
+ * @returns Record of span attributes
+ */
+export function createDefaultEncodeAttributes(metadata: SpanMetadata): Attributes {
+  const attributes: Attributes = {};
+
+  if (metadata.apiName) {
+    attributes[ApiTsAttributes.API_TS_OPERATION_ID] = metadata.apiName;
+  }
+
+  if (metadata.httpRoute) {
+    if (metadata.httpRoute.method) {
+      attributes[ApiTsAttributes.API_TS_METHOD] = metadata.httpRoute.method;
+    }
+    if (metadata.httpRoute.path) {
+      attributes[ApiTsAttributes.API_TS_PATH] = metadata.httpRoute.path;
+    }
+  }
+
+  return attributes;
+}
+
+/**
+ * Creates a span for the decode operation if OpenTelemetry is available
+ * @param metadata The metadata for a span
+ * @returns A span object or undefined if tracing is disabled
+ */
+export function createDecodeSpan(metadata: SpanMetadata): Span | undefined {
+  if (!tracer || !otelApi) {
+    return undefined;
+  }
+
+  const span = tracer.startSpan(`typed-express-router.decode`);
+  const decodeAttributes = createDefaultDecodeAttributes(metadata);
+  span.setAttributes(decodeAttributes);
+
+  return span;
+}
+
+/**
+ * Creates a span for the sendEncoded operation if OpenTelemetry is available
+ * @param metadata The metadata for a span
+ * @returns A span object or undefined if tracing is disabled
+ */
+export function createSendEncodedSpan(metadata: SpanMetadata): Span | undefined {
+  if (!tracer || !otelApi) {
+    return undefined;
+  }
+
+  const span = tracer.startSpan(`typed-express-router.encode`);
+
+  const encodeAttributes = createDefaultEncodeAttributes(metadata);
+  // Add attributes to provide context for the span
+  span.setAttributes(encodeAttributes);
+
+  return span;
+}
+
+/**
+ * Records an error on an encode span
+ * @param span The span to record the error on
+ * @param error The error to record
+ */
+export function recordSpanEncodeError(
+  span: Span | undefined,
+  error: unknown,
+  statusCode: number,
+): void {
+  if (!span || !otelApi) {
+    return;
+  }
+  setSpanAttributes(span, {
+    [ApiTsAttributes.API_TS_STATUS_CODE]: statusCode,
+  });
+  span.recordException(error instanceof Error ? error : new Error(String(error)));
+  span.setStatus({ code: otelApi.SpanStatusCode.ERROR });
+}
+
+/**
+ * Records errors on a decode span
+ * @param span The span to record the errors on
+ * @param error The JSON error value to record
+ * @param statusCode The HTTP status code
+ */
+export function recordSpanDecodeError(
+  span: Span | undefined,
+  error: Json,
+  statusCode: number,
+): void {
+  if (!span || !otelApi) {
+    return;
+  }
+  setSpanAttributes(span, {
+    [ApiTsAttributes.API_TS_STATUS_CODE]: statusCode,
+  });
+  span.recordException(JSON.stringify(error, null, 2));
+  span.setStatus({ code: otelApi.SpanStatusCode.ERROR });
+}
+
+/**
+ * Sets a span's attributes if it exists
+ * @param span The span to modify
+ * @param attributes The attributes to modify the span with
+ */
+export function setSpanAttributes(
+  span: Span | undefined,
+  attributes: Attributes,
+): void {
+  if (!span) {
+    return;
+  }
+  span.setAttributes(attributes);
+}
+
+/**
+ * Ends a span if it exists
+ * @param span The span to end
+ */
+export function endSpan(span: Span | undefined): void {
+  if (!span) {
+    return;
+  }
+  span.end();
+}

--- a/packages/typed-express-router/test/telemetry.test.ts
+++ b/packages/typed-express-router/test/telemetry.test.ts
@@ -1,0 +1,727 @@
+import assert from 'node:assert';
+import test, { beforeEach, afterEach } from 'node:test';
+
+import { apiSpec, httpRequest, HttpRoute, httpRoute } from '@api-ts/io-ts-http';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { Span, SpanKind, context, trace } from '@opentelemetry/api';
+import { setRPCMetadata, RPCType } from '@opentelemetry/core';
+import express from 'express';
+import * as t from 'io-ts';
+import * as http from 'http';
+
+import type { TypedRequestHandler } from '../src/types';
+import { createRouter } from '../src';
+import { ApiTsAttributes } from '../src/telemetry';
+
+const makeRequest = (
+  server: http.Server,
+  method: string,
+  path: string,
+  body?: any,
+): Promise<{ statusCode: number; data: string }> => {
+  return new Promise((resolve, reject) => {
+    const address = server.address();
+
+    if (typeof address === 'string' || address === null) {
+      reject('Unexpected address value');
+      return;
+    }
+
+    const url = `http://localhost:${address.port}${path}`;
+
+    const options: http.RequestOptions = {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const req = http.request(url, options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        resolve({
+          statusCode: res.statusCode || 0,
+          data,
+        });
+      });
+    });
+
+    req.on('error', reject);
+
+    if (body) {
+      req.write(JSON.stringify(body));
+    }
+
+    req.end();
+  });
+};
+
+const GetHello = httpRoute({
+  path: '/hello/{id}',
+  method: 'GET',
+  request: httpRequest({
+    params: {
+      id: t.string,
+    },
+  }),
+  response: {
+    200: t.type({
+      id: t.string,
+    }),
+  },
+});
+
+const GetHelloBad = httpRoute({
+  path: '/hello/bad/{id}',
+  method: 'GET',
+  request: httpRequest({
+    params: {
+      id: t.string,
+    },
+  }),
+  response: {
+    200: t.type({
+      id: t.string,
+    }),
+  },
+});
+
+const PostHello = httpRoute({
+  path: '/hello',
+  method: 'POST',
+  request: httpRequest({
+    body: {
+      secretCode: t.number,
+    },
+  }),
+  response: {
+    200: t.type({
+      message: t.string,
+    }),
+  },
+});
+
+const PutHello = httpRoute({
+  path: '/hello',
+  method: 'PUT',
+  request: httpRequest({
+    body: {
+      secretCode: t.number,
+    },
+  }),
+  response: {
+    200: t.type({
+      message: t.string,
+    }),
+    400: t.type({
+      errors: t.string,
+    }),
+    404: t.unknown,
+    500: t.unknown,
+  },
+});
+
+const DeleteHello = httpRoute({
+  path: '/hello/{id}',
+  method: 'DELETE',
+  request: httpRequest({
+    params: {
+      id: t.string,
+    },
+  }),
+  response: {
+    200: t.type({
+      id: t.string,
+    }),
+  },
+});
+
+const PatchHello = httpRoute({
+  path: '/hello',
+  method: 'PATCH',
+  request: httpRequest({
+    body: {
+      secretCode: t.number,
+    },
+  }),
+  response: {
+    200: t.type({
+      message: t.string,
+    }),
+  },
+});
+
+const TestApiSpec = apiSpec({
+  'hello.world': {
+    get: GetHello,
+    post: PostHello,
+    put: PutHello,
+    delete: DeleteHello,
+    patch: PatchHello,
+  },
+  'hello.world.bad': {
+    get: GetHelloBad,
+  },
+});
+
+type TestApiSpec = typeof TestApiSpec;
+
+const GetHelloWorld: TypedRequestHandler<TestApiSpec, 'hello.world', 'get'> = (
+  { decoded: { id } },
+  res,
+) => res.sendEncoded(200, { id });
+
+const GetHelloWorldBad: TypedRequestHandler<TestApiSpec, 'hello.world.bad', 'get'> = (
+  { decoded: { id } },
+  res,
+) => res.sendEncoded(200, { bad: id } as any);
+
+const PostHelloWorld: TypedRequestHandler<TestApiSpec, 'hello.world', 'post'> = (
+  req,
+  res,
+) => {
+  const { secretCode } = req.decoded;
+  res.sendEncoded(200, {
+    message:
+      secretCode === 42 ? 'Everything you see from here is yours' : "Who's there?",
+  });
+};
+
+const PutHelloWorld: TypedRequestHandler<TestApiSpec, 'hello.world', 'put'> = (
+  req,
+  res,
+) => {
+  const { secretCode } = req.decoded;
+  if (secretCode === 0) {
+    res.sendEncoded(400, {
+      errors: 'Please do not tell me zero! I will now explode',
+    });
+  } else {
+    res.sendEncoded(200, {
+      message:
+        secretCode === 42 ? 'Everything you see from here is yours' : "Who's there?",
+    });
+  }
+};
+
+const DeleteHelloWorld: TypedRequestHandler<TestApiSpec, 'hello.world', 'delete'> = (
+  { decoded: { id } },
+  res,
+) => res.sendEncoded(200, { id });
+
+const PatchHelloWorld: TypedRequestHandler<TestApiSpec, 'hello.world', 'patch'> = (
+  req,
+  res,
+) => {
+  const { secretCode } = req.decoded;
+  res.sendEncoded(200, {
+    message:
+      secretCode === 42 ? 'Everything you see from here is yours' : "Who's there?",
+  });
+};
+
+const memoryExporter = new InMemorySpanExporter();
+const spanProcessor = new SimpleSpanProcessor(memoryExporter);
+const provider = new NodeTracerProvider({
+  spanProcessors: [spanProcessor],
+});
+const tracer = provider.getTracer('typed-express-router');
+const contextManager = new AsyncLocalStorageContextManager().enable();
+let server: http.Server;
+let rootSpan: Span;
+
+context.setGlobalContextManager(contextManager);
+provider.register();
+
+beforeEach(async () => {
+  rootSpan = tracer.startSpan('rootSpan');
+
+  const app = express();
+  app.use(express.json());
+
+  app.use((_, __, next) => {
+    const rpcMetadata = { type: RPCType.HTTP, span: rootSpan };
+    return context.with(
+      setRPCMetadata(trace.setSpan(context.active(), rootSpan), rpcMetadata),
+      next,
+    );
+  });
+
+  const router = createRouter(TestApiSpec);
+
+  router.get('hello.world', [GetHelloWorld]);
+  router.get('hello.world.bad', [GetHelloWorldBad]);
+  router.post('hello.world', [PostHelloWorld]);
+  router.put('hello.world', [PutHelloWorld], {
+    decodeErrorFormatter: (_errs, _req) => {
+      return 'Custom Decode Error';
+    },
+  });
+  router.delete('hello.world', [DeleteHelloWorld]);
+  router.patch('hello.world', [PatchHelloWorld]);
+
+  app.use(router);
+
+  server = http.createServer(app);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, () => {
+      resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  contextManager.disable();
+  contextManager.enable();
+  memoryExporter.reset();
+  server?.close();
+});
+
+const getSpans = () => memoryExporter.getFinishedSpans();
+
+test('should capture span attributes for GET requests', async () => {
+  await context.with(trace.setSpan(context.active(), rootSpan), async () => {
+    // Make request with path parameter
+    const response = await makeRequest(server, 'GET', '/hello/123', undefined);
+    rootSpan.end();
+
+    assert.strictEqual(response.statusCode, 200);
+
+    const responseData = JSON.parse(response.data);
+    assert.strictEqual(responseData.id, '123');
+
+    // Check spans
+    const spans = getSpans();
+
+    // rootSpan, encode, decode
+    assert.ok(spans.length >= 3, `Expected at least 3 spans but got ${spans.length}`);
+
+    // Find decode span
+    const decodeSpan = spans.find(
+      (span) => span.name.includes('decode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(decodeSpan, 'Decode span not found');
+    assert.strictEqual(
+      decodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(decodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD], 'GET');
+    assert.strictEqual(
+      decodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH],
+      '/hello/{id}',
+    );
+
+    // Find encode span
+    const encodeSpan = spans.find(
+      (span) => span.name.includes('encode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(encodeSpan, 'Encode span not found');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(encodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD], 'GET');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH],
+      '/hello/{id}',
+    );
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_STATUS_CODE],
+      200,
+    );
+  });
+});
+
+test('should capture span attributes for POST requests', async () => {
+  await context.with(trace.setSpan(context.active(), rootSpan), async () => {
+    const response = await makeRequest(server, 'POST', '/hello', { secretCode: 42 });
+    rootSpan.end();
+
+    assert.strictEqual(response.statusCode, 200);
+
+    const responseData = JSON.parse(response.data);
+    assert.strictEqual(responseData.message, 'Everything you see from here is yours');
+
+    // Check spans
+    const spans = getSpans();
+
+    // rootSpan, encode, decode
+    assert.ok(spans.length >= 3, `Expected at least 3 spans but got ${spans.length}`);
+
+    // Find decode span
+    const decodeSpan = spans.find(
+      (span) => span.name.includes('decode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(decodeSpan, 'Decode span not found');
+    assert.strictEqual(
+      decodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(decodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD], 'POST');
+    assert.strictEqual(decodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH], '/hello');
+
+    // Find encode span
+    const encodeSpan = spans.find(
+      (span) => span.name.includes('encode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(encodeSpan, 'Encode span not found');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(encodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD], 'POST');
+    assert.strictEqual(encodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH], '/hello');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_STATUS_CODE],
+      200,
+    );
+  });
+});
+
+test('should capture span attributes for PUT requests', async () => {
+  await context.with(trace.setSpan(context.active(), rootSpan), async () => {
+    const response = await makeRequest(server, 'PUT', '/hello', { secretCode: 42 });
+    rootSpan.end();
+
+    assert.strictEqual(response.statusCode, 200);
+
+    const responseData = JSON.parse(response.data);
+    assert.strictEqual(responseData.message, 'Everything you see from here is yours');
+
+    // Check spans
+    const spans = getSpans();
+
+    // rootSpan, encode, decode
+    assert.ok(spans.length >= 3, `Expected at least 3 spans but got ${spans.length}`);
+
+    // Find decode span
+    const decodeSpan = spans.find(
+      (span) => span.name.includes('decode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(decodeSpan, 'Decode span not found');
+    assert.strictEqual(
+      decodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(decodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH], '/hello');
+    assert.strictEqual(decodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD], 'PUT');
+
+    // Find encode span
+    const encodeSpan = spans.find(
+      (span) => span.name.includes('encode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(encodeSpan, 'Encode span not found');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(encodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH], '/hello');
+    assert.strictEqual(encodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD], 'PUT');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_STATUS_CODE],
+      200,
+    );
+  });
+});
+
+test('should capture span attributes for DELETE requests', async () => {
+  await context.with(trace.setSpan(context.active(), rootSpan), async () => {
+    // Make request with path parameter
+    const response = await makeRequest(server, 'DELETE', '/hello/123', undefined);
+    rootSpan.end();
+
+    assert.strictEqual(response.statusCode, 200);
+
+    const responseData = JSON.parse(response.data);
+    assert.strictEqual(responseData.id, '123');
+
+    // Check spans
+    const spans = getSpans();
+
+    // rootSpan, encode, decode
+    assert.ok(spans.length >= 3, `Expected at least 3 spans but got ${spans.length}`);
+
+    // Find decode span
+    const decodeSpan = spans.find(
+      (span) => span.name.includes('decode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(decodeSpan, 'Decode span not found');
+    assert.strictEqual(
+      decodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(
+      decodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD],
+      'DELETE',
+    );
+    assert.strictEqual(
+      decodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH],
+      '/hello/{id}',
+    );
+
+    // Find encode span
+    const encodeSpan = spans.find(
+      (span) => span.name.includes('encode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(encodeSpan, 'Encode span not found');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD],
+      'DELETE',
+    );
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH],
+      '/hello/{id}',
+    );
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_STATUS_CODE],
+      200,
+    );
+  });
+});
+
+test('should capture span attributes for PATCH requests', async () => {
+  await context.with(trace.setSpan(context.active(), rootSpan), async () => {
+    const response = await makeRequest(server, 'PATCH', '/hello', { secretCode: 42 });
+    rootSpan.end();
+
+    assert.strictEqual(response.statusCode, 200);
+
+    const responseData = JSON.parse(response.data);
+    assert.strictEqual(responseData.message, 'Everything you see from here is yours');
+
+    // Check spans
+    const spans = getSpans();
+
+    // rootSpan, encode, decode
+    assert.ok(spans.length >= 3, `Expected at least 3 spans but got ${spans.length}`);
+
+    // Find decode span
+    const decodeSpan = spans.find(
+      (span) => span.name.includes('decode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(decodeSpan, 'Decode span not found');
+    assert.strictEqual(
+      decodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(
+      decodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD],
+      'PATCH',
+    );
+    assert.strictEqual(decodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH], '/hello');
+
+    // Find encode span
+    const encodeSpan = spans.find(
+      (span) => span.name.includes('encode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(encodeSpan, 'Encode span not found');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD],
+      'PATCH',
+    );
+    assert.strictEqual(encodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH], '/hello');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_STATUS_CODE],
+      200,
+    );
+  });
+});
+
+test('should capture bad-request responses', async () => {
+  await context.with(trace.setSpan(context.active(), rootSpan), async () => {
+    // Make request that will trigger validation error
+    const response = await makeRequest(server, 'PUT', '/hello', { secretCode: 0 });
+    rootSpan.end();
+
+    assert.strictEqual(response.statusCode, 400);
+    const responseData = JSON.parse(response.data);
+    assert.strictEqual(
+      responseData.errors,
+      'Please do not tell me zero! I will now explode',
+    );
+
+    // Check spans
+    const spans = getSpans();
+
+    // rootSpan, encode, decode
+    assert.ok(spans.length >= 3, `Expected at least 3 spans but got ${spans.length}`);
+
+    // Find decode span
+    const decodeSpan = spans.find(
+      (span) => span.name.includes('decode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(decodeSpan, 'Decode span not found');
+    assert.strictEqual(
+      decodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(decodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD], 'PUT');
+    assert.strictEqual(decodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH], '/hello');
+
+    // Find encode span
+    const encodeSpan = spans.find(
+      (span) => span.name.includes('encode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(encodeSpan, 'Encode span not found');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(encodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD], 'PUT');
+    assert.strictEqual(encodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH], '/hello');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_STATUS_CODE],
+      400,
+    );
+  });
+});
+
+test('should capture decode errors', async () => {
+  await context.with(trace.setSpan(context.active(), rootSpan), async () => {
+    const response = await makeRequest(server, 'PUT', '/hello', {
+      secretCode: 'not a number',
+    });
+    rootSpan.end();
+
+    assert.strictEqual(response.statusCode, 400);
+
+    // Check spans
+    const spans = getSpans();
+
+    // Find decode span
+    const decodeSpan = spans.find(
+      (span) => span.name.includes('decode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(decodeSpan, 'Encode span not found');
+    assert.strictEqual(
+      decodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world',
+    );
+    assert.strictEqual(decodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD], 'PUT');
+    assert.strictEqual(decodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH], '/hello');
+    const errorEvents = decodeSpan.events.filter((event) => {
+      return event['name'] === 'exception';
+    });
+    assert.ok(errorEvents.length > 0, 'Expected at least 1 error event');
+
+    assert.ok(
+      errorEvents.find(
+        (event) => event.attributes?.['exception.message'] === '"Custom Decode Error"',
+      ),
+      'Expected custom decode reporter message',
+    );
+  });
+});
+
+test('should capture encode errors', async () => {
+  await context.with(trace.setSpan(context.active(), rootSpan), async () => {
+    const response = await makeRequest(server, 'GET', '/hello/bad/1');
+    rootSpan.end();
+
+    assert.strictEqual(response.statusCode, 500);
+
+    // Check spans
+    const spans = getSpans();
+
+    // rootSpan, encode, decode
+    assert.ok(spans.length >= 3, `Expected at least 3 spans but got ${spans.length}`);
+
+    // Find encode span
+    const encodeSpan = spans.find(
+      (span) => span.name.includes('encode') && span.kind === SpanKind.INTERNAL,
+    );
+    assert.ok(encodeSpan, 'Encode span not found');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_OPERATION_ID],
+      'hello.world.bad',
+    );
+    assert.strictEqual(encodeSpan?.attributes?.[ApiTsAttributes.API_TS_METHOD], 'GET');
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_PATH],
+      '/hello/bad/{id}',
+    );
+    assert.strictEqual(
+      encodeSpan?.attributes?.[ApiTsAttributes.API_TS_STATUS_CODE],
+      500,
+    );
+    const errorEvents = encodeSpan.events.filter((event) => {
+      const attributes = event.attributes;
+      if (!attributes) return false;
+      return attributes['exception.type'] === 'Error';
+    });
+    assert.ok(errorEvents.length > 0, 'Expected at least 1 error event');
+
+    assert.ok(
+      errorEvents.find((event) =>
+        event.attributes?.['exception.message']
+          ?.toString()
+          .startsWith('response does not match expected type'),
+      ),
+      'Expected encode error message',
+    );
+  });
+});
+
+test('should handle missing opentelemetry package', async () => {
+  const originalCache = { ...require.cache };
+  const resolvedPath = require.resolve('@opentelemetry/api');
+
+  try {
+    require.cache[resolvedPath] = {
+      ...require.cache[resolvedPath]!!,
+      exports: undefined,
+    };
+    delete require.cache[require.resolve('../src/telemetry')];
+
+    const tempModule = await import('../src/telemetry');
+
+    const testMetadata = {
+      apiName: 'test.missing.otel',
+      httpRoute: {
+        path: '/test-path',
+        method: 'GET',
+      } as HttpRoute,
+    };
+    // Verify that span creation functions return undefined
+    const decodeSpan = tempModule.createDecodeSpan(testMetadata);
+    const encodeSpan = tempModule.createSendEncodedSpan(testMetadata);
+
+    assert.strictEqual(
+      decodeSpan,
+      undefined,
+      'Decode span should be undefined when OpenTelemetry is missing',
+    );
+    assert.strictEqual(
+      encodeSpan,
+      undefined,
+      'Encode span should be undefined when OpenTelemetry is missing',
+    );
+
+    // Verify that other functions don't throw when given undefined spans
+    assert.doesNotThrow(() => {
+      tempModule.recordSpanEncodeError(decodeSpan, 'Test error', 500);
+      tempModule.recordSpanDecodeError(encodeSpan, [], 400);
+      tempModule.setSpanAttributes(decodeSpan, {});
+      tempModule.endSpan(encodeSpan);
+    }, 'Telemetry functions should handle undefined spans gracefully');
+  } finally {
+    require.cache = originalCache;
+  }
+});


### PR DESCRIPTION
Ticket: DX-1473

This PR implements `opentelemetry` instrumentation for the `decode` and `sendEncoded` calls in `wrapRouter`. 

Changes:
- `typed-express-wrapper`
  - `@opentelemetry/api@^1.0.0` added as an optional peer dependency
  - `@opentelemetry/sdk-trace-base@1.30.1` , `@opentelemetry/sdk-trace-node@1.30.1`, and `@opentelemetry/api@1.9.0` added as dev dependencies
  - `wrapRouter` modified to create decode and encode spans if `@opentelemetry/api` is installed
    - if `@opentelemetry/api` is not installed, spans are not created
  - `onDecodeError` option removed. Please use `decodeErrorFormatter` and `getDecodeErrorStatusCode`
    - `decodeErrorFormatter` takes in an array of `ValidationError`s and a `WrappedRequest`, returning a `Json` object.
    - `getDecodeErrorStatusCode` takes in an array of `ValidationError`s and a `WrappedRequest`, returning a number.
  - `onEncodeError` option removed. Please use `encodeErrorFormatter` and `getEncodeErrorStatusCode`
    - `encodeErrorFormatter` takes in an error and a `WrappedRequest`, returning a `Json` object.
    - `getEncodeErrorStatusCode` takes in an error and a `WrappedRequest`, returning a number.
  - `typed-express-router` now handles the sending of the http response when there is a decode or encode error 
- `express-wrapper`
  - `routerForApiSpec` modified to pass in new parameters `decodeErrorFormatter`, `getDecodeErrorStatusCode`, `encodeErrorFormatter`, and `getEncodeErrorStatusCode`
    - These new parameters can also be customized by modifying the props passed into the function (see `CreateRouterProps`)

BREAKING CHANGE: `onDecodeError` and `onEncodeError` have been removed. Please use `decodeErrorFormatter`, `getDecodeErrorStatusCode`, `encodeErrorFormatter`, and `getEncodeErrorStatusCode`