### PR TITLE
feat(dependabot): use fix commit prefix for dependency updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -45,6 +45,9 @@ updates:
     labels:
       - dependencies
       - npm
+    commit-message:
+      prefix: 'fix'
+      include: 'scope'
     allow:
       - dependency-type: direct
     versioning-strategy: increase-if-necessary


### PR DESCRIPTION
Configure Dependabot to prefix all automated pull requests and commits with the 'fix' Conventional Commit type. This ensures that any dependency update will trigger an automated release.

Ticket: AI-757