### PR TITLE
fix(deps): Bump path-to-regexp from 0.1.12 to 0.1.13

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10346,9 +10346,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/express/node_modules/range-parser": {

--- a/website/package.json
+++ b/website/package.json
@@ -27,7 +27,10 @@
   },
   "overrides": {
     "minimatch": "^3.1.3",
-    "qs": "6.14.2"
+    "qs": "6.14.2",
+    "express": {
+      "path-to-regexp": "0.1.13"
+    }
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.7.0"


### PR DESCRIPTION
Resolves https://github.com/BitGo/api-ts/security/dependabot/190

Bumps [path-to-regexp](https://github.com/pillarjs/path-to-regexp) from 0.1.12 to 0.1.13.
- [Changelog](https://github.com/pillarjs/path-to-regexp/blob/master/History.md)
- [Commits](https://github.com/pillarjs/path-to-regexp/commits)

Dependabot advisory: [GHSA-37ch-88jc-xwx2](https://github.com/advisories/GHSA-37ch-88jc-xwx2)
Ticket: AI-944