### PR TITLE
ci: serialize semantic-release initialization

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
         run: mv .npmrc-release .npmrc
 
       - name: Release
-        run: npx multi-semantic-release
+        run: npx multi-semantic-release --sequential-init
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
semantic-release 25 fetches Git notes while initializing each package. Serial initialization avoids concurrent notes reads from an incomplete local ref.

Ticket: AI-739