### PR TITLE
refactor: improve the error message for missing external codecs in openapi-generator

### DIFF
--- a/packages/openapi-generator/src/codec.ts
+++ b/packages/openapi-generator/src/codec.ts
@@ -528,7 +528,11 @@ export function parseCodecInitializer(
           // schema.location might be a package name -> need to resolve the path from the project types
           const path = project.getTypes()[schema.name];
           if (path === undefined)
-            return errorLeft(`Cannot find module '${schema.location}' in the project`);
+            return errorLeft(
+              `Cannot find external codec '${schema.name}' from module '${schema.location}'. ` +
+                `To fix this, add the codec definition to your codec config file. ` +
+                `See: https://github.com/BitGo/api-ts/tree/master/packages/openapi-generator#4-defining-custom-codecs`,
+            );
           refSource = project.get(path);
           if (refSource === undefined) {
             return errorLeft(`Cannot find '${schema.name}' from '${schema.location}'`);

--- a/packages/openapi-generator/test/apiSpec.test.ts
+++ b/packages/openapi-generator/test/apiSpec.test.ts
@@ -290,5 +290,5 @@ const MISSING_REFERENCE = {
 };
 
 testCase('missing reference', MISSING_REFERENCE, '/index.ts', {}, [
-  "Cannot find module 'foo' in the project",
+  "Cannot find external codec 'Foo' from module 'foo'. To fix this, add the codec definition to your codec config file. See: https://github.com/BitGo/api-ts/tree/master/packages/openapi-generator#4-defining-custom-codecs",
 ]);


### PR DESCRIPTION
Ticket: [DX-688](https://bitgoinc.atlassian.net/browse/DX-688)

Error message was made following the standards of: 
1. What went wrong
2. How can the developer go about solving the problem

[DX-688]: https://bitgoinc.atlassian.net/browse/DX-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ