### PR TITLE
fix: support arrow functions in OpenAPI generator

### DIFF
--- a/packages/openapi-generator/test/externalModuleApiSpec.test.ts
+++ b/packages/openapi-generator/test/externalModuleApiSpec.test.ts
@@ -368,3 +368,46 @@ testCase(
   },
   [],
 );
+
+testCase(
+  'simple api spec with util type functions',
+  'test/sample-types/apiSpecWithArrow.ts',
+  {
+    openapi: '3.0.3',
+    info: {
+      title: 'simple api spec with util type functions',
+      version: '1.0.0',
+      description: 'simple api spec with util type functions',
+    },
+    paths: {
+      '/test': {
+        get: {
+          parameters: [],
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      hasLargeNumberOfAddresses: {
+                        nullable: true,
+                        type: 'boolean',
+                      },
+                    },
+                    required: ['hasLargeNumberOfAddresses'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {},
+    },
+  },
+  [],
+);

--- a/packages/openapi-generator/test/sample-types/apiSpecWithArrow.ts
+++ b/packages/openapi-generator/test/sample-types/apiSpecWithArrow.ts
@@ -1,0 +1,23 @@
+import * as h from '@api-ts/io-ts-http';
+import * as t from 'io-ts';
+import { BooleanFromString, fromNullable } from 'io-ts-types';
+
+const BooleanFromNullableWithFallback = () =>
+  fromNullable(t.union([BooleanFromString, t.boolean]), false);
+
+export const TEST_ROUTE = h.httpRoute({
+  path: '/test',
+  method: 'GET',
+  request: h.httpRequest({}),
+  response: {
+    200: t.type({
+      hasLargeNumberOfAddresses: BooleanFromNullableWithFallback(),
+    }),
+  },
+});
+
+export const apiSpec = h.apiSpec({
+  'api.test': {
+    get: TEST_ROUTE,
+  },
+});


### PR DESCRIPTION
Ticket: DX-1799

### Problem 
The generator couldn't resolve `CallExpressions` where the callee is an arrow function. When it looked up `BooleanFromNullableWithFallback` and found an arrow function, it had no logic to parse the function body to extract the codec it returns, falling back to an empty schema.

Example of the issue can be found in the ticket description. 

---

### Fix:
- Adds `parseFunctionBody()` to extract and parse arrow function return values
- Detects when `CallExpression` callees resolve to arrow functions
- Uses `findSymbolInitializer()` for cross-file lookup of imported functions
- Supports `expression body (() => expr)`

### Validation: 
Test covers the bug scenario: calling an arrow function `BooleanFromNullableWithFallback()`within a codec property definition.

### Note: 
Block statement arrow functions were not part of the bug, but its valid TypeScript that the parser is not supporting. 
An example of one is: `block statement (() => { return expr })` . 

I added that in the error message and have created a new ticket [DX-2182](https://bitgoinc.atlassian.net/browse/DX-2182) to address this. 

[DX-2182]: https://bitgoinc.atlassian.net/browse/DX-2182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ