### PR TITLE
fix: support BlockStatement arrow functions in codec parser

### DIFF
--- a/packages/openapi-generator/src/codec.ts
+++ b/packages/openapi-generator/src/codec.ts
@@ -459,7 +459,14 @@ function parseFunctionBody(
     return errorLeft('Function body is undefined');
   }
   if (func.body.type === 'BlockStatement') {
-    return errorLeft('BlockStatement arrow functions are not yet supported');
+    const returnStmt = func.body.stmts.find((s) => s.type === 'ReturnStatement');
+    if (!returnStmt || returnStmt.type !== 'ReturnStatement') {
+      return errorLeft('BlockStatement must contain a return statement');
+    }
+    if (!returnStmt.argument) {
+      return errorLeft('Return statement must have an argument');
+    }
+    return parseCodecInitializer(project, source, returnStmt.argument);
   }
   return parseCodecInitializer(project, source, func.body);
 }

--- a/packages/openapi-generator/test/externalModuleApiSpec.test.ts
+++ b/packages/openapi-generator/test/externalModuleApiSpec.test.ts
@@ -411,3 +411,46 @@ testCase(
   },
   [],
 );
+
+testCase(
+  'simple api spec with block statement arrow functions',
+  'test/sample-types/apiSpecWithBlockArrow.ts',
+  {
+    openapi: '3.0.3',
+    info: {
+      title: 'simple api spec with block statement arrow functions',
+      version: '1.0.0',
+      description: 'simple api spec with block statement arrow functions',
+    },
+    paths: {
+      '/test': {
+        get: {
+          parameters: [],
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      hasLargeNumberOfAddresses: {
+                        nullable: true,
+                        type: 'boolean',
+                      },
+                    },
+                    required: ['hasLargeNumberOfAddresses'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {},
+    },
+  },
+  [],
+);

--- a/packages/openapi-generator/test/sample-types/apiSpecWithBlockArrow.ts
+++ b/packages/openapi-generator/test/sample-types/apiSpecWithBlockArrow.ts
@@ -1,0 +1,24 @@
+import * as h from '@api-ts/io-ts-http';
+import * as t from 'io-ts';
+import { BooleanFromString, fromNullable } from 'io-ts-types';
+
+const BooleanFromNullableWithFallback = () => {
+  return fromNullable(t.union([BooleanFromString, t.boolean]), false);
+};
+
+export const TEST_ROUTE = h.httpRoute({
+  path: '/test',
+  method: 'GET',
+  request: h.httpRequest({}),
+  response: {
+    200: t.type({
+      hasLargeNumberOfAddresses: BooleanFromNullableWithFallback(),
+    }),
+  },
+});
+
+export const apiSpec = h.apiSpec({
+  'api.test': {
+    get: TEST_ROUTE,
+  },
+});


### PR DESCRIPTION
### Problem

Previously, only implicit-return arrow functions were supported. However, BlockStatement arrow functions are not yet supported. 

---

### Example 

```typescript
// implicit-return arrow functions were supported
const factory = () => t.string;  // ✅ Works

// BlockStatement arrow functions with explicit returns would fail
const factory = () => {
  return t.string;  // ❌ Error: "BlockStatement arrow functions are not yet supported
};
```

---

### Fix:
- Searches `BlockStatement.stmts` for ReturnStatement nodes
- Extracts the return value expression (`returnStmt.argument`)
- Passes it to `parseCodecInitializer()` for recursive parsing
- Validates that a return statement exists with a non-undefined argument

Both (block statement and non-block statement) styles now produce identical schemas since they converge on the same `parseCodecInitializer()` call with the return value expression.

Test case added using `BooleanFromNullableWithFallback()` with explicit block syntax to verify the parser handles both arrow function styles.