### PR TITLE
ci: restore npm trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,12 @@ jobs:
     name: Release
     if: github.repository_owner == 'BitGo'
     runs-on: ubuntu-latest
+    environment: publish-apits
+    permissions:
+      id-token: write
+      contents: write
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
The release workflow removed NPM_TOKEN without restoring the OIDC permission and environment required by npm. Restore both so semantic-release can exchange the GitHub identity for a short-lived publish credential.

Ticket: AI-743