### PR TITLE
chore: fix boolean from string type

### DIFF
--- a/packages/openapi-generator/src/knownImports.ts
+++ b/packages/openapi-generator/src/knownImports.ts
@@ -372,7 +372,8 @@ export const KNOWN_IMPORTS: KnownImports = {
       E.right({ type: 'string', format: 'number', decodedType: 'bigint' }),
     BooleanFromNumber: () =>
       E.right({ type: 'number', enum: [0, 1], decodedType: 'boolean' }),
-    BooleanFromString: () => E.right({ type: 'boolean' }),
+    BooleanFromString: () =>
+      E.right({ type: 'string', enum: ['true', 'false'], decodedType: 'boolean' }),
     DateFromISOString: () =>
       E.right({ type: 'string', format: 'date-time', title: 'ISO Date String' }),
     DateFromNumber: () =>

--- a/packages/openapi-generator/test/openapi/union.test.ts
+++ b/packages/openapi-generator/test/openapi/union.test.ts
@@ -201,7 +201,10 @@ testCase(
               in: 'query',
               required: true,
               schema: {
-                oneOf: [{ type: 'boolean' }, { type: 'string', format: 'number' }],
+                oneOf: [
+                  { type: 'string', format: 'number' },
+                  { type: 'string', enum: ['true', 'false'] },
+                ],
               },
             },
             {
@@ -209,14 +212,17 @@ testCase(
               in: 'query',
               required: true,
               schema: {
-                oneOf: [{ type: 'string' }, { type: 'boolean' }],
+                oneOf: [
+                  { type: 'string' },
+                  { type: 'string', enum: ['true', 'false'] },
+                ],
               },
             },
             {
               name: 'firstNonUnion',
               in: 'query',
               required: true,
-              schema: { type: 'boolean' },
+              schema: { type: 'string', enum: ['true', 'false'] },
             },
             {
               name: 'secondNonUnion',


### PR DESCRIPTION
`BooleanFromString` should show up as string type in api specs, not boolean.

Ticket: DX-2947