### PR TITLE
fix: declare repository field for npm trusted publishing

### DIFF
--- a/packages/express-wrapper/package.json
+++ b/packages/express-wrapper/package.json
@@ -32,5 +32,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BitGo/api-ts.git",
+    "directory": "packages/express-wrapper"
   }
 }

--- a/packages/io-ts-http/package.json
+++ b/packages/io-ts-http/package.json
@@ -31,5 +31,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BitGo/api-ts.git",
+    "directory": "packages/io-ts-http"
   }
 }

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -39,10 +39,15 @@
     "typescript": "4.7.4"
   },
   "optionalDependencies": {
-    "@swc/core-linux-x64-gnu": "1.5.7",
-    "@swc/core-darwin-arm64": "1.5.7"
+    "@swc/core-darwin-arm64": "1.5.7",
+    "@swc/core-linux-x64-gnu": "1.5.7"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BitGo/api-ts.git",
+    "directory": "packages/openapi-generator"
   }
 }

--- a/packages/response/package.json
+++ b/packages/response/package.json
@@ -22,5 +22,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BitGo/api-ts.git",
+    "directory": "packages/response"
   }
 }

--- a/packages/superagent-wrapper/package.json
+++ b/packages/superagent-wrapper/package.json
@@ -41,5 +41,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BitGo/api-ts.git",
+    "directory": "packages/superagent-wrapper"
   }
 }

--- a/packages/typed-express-router/package.json
+++ b/packages/typed-express-router/package.json
@@ -33,14 +33,19 @@
   },
   "devDependencies": {
     "@api-ts/superagent-wrapper": "0.0.0-semantically-released",
-    "@swc-node/register": "1.11.1",
-    "c8": "10.1.3",
-    "typescript": "4.7.4",
+    "@opentelemetry/api": "1.9.0",
     "@opentelemetry/sdk-trace-base": "1.30.1",
     "@opentelemetry/sdk-trace-node": "1.30.1",
-    "@opentelemetry/api": "1.9.0"
+    "@swc-node/register": "1.11.1",
+    "c8": "10.1.3",
+    "typescript": "4.7.4"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BitGo/api-ts.git",
+    "directory": "packages/typed-express-router"
   }
 }


### PR DESCRIPTION
## Problem

Release run [29864210735](https://github.com/BitGo/api-ts/actions/runs/29864210735/job/88749577915) fails at `npm publish` with:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@api-ts%2fopenapi-generator
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/BitGo/api-ts" from provenance
```

OIDC trusted publishing itself works — the provenance statement is signed and uploaded — but the registry rejects the tarball because provenance validation requires `repository.url` in each published `package.json` to match the repo in the attestation, and no workspace package declared one.

## Fix

Declare `repository` (with `directory`) in all six workspace manifests, matching the pattern used by BitGo/BitGoWASM where trusted publishing works.

Also carries the AI-744 CI commits switching the release workflow to OIDC-capable npm.

Ticket: AI-744

🤖 Generated with [Claude Code](https://claude.com/claude-code)