### PR TITLE
ci: enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,4 +48,3 @@ jobs:
         run: npx multi-semantic-release --sequential-init
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The release job injected NPM_TOKEN even though trusted publishing gets credentials from GitHub Actions OIDC. Removing the legacy token matches the known working BitGoWASM release workflow at commit 204625c.

Ticket: AI-742