### PR TITLE
fix: check if parseFunctionBody fails

### DIFF
--- a/packages/openapi-generator/src/codec.ts
+++ b/packages/openapi-generator/src/codec.ts
@@ -510,7 +510,10 @@ export function parseCodecInitializer(
       if (E.isRight(calleeInitE)) {
         const [calleeSourceFile, calleeInit] = calleeInitE.right;
         if (calleeInit !== null && calleeInit.type === 'ArrowFunctionExpression') {
-          return parseFunctionBody(project, calleeSourceFile, calleeInit);
+          const bodyResult = parseFunctionBody(project, calleeSourceFile, calleeInit);
+          if (E.isRight(bodyResult)) {
+            return bodyResult;
+          }
         }
       }
     }


### PR DESCRIPTION
Ticket: DX-2210

This PR checks if the `parseFunctionBody` call fails, if so, falls back to regular parsing behaviour