### PR TITLE
chore(deps): group OpenTelemetry trace SDK updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -55,6 +55,10 @@ updates:
       dependencies:
         patterns:
           - '@swc/core*'
+      opentelemetry-trace-sdk:
+        patterns:
+          - '@opentelemetry/sdk-trace-base'
+          - '@opentelemetry/sdk-trace-node'
     ignore:
       # Ignore all @types/nodes patch updates, since
       # this package updates so frequently


### PR DESCRIPTION
## Summary

- group `@opentelemetry/sdk-trace-base` and `@opentelemetry/sdk-trace-node` Dependabot updates
- prevent mixed-version SDK type graphs from reaching future dependency pull requests

## Verification

- `nix flake check --print-build-logs`

Ticket: AI-784
