### PR TITLE
ci: remove Trusted Publishing config

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,5 @@
 ---
 name: Release
-permissions:
-  # Needed for OIDC Trusted Publishing
-  id-token: write
-  # Needed for semantic-release
-  contents: write
-  pull-requests: write
-  issues: write
 
 on:
   push:
@@ -22,7 +15,6 @@ jobs:
     name: Release
     if: github.repository_owner == 'BitGo'
     runs-on: ubuntu-latest
-    environment: publish-apits
 
     steps:
       - name: Checkout
@@ -56,3 +48,4 @@ jobs:
         run: npx multi-semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**What problem are we solving?**
Until `multi-semantic-release` truly supports OIDC Trusted Publishing w/ GitHub Environments, we should go back to regular publishing.

**Why are we solving it this way?**
This way, we can still trigger necessary releases.



Ticket: DX-2319