### PR TITLE
ci: run every matrix job to completion

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           # Skip lts/-2 while it refers to Node.js 16, since this version


### PR DESCRIPTION
Report results for every supported Node.js version instead of cancelling remaining jobs after the first failure.

Ticket: AI-747