### PR TITLE
feat: default to preserving line breaks

### DIFF
--- a/packages/openapi-generator/src/comments.ts
+++ b/packages/openapi-generator/src/comments.ts
@@ -77,10 +77,7 @@ export function leadingComment(
     commentString = commentString.replace(/@preserveLineBreaks\s*/g, '');
   }
 
-  const parsedComment = parseComment(
-    commentString,
-    shouldPreserveLineBreaks ? { spacing: 'preserve' } : undefined,
-  );
+  const parsedComment = parseComment(commentString, { spacing: 'preserve' });
 
   for (const block of parsedComment) {
     block.description = block.description.trim();

--- a/packages/openapi-generator/test/openapi/comments.test.ts
+++ b/packages/openapi-generator/test/openapi/comments.test.ts
@@ -2111,3 +2111,77 @@ testCase('route with multibyte chars', ROUTE_WITH_MULTIBYTE_CHARS, {
     },
   },
 });
+
+const ROUTE_WITH_MARKDOWN_LIST = `
+import * as t from 'io-ts';
+import * as h from '@api-ts/io-ts-http';
+
+/**
+ * A route with a list in the comment
+ *
+ * @operationId api.v1.list
+ * @tag Test Routes
+ */
+export const route = h.httpRoute({
+  path: '/list',
+  method: 'GET',
+  request: h.httpRequest({
+    query: {
+      /**
+       * The permissions granted by this access token.
+       *
+       * - \`all\` - Access all actions in the test environment.
+       * - \`crypto_compare\` - Call CryptoCompare API.
+       */
+      permissions: t.string,
+    },
+  }),
+  response: {
+    200: t.string
+  },
+});
+`;
+
+testCase('route with markdown list in comment', ROUTE_WITH_MARKDOWN_LIST, {
+  openapi: '3.0.3',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/list': {
+      get: {
+        summary: 'A route with a list in the comment',
+        operationId: 'api.v1.list',
+        tags: ['Test Routes'],
+        parameters: [
+          {
+            name: 'permissions',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+            description:
+              'The permissions granted by this access token.\n\n- `all` - Access all actions in the test environment.\n- `crypto_compare` - Call CryptoCompare API.',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+});


### PR DESCRIPTION
Ticket: DX-2753

This commit defaults the tool to preserving line breaks/spacing. The changes are effectively a redo of
https://github.com/BitGo/api-ts/pull/1081/changes