### PR TITLE
feat: require @description tags for enum comments

### DIFF
--- a/packages/openapi-generator/src/knownImports.ts
+++ b/packages/openapi-generator/src/knownImports.ts
@@ -2,6 +2,7 @@ import * as E from 'fp-ts/Either';
 
 import { isPrimitive, type Schema } from './ir';
 import { errorLeft } from './error';
+import { parseCommentBlock } from './jsdoc';
 
 export type DerefFn = (ref: Schema) => E.Either<string, Schema>;
 export type KnownCodec = (
@@ -132,9 +133,12 @@ export const KNOWN_IMPORTS: KnownImports = {
 
       for (const prop of enumValues) {
         const propertySchema = arg.properties[prop];
-        if (propertySchema?.comment?.description) {
-          enumDescriptions[prop] = propertySchema.comment.description;
-          hasDescriptions = true;
+        if (propertySchema?.comment) {
+          const jsdoc = parseCommentBlock(propertySchema.comment);
+          if (jsdoc.tags?.description) {
+            enumDescriptions[prop] = jsdoc.tags.description;
+            hasDescriptions = true;
+          }
         }
       }
 


### PR DESCRIPTION
Ticket: DX-1373

Previously, all JSDoc comments on enum values were automatically converted to x-enumDescriptions in the OpenAPI spec, causing internal developer comments to be exposed as public API documentation.

This change modifies the keyof function to only generate x-enumDescriptions when enum values have explicit `@description` tags, giving developers control over what becomes public documentation.

More context can be found on [this Slack thread](https://bitgo.slack.com/archives/C05UM41K66A/p1764010275017689).