### PR TITLE
ci: skip Node.js 22 compatibility check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,10 @@ jobs:
           # ships with a segfault when collecting code coverage with
           # Node.js's built-in test runner.
           # - lts/-2
-          - lts/-1
+          # Skip lts/-1 while it resolves to Node.js 22, whose bundled npm 10
+          # unnecessarily complicates peer dependency resolution. Re-enable
+          # once the lts/-1 pointer advances.
+          # - lts/-1
           - lts/*
 
     name: Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary

- disable the `lts/-1` CI matrix entry while it resolves to Node.js 22
- keep the current LTS check enabled
- leave an inline reminder to re-enable the check after the LTS pointer advances

## Motivation

Node.js 22 bundles npm 10, whose peer dependency behavior unnecessarily complicates CI dependency installation. This is a temporary disablement until `lts/-1` advances.

## Verification

- `nix flake check`
- `npm run build`
- `npm test`
- parsed the workflow matrix and confirmed its only active Node.js version is `lts/*`

Linear: [AI-748](https://linear.app/bitgo/issue/AI-748/temporarily-remove-the-nodejs-lts-1-ci-check)