### PR TITLE
fix: support multiline descriptions

### DIFF
--- a/packages/openapi-generator/src/comments.ts
+++ b/packages/openapi-generator/src/comments.ts
@@ -93,7 +93,12 @@ export function combineComments(schema: Schema): Block | undefined {
     result.description = comments[0].description;
   }
 
-  // Add all seen tags, problems, and source comments to the result
+  // Only use the first comment's source to avoid duplicates when parsing
+  if (comments[0]?.source) {
+    result.source = comments[0].source;
+  }
+
+  // Add all seen tags and problems to the result
   for (const comment of comments) {
     for (const tag of comment.tags) {
       // Only add the tag if we haven't seen it before. Otherwise, the higher level tag is 'probably' the more relevant tag.
@@ -104,7 +109,6 @@ export function combineComments(schema: Schema): Block | undefined {
     }
 
     result.problems.push(...comment.problems);
-    result.source.push(...comment.source);
   }
 
   return result;

--- a/packages/openapi-generator/test/openapi/comments.test.ts
+++ b/packages/openapi-generator/test/openapi/comments.test.ts
@@ -1682,3 +1682,139 @@ testCase(
     },
   },
 );
+
+const ROUTE_WITH_MARKDOWN_BULLET_LISTS = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * Route to test markdown formatting with bullet lists
+ *
+ * @operationId api.v1.markdownBullets
+ * @tag Test Routes
+ */
+export const route = h.httpRoute({
+  path: '/auth/token',
+  method: 'POST',
+  request: h.httpRequest({
+    query: {
+      /** The permissions granted by this access token.
+       *
+       * - \`all\` - Access all actions in the test environment.
+       * - \`crypto_compare\` - Call CryptoCompare API.
+       * - \`enterprise_manage_all\` - Manage users and settings for any enterprise to which the user belongs.
+       * - \`wallet_view\` - View a wallet.
+       * - \`wallet_spend\` - Initiate transactions from a wallet.
+       */
+      scope: t.string,
+    },
+    body: {
+      /** Grant type options.
+       *
+       * - \`authorization_code\` - Use authorization code flow.
+       * - \`refresh_token\` - Use refresh token to get new access token.
+       * - \`client_credentials\` - Use client credentials flow.
+       */
+      grant_type: t.string,
+    },
+  }),
+  response: {
+    200: {
+      /** Access token information.
+       *
+       * - Contains the JWT token
+       * - Includes expiration time
+       * - May include refresh token
+       */
+      access_token: t.string,
+    },
+  },
+});
+`;
+
+testCase(
+  'route with markdown bullet lists in parameter and field descriptions',
+  ROUTE_WITH_MARKDOWN_BULLET_LISTS,
+  {
+    openapi: '3.0.3',
+    info: {
+      title: 'Test',
+      version: '1.0.0',
+    },
+    paths: {
+      '/auth/token': {
+        post: {
+          summary: 'Route to test markdown formatting with bullet lists',
+          operationId: 'api.v1.markdownBullets',
+          tags: ['Test Routes'],
+          parameters: [
+            {
+              name: 'scope',
+              description:
+                'The permissions granted by this access token.\n' +
+                '\n' +
+                '- `all` - Access all actions in the test environment.\n' +
+                '- `crypto_compare` - Call CryptoCompare API.\n' +
+                '- `enterprise_manage_all` - Manage users and settings for any enterprise to which the user belongs.\n' +
+                '- `wallet_view` - View a wallet.\n' +
+                '- `wallet_spend` - Initiate transactions from a wallet.',
+              in: 'query',
+              required: true,
+              schema: {
+                type: 'string',
+              },
+            },
+          ],
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    grant_type: {
+                      type: 'string',
+                      description:
+                        'Grant type options.\n' +
+                        '\n' +
+                        '- `authorization_code` - Use authorization code flow.\n' +
+                        '- `refresh_token` - Use refresh token to get new access token.\n' +
+                        '- `client_credentials` - Use client credentials flow.',
+                    },
+                  },
+                  required: ['grant_type'],
+                },
+              },
+            },
+          },
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      access_token: {
+                        type: 'string',
+                        description:
+                          'Access token information.\n' +
+                          '\n' +
+                          '- Contains the JWT token\n' +
+                          '- Includes expiration time\n' +
+                          '- May include refresh token',
+                      },
+                    },
+                    required: ['access_token'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {},
+    },
+  },
+);


### PR DESCRIPTION
Changes are verified through the added test and a manual `diff` of the before and after wallet-platform.yaml

Partial `diff` output:
```
...
1397c1467,1471
<                   description: Number of confirmations before triggering the webhook. If 0 or unspecified, requests will be sent to the callback endpoint when the transfer is first seen and when it is confirmed.
---
>                   description: |-
>                     Number of confirmations before triggering the webhook. If 0 or unspecified,
> 
>                     requests will be sent to the callback endpoint when the transfer is first
>                     seen and when it is confirmed.
1402c1476,1479
<                   description: Triggers on coin transfers and token transfers for ETH and Stellar. Must be set to true to receive webhooks for Trade accounts.
---
>                   description: |-
>                     Triggers on coin transfers and token transfers for ETH and Stellar.
> 
>                     Must be set to true to receive webhooks for Trade accounts.
...
```

Also verified changes look good in ReadMe: https://developers.bitgo.com/v1.0_benson-test/reference/v2accesstokenadd#/

| Before | After |
| ------- | ------- |
| <img width="892" height="901" alt="image" src="https://github.com/user-attachments/assets/f5b1dac9-bab3-45ff-a054-f0119fe96e3f" /> | <img width="887" height="801" alt="image" src="https://github.com/user-attachments/assets/1fe8d7bc-9206-4c97-a348-7af2f7118245" /> | 

Ticket: DX-1136