### PR TITLE
fix: support multiline descriptions

### DIFF
--- a/packages/openapi-generator/src/comments.ts
+++ b/packages/openapi-generator/src/comments.ts
@@ -40,7 +40,15 @@ export function leadingComment(
     commentString = commentString + endingSubstring;
   }
 
-  const parsedComment = parseComment(commentString);
+  const parsedComment = parseComment(commentString, { spacing: 'preserve' });
+
+  for (const block of parsedComment) {
+    block.description = block.description.trim();
+    for (const tag of block.tags) {
+      tag.description = tag.description.trim();
+    }
+  }
+
   return parsedComment;
 }
 

--- a/packages/openapi-generator/test/openapi/comments.test.ts
+++ b/packages/openapi-generator/test/openapi/comments.test.ts
@@ -693,7 +693,7 @@ export const route = h.httpRoute({
       /** 
        * This is a bar param.
        * @example { "foo": "bar" }
-      */
+       */
       bar: t.record(t.string, t.string),
     },
     body: {
@@ -701,7 +701,7 @@ export const route = h.httpRoute({
        * foo description
        * @pattern ^[1-9][0-9]{4}$
        * @example 12345
-      */
+       */
       foo: t.number,
       child: {
         /** 
@@ -840,7 +840,7 @@ export const route = h.httpRoute({
       /** 
        * This is a foo description. 
        * @example BitGo Inc
-      */
+       */
       foo: Foo,
       bar: Bar,
     },
@@ -979,7 +979,7 @@ export const route = h.httpRoute({
        * @maxLength 10
        * @example SomeInc
        * @default BitgoInc
-      */
+       */
       foo: t.string()
     },
   }),
@@ -1682,3 +1682,77 @@ testCase(
     },
   },
 );
+
+const ROUTE_WITH_MARKDOWN_LIST = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * A route with a list in the comment
+ *
+ * @operationId api.v1.list
+ * @tag Test Routes
+ */
+export const route = h.httpRoute({
+  path: '/list',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      /**
+       * The permissions granted by this access token.
+       *
+       * - \`all\` - Access all actions in the test environment.
+       * - \`crypto_compare\` - Call CryptoCompare API.
+       */
+      permissions: t.string,
+    },
+  }),
+  response: {
+    200: t.string
+  },
+});
+`;
+
+testCase('route with markdown list in comment', ROUTE_WITH_MARKDOWN_LIST, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/list': {
+      get: {
+        summary: 'A route with a list in the comment',
+        operationId: 'api.v1.list',
+        tags: ['Test Routes'],
+        parameters: [
+          {
+            name: 'permissions',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+            description:
+              'The permissions granted by this access token.\n\n- `all` - Access all actions in the test environment.\n- `crypto_compare` - Call CryptoCompare API.',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});


### PR DESCRIPTION
Changes are verified through the added test and a manual `diff` of the before and after wallet-platform.yaml

Partial `diff` output:
```
...
1124c1159,1194
<                   description: The permissions granted by this access token. - `all` - Access all actions in the test environment. - `crypto_compare` - Call CryptoCompare API. - `enterprise_manage_all` - Manage users and settings for any enterprise to which the user belongs. - `enterprise_view_all` - View any enterprise to which the user belongs. - `metamask_institutional` - [DEPRECATED] Enables using BitGo wallets in the MetaMask Institutional extension. - `openid` - Verify your BitGo user ID using OpenID Connect. - `pending_approval_update` - Approve or reject pending actions that require approval to proceed. - `portfolio_view` - [DEPRECATED] Call the Portfolio API. - `profile` - View your BitGo Profile. - `settlement_network_read` - View your client's Go Network data, enabling allocations to and from your platform. Only for Go Network partners. - `settlement_network_write` - Update your client's Go Network data, enabling allocations to and from your platform. Only for Go Network partners. - `trade_trade` - Initiate trades. - `trade_view` - View trades. - `wallet_approve` - Approve policies and transactions for a wallet where the user is a wallet admin. - `wallet_approve_all` - Approve transactions for any wallet where the user is a wallet admin within any enterprise to which the user belongs. - `wallet_approve_enterprise` - Approve transactions for any wallet where the user is a wallet admin within a single enterprise. - `wallet_create` - Create wallets. - `wallet_edit` - Edit comments on a transfer. - `wallet_edit_all` - Edit comments on all transfers within multiple enterprises. - `wallet_edit_enterprise` - [DEPRECATED] Edit comments on all transfers within a single enterprise. - `wallet_freeze` - Freeze a wallet. - `wallet_freeze_all` - Freeze any wallet within any enterprises to which the user belongs. - `wallet_manage` - Manage settings for a wallet where the user is a wallet admin. - `wallet_manage_all` - Manage settings for any wallet where the user is a wallet admin within any enterprise to which the user belongs. - `wallet_manage_enterprise` - Manage settings for any wallet where the user is a wallet admin within a single enterprise. - `wallet_spend` - Initiate transactions from a wallet. - `wallet_spend_all` - Initiate transactions from any wallet within any enterprise to which the user belongs. - `wallet_spend_enterprise` - Initiate transactions from any wallet within a single enterprise. - `wallet_stake` - Initiate staking transactions from a wallet. - `wallet_stake_all` - Initiate staking transactions from any wallet within any enterprise to which the user belongs. - `wallet_view` - View a wallet. - `wallet_view_all` - View any wallet within any enterprise to which the user belongs. - `wallet_view_enterprise` - View any wallet within a single enterprise.
---
>                   description: |-
>                     The permissions granted by this access token.
> 
>                     - `all` - Access all actions in the test environment.
>                     - `crypto_compare` - Call CryptoCompare API.
>                     - `enterprise_manage_all` - Manage users and settings for any enterprise to which the user belongs.
>                     - `enterprise_view_all` - View any enterprise to which the user belongs.
>                     - `metamask_institutional` - [DEPRECATED] Enables using BitGo wallets in the MetaMask Institutional extension.
>                     - `openid` - Verify your BitGo user ID using OpenID Connect.
>                     - `pending_approval_update` - Approve or reject pending actions that require approval to proceed.
>                     - `portfolio_view` - [DEPRECATED] Call the Portfolio API.
>                     - `profile` - View your BitGo Profile.
>                     - `settlement_network_read` - View your client's Go Network data, enabling allocations to and from your platform. Only for Go Network partners.
>                     - `settlement_network_write` - Update your client's Go Network data, enabling allocations to and from your platform. Only for Go Network partners.
>                     - `trade_trade` - Initiate trades.
>                     - `trade_view` - View trades.
>                     - `wallet_approve` - Approve policies and transactions for a wallet where the user is a wallet admin.
>                     - `wallet_approve_all` - Approve transactions for any wallet where the user is a wallet admin within any enterprise to which the user belongs.
>                     - `wallet_approve_enterprise` - Approve transactions for any wallet where the user is a wallet admin within a single enterprise.
>                     - `wallet_create` - Create wallets.
>                     - `wallet_edit` - Edit comments on a transfer.
>                     - `wallet_edit_all` - Edit comments on all transfers within multiple enterprises.
>                     - `wallet_edit_enterprise` - [DEPRECATED] Edit comments on all transfers within a single enterprise.
>                     - `wallet_freeze` - Freeze a wallet.
>                     - `wallet_freeze_all` - Freeze any wallet within any enterprises to which the user belongs.
>                     - `wallet_manage` - Manage settings for a wallet where the user is a wallet admin.
>                     - `wallet_manage_all` - Manage settings for any wallet where the user is a wallet admin within any enterprise to which the user belongs.
>                     - `wallet_manage_enterprise` - Manage settings for any wallet where the user is a wallet admin within a single enterprise.
>                     - `wallet_spend` - Initiate transactions from a wallet.
>                     - `wallet_spend_all` - Initiate transactions from any wallet within any enterprise to which the user belongs.
>                     - `wallet_spend_enterprise` - Initiate transactions from any wallet within a single enterprise.
>                     - `wallet_stake` - Initiate staking transactions from a wallet.
>                     - `wallet_stake_all` - Initiate staking transactions from any wallet within any enterprise to which the user belongs.
>                     - `wallet_view` - View a wallet.
>                     - `wallet_view_all` - View any wallet within any enterprise to which the user belongs.
>                     - `wallet_view_enterprise` - View any wallet within a single enterprise.
1397c1467,1470
<                   description: Number of confirmations before triggering the webhook. If 0 or unspecified, requests will be sent to the callback endpoint when the transfer is first seen and when it is confirmed.
---
>                   description: |-
>                     Number of confirmations before triggering the webhook. If 0 or unspecified,
>                     requests will be sent to the callback endpoint when the transfer is first
>                     seen and when it is confirmed.
1402c1475,1477
<                   description: Triggers on coin transfers and token transfers for ETH and Stellar. Must be set to true to receive webhooks for Trade accounts.
---
>                   description: |-
>                     Triggers on coin transfers and token transfers for ETH and Stellar.
>                     Must be set to true to receive webhooks for Trade accounts.
...
```

Also verified changes look good in ReadMe: 
- https://developers.bitgo.com/v1.0_benson-test/reference/v2accesstokenadd#/
- https://developers.bitgo.com/v1.0_benson-test/reference/v2walletaddwebhook#/

| Before | After |
| ------- | ------- |
| <img width="892" height="901" alt="image" src="https://github.com/user-attachments/assets/f5b1dac9-bab3-45ff-a054-f0119fe96e3f" /> | <img width="887" height="801" alt="image" src="https://github.com/user-attachments/assets/1fe8d7bc-9206-4c97-a348-7af2f7118245" /> | 

Ticket: DX-1136