### PR TITLE
test: add tests for arrow function fallback behavior

### DIFF
--- a/packages/openapi-generator/src/codec.ts
+++ b/packages/openapi-generator/src/codec.ts
@@ -510,9 +510,9 @@ export function parseCodecInitializer(
       if (E.isRight(calleeInitE)) {
         const [calleeSourceFile, calleeInit] = calleeInitE.right;
         if (calleeInit !== null && calleeInit.type === 'ArrowFunctionExpression') {
-          const bodyResult = parseFunctionBody(project, calleeSourceFile, calleeInit);
-          if (E.isRight(bodyResult)) {
-            return bodyResult;
+          const hasNoParameters = calleeInit.params.length === 0;
+          if (hasNoParameters) {
+            return parseFunctionBody(project, calleeSourceFile, calleeInit);
           }
         }
       }

--- a/packages/openapi-generator/test/arrowFunctionWithParameter.test.ts
+++ b/packages/openapi-generator/test/arrowFunctionWithParameter.test.ts
@@ -1,0 +1,125 @@
+import * as E from 'fp-ts/lib/Either';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { TestProject } from './testProject';
+import { parsePlainInitializer, type Schema } from '../src';
+import { KNOWN_IMPORTS, type KnownImports } from '../src/knownImports';
+
+const ARROW_WITH_PARAMS_MAIN = `
+import * as t from 'io-ts';
+import { NonEmptyString } from './types';
+import { arrayFromArrayOrSingle } from './codecs';
+
+export const UpdateShardKeyRequestBody = {
+  shardKey: t.string,
+  collectionType: t.union([
+    t.literal('user'),
+    t.literal('enterprise'),
+    t.literal('enterpriseTemplate')
+  ]),
+  ids: arrayFromArrayOrSingle(NonEmptyString),
+  enterpriseUpdateUsers: t.boolean,
+} as const;
+`;
+
+const ARROW_WITH_PARAMS_TYPES = `
+import * as t from 'io-ts';
+
+export const NonEmptyString = t.string;
+`;
+
+const ARROW_WITH_PARAMS_CODECS = `
+import * as t from 'io-ts';
+
+export const arrayFromArrayOrSingle = <C extends t.Mixed>(codec: C) =>
+  t.array(codec);
+`;
+
+test('arrow function with parameters uses custom codec definition', async () => {
+  const files = {
+    '/src/main.ts': ARROW_WITH_PARAMS_MAIN,
+    '/src/types.ts': ARROW_WITH_PARAMS_TYPES,
+    '/src/codecs.ts': ARROW_WITH_PARAMS_CODECS,
+  };
+
+  // Custom codec for arrayFromArrayOrSingle, merged with default io-ts codecs
+  const knownImports: KnownImports = {
+    ...KNOWN_IMPORTS,
+    '.': {
+      ...KNOWN_IMPORTS['.'],
+      arrayFromArrayOrSingle: (_deref, innerSchema): E.Either<string, Schema> =>
+        E.right({ type: 'array', items: innerSchema }),
+    },
+  };
+
+  const project = new TestProject(files, knownImports);
+  await project.parseEntryPoint('/src/main.ts');
+  const sourceFile = project.get('/src/main.ts');
+
+  assert.ok(sourceFile !== undefined, 'Source file not found');
+
+  const declaration = sourceFile.symbols.declarations.find(
+    (s) => s.name === 'UpdateShardKeyRequestBody',
+  );
+  assert.ok(declaration?.init !== undefined, 'Declaration not found');
+
+  const result = parsePlainInitializer(project, sourceFile, declaration.init);
+
+  assert.ok(
+    E.isRight(result),
+    `Expected success, got: "${E.isLeft(result) ? result.left : ''}"`,
+  );
+  assert.equal(result.right.type, 'object');
+  if (result.right.type === 'object') {
+    assert.equal(
+      result.right.properties?.ids?.type,
+      'array',
+      'ids field should be array (from custom codec)',
+    );
+  }
+});
+
+test('arrow function with parameters without custom codec returns ref', async () => {
+  const files = {
+    '/src/main.ts': `
+import * as t from 'io-ts';
+import { NonEmptyString } from './types';
+import { arrayFromArrayOrSingle } from './codecs';
+
+export const TestBody = {
+  ids: arrayFromArrayOrSingle(NonEmptyString),
+} as const;
+`,
+    '/src/types.ts': ARROW_WITH_PARAMS_TYPES,
+    '/src/codecs.ts': ARROW_WITH_PARAMS_CODECS,
+  };
+
+  // No custom codec for arrayFromArrayOrSingle
+  const project = new TestProject(files, KNOWN_IMPORTS);
+  await project.parseEntryPoint('/src/main.ts');
+  const sourceFile = project.get('/src/main.ts');
+
+  assert.ok(sourceFile !== undefined, 'Source file not found');
+
+  const declaration = sourceFile.symbols.declarations.find(
+    (s) => s.name === 'TestBody',
+  );
+  assert.ok(declaration?.init !== undefined, 'Declaration not found');
+
+  const result = parsePlainInitializer(project, sourceFile, declaration.init);
+
+  // Without custom codec, should return a ref (not an error)
+  assert.ok(
+    E.isRight(result),
+    `Expected success, got: "${E.isLeft(result) ? result.left : ''}"`,
+  );
+  assert.equal(result.right.type, 'object');
+  if (result.right.type === 'object') {
+    assert.equal(
+      result.right.properties?.ids?.type,
+      'ref',
+      'ids field should be ref (no custom codec)',
+    );
+  }
+});


### PR DESCRIPTION
Ticket: DX-2214

This PR attempts to validate this following [fix](https://github.com/BitGo/api-ts/commit/d1f0946541be91afe6acadab9f1ccc6828c2727d), which resolved an issue introduced by this [Regression Commit](https://github.com/BitGo/api-ts/commit/cec1e8bdb4ac6a7fa61b26aef836a2ad8edbc9f7).

###  Original Problem

The system encountered an error when parsing certain **Arrow Functions with parameters** (e.g., `(codec) => t.array(codec)`), specifically: `Error: Error when parsing AdminUpdateShardKeyApiSpec: Unknown identifier codec`.

### What is `parseFunctionBody`

`parseFunctionBody` extracts and parses the body of an arrow function:
- For expression bodies like `() => t.string`, it parses the expression `t.string`
- For block bodies like `() => { return t.string; }`, it finds the return statement and parses its argument

The problem is that when parsing the body, any function parameters (like `codec`) are not in the symbol table (`codecIdentifier` has not been called yet)

###  The Fix

We only try inlining for arrow functions without parameters (that would have custom codecs). 

### Testing

1. **With custom codec defined**: Verifies that `arrayFromArrayOrSingle(NonEmptyString)` correctly resolves to `{ type: 'array', items: {...} }` using the custom codec
2. **Without custom codec**: Verifies that the parser returns a `ref` instead of throwing `"Unknown identifier codec"`