### PR TITLE
fix(deps): Bump qs from 6.13.0 to 6.14.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8425,11 +8425,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "typescript": "4.7.4"
   },
   "overrides": {
-    "semantic-release": ">=25.0.0"
+    "semantic-release": ">=25.0.0",
+    "qs": "6.14.2"
   },
   "engines": {
     "npm": ">=7"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -17433,12 +17433,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"

--- a/website/package.json
+++ b/website/package.json
@@ -26,7 +26,8 @@
     "zod": "^3.24.2"
   },
   "overrides": {
-    "minimatch": "^3.1.3"
+    "minimatch": "^3.1.3",
+    "qs": "6.14.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.7.0"


### PR DESCRIPTION
Resolves https://github.com/BitGo/api-ts/security/dependabot/144

Bumps [qs](https://github.com/ljharb/qs) from 6.13.0 to 6.14.2.
- [Changelog](https://github.com/ljharb/qs/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ljharb/qs/commits)

Dependabot advisory: [GHSA-w7fw-mjwx-w883](https://github.com/advisories/GHSA-w7fw-mjwx-w883)
Ticket: AI-939